### PR TITLE
Fix Windows compatibility: guard os.getuid() call

### DIFF
--- a/python/kicad_api/ipc_backend.py
+++ b/python/kicad_api/ipc_backend.py
@@ -74,12 +74,18 @@ class IPCBackend(KiCADBackend):
             if socket_path:
                 socket_paths_to_try.append(socket_path)
             else:
-                # Common socket locations
-                socket_paths_to_try = [
-                    'ipc:///tmp/kicad/api.sock',  # Linux default
-                    f'ipc:///run/user/{os.getuid()}/kicad/api.sock',  # XDG runtime
-                    None  # Let kipy auto-detect
-                ]
+                # Common socket locations (platform-specific)
+                socket_paths_to_try = []
+
+                # Unix-specific socket paths (Linux/macOS)
+                if hasattr(os, 'getuid'):
+                    socket_paths_to_try.extend([
+                        'ipc:///tmp/kicad/api.sock',  # Linux default
+                        f'ipc:///run/user/{os.getuid()}/kicad/api.sock',  # XDG runtime
+                    ])
+
+                # Always try auto-detect last (works on all platforms including Windows)
+                socket_paths_to_try.append(None)
 
             last_error = None
             for path in socket_paths_to_try:


### PR DESCRIPTION
## Summary

The `os.getuid()` function is Unix-specific and does not exist on Windows, causing an `AttributeError` when the IPC backend tries to connect:

```
[ERROR] Failed to connect via IPC: module 'os' has no attribute 'getuid'
```

## Changes

- Added `hasattr(os, 'getuid')` check before using Unix socket paths
- Unix-specific paths are only tried on Unix systems (Linux/macOS)
- Windows relies on kipy's auto-detection (which uses named pipes)

## Testing

Tested on Windows 11 with:
- KiCad 9.0.7
- kicad-python 0.5.0
- KiCAD-MCP-Server latest

Before fix: IPC backend fails with `AttributeError`, falls back to SWIG
After fix: IPC backend should properly attempt auto-detection on Windows

Fixes #36

---

🤖 Generated with [Claude Code](https://claude.ai/code)