### PR TITLE
fix: remove invalid ;; comments from template (KiCAD parse error, regression from b98c94b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ All notable changes to the KiCAD MCP Server project are documented here.
   format version `20250114` (KiCAD 9) after upstream commit `2b38796` accidentally downgraded
   both files to `20240101`. KiCAD 9 rejects schematics with outdated version numbers.
 
+- **CRITICAL: `template_with_symbols_expanded.kicad_sch`**: removed 7 invalid `;;` comment
+  lines introduced by upstream commit `b98c94b`. KiCAD's S-expression parser does not support
+  any comment syntax — it expects every non-empty, non-whitespace line to start with `(`.
+  The comments (`;; PASSIVES`, `;; SEMICONDUCTORS`, `;; INTEGRATED CIRCUITS`, `;; CONNECTORS`,
+  `;; POWER/REGULATORS`, `;; MISC`, `;; TEMPLATE INSTANCES (...)`) caused KiCAD 9 to reject
+  every schematic created from this template with a hard parse error:
+  > `Expecting '(' in <file>.kicad_sch, line 8, offset 5`
+  **Action required for existing projects:** delete every line beginning with `;;` from any
+  `.kicad_sch` file created between upstream commit `b98c94b` and this fix.
+
 ### Maintenance
 
 - `.gitignore`: added `*.kicad_pcb.bak`, `*.kicad_pro.bak` alongside existing `-bak` variants;

--- a/python/templates/template_with_symbols_expanded.kicad_sch
+++ b/python/templates/template_with_symbols_expanded.kicad_sch
@@ -5,7 +5,6 @@
   (paper "A4")
 
   (lib_symbols
-    ;; PASSIVES
     (symbol "Device:R" (pin_numbers hide) (pin_names (offset 0)) (in_bom yes) (on_board yes)
       (property "Reference" "R" (at 2.032 0 90)
         (effects (font (size 1.27 1.27)))
@@ -182,7 +181,6 @@
         )
       )
     )
-    ;; SEMICONDUCTORS
     (symbol "Device:D" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
       (property "Reference" "D" (at 0 2.54 0)
         (effects (font (size 1.27 1.27)))
@@ -497,7 +495,6 @@
         )
       )
     )
-    ;; INTEGRATED CIRCUITS
     (symbol "Amplifier_Operational:LM358" (pin_names (offset 0.127)) (in_bom yes) (on_board yes)
       (property "Reference" "U" (at 0 5.08 0)
         (effects (font (size 1.27 1.27)) (justify left))
@@ -546,7 +543,6 @@
         )
       )
     )
-    ;; CONNECTORS
     (symbol "Connector_Generic:Conn_01x02" (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
       (property "Reference" "J" (at 0 2.54 0)
         (effects (font (size 1.27 1.27)))
@@ -635,7 +631,6 @@
         )
       )
     )
-    ;; POWER/REGULATORS
     (symbol "Regulator_Linear:AMS1117-3.3" (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
       (property "Reference" "U" (at -3.81 3.175 0)
         (effects (font (size 1.27 1.27)))
@@ -670,7 +665,6 @@
         )
       )
     )
-    ;; MISC
     (symbol "Switch:SW_Push" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
       (property "Reference" "SW" (at 1.27 2.54 0)
         (effects (font (size 1.27 1.27)) (justify left))
@@ -721,7 +715,6 @@
     )
   )
 
-  ;; TEMPLATE INSTANCES (placed offscreen at -100, -110, etc.)
   (symbol (lib_id "Device:R") (at -100 -100 0) (unit 1)
     (in_bom no) (on_board no) (dnp yes)
     (uuid 00000000-0000-0000-0000-000000000001)


### PR DESCRIPTION
## Problem

Upstream commit b98c94b added 7 comment lines to
`python/templates/template_with_symbols_expanded.kicad_sch`:

```
;; PASSIVES
;; SEMICONDUCTORS
;; INTEGRATED CIRCUITS
;; CONNECTORS
;; POWER/REGULATORS
;; MISC
;; TEMPLATE INSTANCES (placed offscreen at -100, -110, etc.)
```


KiCAD's S-expression parser **does not support any comment syntax**.
It expects every non-empty, non-whitespace line to start with `(`.
These lines cause KiCAD 9 to reject every schematic generated from
this template with a hard parse error:

> `Expecting '(' in <file>.kicad_sch, line 8, offset 5`

## Fix

Remove all 7 `;;` lines from the template. No functional change —
the comments conveyed no information not already apparent from the
symbol names themselves.

## Action required for existing projects

Any `.kicad_sch` file generated by the MCP server **after upstream
commit `b98c94b`** and before this fix contains the same invalid lines.
Those files must be repaired manually:

1. Open the `.kicad_sch` file in a text editor.
2. Delete every line that starts with `;;`.
3. Save and reopen in KiCAD.

## Also included

- CHANGELOG entry for this regression under `v2.2.2-alpha`, including
  the critical user-action note above.
- CHANGELOG entries for `v2.2.2-alpha` that were missing from upstream
  (`route_pad_to_pad`, `copy_routing_pattern` MCP registration,
  three bug fixes from PR #49).