### PR TITLE
Fix: Add hierarchical schematic support for netlist generation

### DIFF
--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -733,7 +733,7 @@ class KiCADInterface:
             if not schematic:
                 return {"success": False, "message": "Failed to load schematic"}
 
-            netlist = ConnectionManager.generate_netlist(schematic)
+            netlist = ConnectionManager.generate_netlist(schematic, schematic_path)
             return {"success": True, "netlist": netlist}
         except Exception as e:
             logger.error(f"Error generating netlist: {str(e)}")


### PR DESCRIPTION
## Summary

The `generate_netlist` function now properly handles hierarchical schematics by recursively traversing sheet instances and collecting components from all child sheets.

## Changes

- Add `_collect_from_schematic()` helper for recursive traversal of hierarchical sheets
- Update `generate_netlist()` to accept `schematic_path` parameter for resolving relative paths
- Properly prefix component references with hierarchy path (e.g., `Crossbar_Layer1/R1`)
- Collect nets and labels from all hierarchy levels
- Pass `schematic_path` from `kicad_interface.py`

## Problem Solved

Before this fix, `generate_netlist` would only return components from the top-level schematic, missing all components in hierarchical sheets. This caused issues for projects using hierarchical organization (common for complex designs with repeated blocks like crossbar arrays, neuron circuits, etc.)

## Testing

Tested with a project containing 6 hierarchical sheets and ~1500 components. All components are now correctly included in the netlist output with proper hierarchical prefixes.