### PR TITLE
fix: add_schematic_component corrupts .kicad_sch files (sexpdata rewrite)

### DIFF
--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -556,10 +556,11 @@ class KiCADInterface:
             return {"success": False, "message": str(e)}
     
     def _handle_add_schematic_component(self, params):
-        """Add a component to a schematic with dynamic symbol loading support"""
+        """Add a component to a schematic using text-based injection (no sexpdata)"""
         logger.info("Adding component to schematic")
         try:
             from pathlib import Path
+            from commands.dynamic_symbol_loader import DynamicSymbolLoader
 
             schematic_path = params.get("schematicPath")
             component = params.get("component", {})
@@ -569,87 +570,30 @@ class KiCADInterface:
             if not component:
                 return {"success": False, "message": "Component definition is required"}
 
-            # Convert to Path object for dynamic loader
-            schematic_path_obj = Path(schematic_path)
-
-            # Load schematic
-            schematic = SchematicManager.load_schematic(schematic_path)
-            if not schematic:
-                return {"success": False, "message": "Failed to load schematic"}
-
-            # Check if component type requires dynamic loading
             comp_type = component.get('type', 'R')
             library = component.get('library', 'Device')
+            reference = component.get('reference', 'X?')
+            value = component.get('value', comp_type)
+            x = component.get('x', 0)
+            y = component.get('y', 0)
 
-            # Check if template exists in static templates
-            template_ref = ComponentManager.TEMPLATE_MAP.get(comp_type)
-            needs_dynamic_loading = False
+            loader = DynamicSymbolLoader()
+            loader.add_component(
+                Path(schematic_path), library, comp_type,
+                reference=reference, value=value, x=x, y=y
+            )
 
-            if template_ref:
-                # Check if template exists in schematic
-                if not hasattr(schematic.symbol, template_ref):
-                    needs_dynamic_loading = True
-                    logger.info(f"Static template {template_ref} not found in schematic, will try dynamic loading")
-            else:
-                # Not in static map, definitely needs dynamic loading
-                needs_dynamic_loading = True
-                logger.info(f"Component type {comp_type} not in static templates, will use dynamic loading")
-
-            # If dynamic loading is needed and available
-            if needs_dynamic_loading:
-                try:
-                    from commands.dynamic_symbol_loader import DynamicSymbolLoader
-
-                    loader = DynamicSymbolLoader()
-
-                    # Save current schematic first to preserve any changes
-                    SchematicManager.save_schematic(schematic, schematic_path)
-                    logger.info("Saved schematic before dynamic loading")
-
-                    # Dynamically load the symbol (injects into file and creates template)
-                    logger.info(f"Dynamically loading symbol: {library}:{comp_type}")
-                    template_ref = loader.load_symbol_dynamically(schematic_path_obj, library, comp_type)
-                    logger.info(f"Dynamic loading successful. Template ref: {template_ref}")
-
-                    # Reload schematic to get the newly injected symbol
-                    schematic = SchematicManager.load_schematic(schematic_path)
-                    if not schematic:
-                        return {"success": False, "message": "Failed to reload schematic after dynamic loading"}
-                    logger.info("Reloaded schematic with new symbol definition")
-
-                except ImportError:
-                    logger.warning("Dynamic symbol loader not available, falling back to static templates")
-                except Exception as e:
-                    logger.error(f"Dynamic loading failed: {e}")
-                    logger.warning("Falling back to static templates")
-
-            # Add component (now with template available in schematic)
-            component_obj = ComponentManager.add_component(schematic, component, schematic_path_obj)
-            success = component_obj is not None
-
-            if success:
-                SchematicManager.save_schematic(schematic, schematic_path)
-
-                # Prepare response with dynamic loading info
-                response = {
-                    "success": True,
-                    "component_reference": component.get('reference', 'unknown'),
-                    "dynamic_loading_used": needs_dynamic_loading
-                }
-
-                if needs_dynamic_loading:
-                    response["symbol_source"] = f"{library}:{comp_type}"
-                    response["template_reference"] = template_ref if 'template_ref' in locals() else "unknown"
-
-                return response
-            else:
-                return {"success": False, "message": "Failed to add component"}
+            return {
+                "success": True,
+                "component_reference": reference,
+                "symbol_source": f"{library}:{comp_type}"
+            }
         except Exception as e:
             logger.error(f"Error adding component to schematic: {str(e)}")
             import traceback
             logger.error(traceback.format_exc())
-            return {"success": False, "message": str(e), "errorDetails": traceback.format_exc()}
-    
+            return {"success": False, "message": str(e)}
+
     def _handle_add_schematic_wire(self, params):
         """Add a wire to a schematic using WireManager"""
         logger.info("Adding wire to schematic")


### PR DESCRIPTION
## Problem

The `add_schematic_component` tool fails after the first component addition because `DynamicSymbolLoader` uses `sexpdata.loads()` / `sexpdata.dumps()` to parse and rewrite the `.kicad_sch` file. This corrupts the KiCad file format:

- `sexpdata.dumps()` does not preserve KiCad's formatting
- Sub-symbol names get incorrectly prefixed (e.g., `Device:R_0_1` instead of `R_0_1`)
- The handler uses a complex template-clone workflow via kicad-skip that also reformats the file

## Solution

Rewrote `DynamicSymbolLoader` (`python/commands/dynamic_symbol_loader.py`) to use **raw text manipulation** instead of `sexpdata`:

- Extracts symbol definitions from `.kicad_sym` library files by matching parentheses depth
- Injects them into the schematic's `lib_symbols` section as raw text
- Correctly handles KiCad 9 naming rules:
  - Top-level symbols get library prefix: `(symbol "Device:R" ...)`
  - Sub-symbols keep short names: `(symbol "R_0_1" ...)`
- Resolves `(extends "ParentName")` by including parent symbols before children
- Added `add_component()` high-level method that injects symbol + creates instance in one call

Simplified `_handle_add_schematic_component` in `python/kicad_interface.py` to call `DynamicSymbolLoader.add_component()` directly, bypassing the kicad-skip load/save cycle.

## Testing

Tested with KiCad 9.0.7 on macOS. Successfully added R, C, LED, ESP32-WROOM-32E, Q_NMOS components to a blank schematic — all open correctly in KiCad without errors.

## Files changed

| File | Change |
|---|---|
| `python/commands/dynamic_symbol_loader.py` | Complete rewrite — text-based instead of sexpdata |
| `python/kicad_interface.py` | Simplified `_handle_add_schematic_component` handler |