### PR TITLE
fix: Resolve 4 bugs in library search, component placement, and SVG export

### DIFF
--- a/python/commands/component.py
+++ b/python/commands/component.py
@@ -81,8 +81,13 @@ class ComponentCommands:
                     "errorDetails": "Could not determine library nickname"
                 }
 
-            # Load the footprint
-            module = pcbnew.FootprintLoad(library_path, footprint_name)
+            # Load the footprint using KiCad 9.x API (3-arg form with FP_LIB_TABLE)
+            try:
+                fp_lib_table = pcbnew.GetGlobalFootprintLib()
+                module = pcbnew.FootprintLoad(fp_lib_table, library_nickname, footprint_name)
+            except Exception:
+                # Fallback: try legacy 2-arg form for older KiCad versions
+                module = pcbnew.FootprintLoad(library_path, footprint_name)
             if not module:
                 return {
                     "success": False,

--- a/python/commands/export.py
+++ b/python/commands/export.py
@@ -270,6 +270,13 @@ class ExportCommands:
             plot_opts.SetPlotReference(include_components)
             plot_opts.SetBlackAndWhite(black_and_white)
 
+            # Open the plot file (required before PlotLayer calls)
+            plotter.OpenPlotfile(
+                os.path.splitext(os.path.basename(output_path))[0],
+                pcbnew.PLOT_FORMAT_SVG,
+                "SVG Export"
+            )
+
             # Plot specified layers or all enabled layers
             plotted_layers = []
             if layers:
@@ -286,6 +293,9 @@ class ExportCommands:
                         plotter.SetLayer(layer_id)
                         plotter.PlotLayer()
                         plotted_layers.append(layer_name)
+
+            # Finalize and flush the plot file to disk
+            plotter.ClosePlot()
 
             return {
                 "success": True,


### PR DESCRIPTION
## Summary

- **Bug #1:** Fix parameter/field name mismatches between TypeScript and Python layers in `search_footprints`, `list_library_footprints`, and `get_footprint_info` — TS sends `search_term`/`library_name`/`footprint_name` but Python expected `pattern`/`library`/`footprint`, and TS reads `fp.name` but Python returned `fp.footprint`, causing `Library:undefined` results
- **Bug #2 & #4:** Update `FootprintLoad` in `component.py` to use KiCad 9.x 3-arg API (`fp_lib_table, library_nickname, footprint_name`) with fallback to legacy 2-arg form — fixes placement failures after delete cycles and B.Cu layer placement
- **Bug #3:** Add missing `OpenPlotfile()` and `ClosePlot()` calls to `export_svg` in `export.py` so SVG files are actually written to disk

## Files Changed

| File | Change |
|------|--------|
| `python/commands/library.py` | Accept both TS and legacy parameter names; return both `name` and `footprint` fields; return both `info` and `footprint_info` keys |
| `python/commands/component.py` | Use `pcbnew.GetGlobalFootprintLib()` + 3-arg `FootprintLoad` for KiCad 9.x |
| `python/commands/export.py` | Add `OpenPlotfile()` before plotting and `ClosePlot()` after |
| `bug.md` | Bug tracker with root causes and fix status |

## Test plan

- [ ] Verify `search_footprints` returns proper `Library:FootprintName` results (not `Library:undefined`)
- [ ] Verify `list_library_footprints` accepts library name without "Missing library parameter" error
- [ ] Verify `get_footprint_info` returns footprint details
- [ ] Verify `place_component` works after delete+place cycles
- [ ] Verify `place_component` with `layer: "B.Cu"` works
- [ ] Verify `export_svg` creates an actual SVG file on disk