### PR TITLE
Handle relative XDG config/cache paths on Linux

### DIFF
--- a/python/utils/platform_helper.py
+++ b/python/utils/platform_helper.py
@@ -188,7 +188,10 @@ class PlatformHelper:
             # Use XDG Base Directory specification
             xdg_config = os.environ.get("XDG_CONFIG_HOME")
             if xdg_config:
-                return Path(xdg_config) / "kicad-mcp"
+                xdg_config_path = Path(xdg_config).expanduser()
+                if xdg_config_path.is_absolute():
+                    return xdg_config_path / "kicad-mcp"
+                logger.warning("Ignoring relative XDG_CONFIG_HOME: %s", xdg_config)
             return Path.home() / ".config" / "kicad-mcp"
         elif PlatformHelper.is_macos():
             return Path.home() / "Library" / "Application Support" / "kicad-mcp"
@@ -225,7 +228,10 @@ class PlatformHelper:
         elif PlatformHelper.is_linux():
             xdg_cache = os.environ.get("XDG_CACHE_HOME")
             if xdg_cache:
-                return Path(xdg_cache) / "kicad-mcp"
+                xdg_cache_path = Path(xdg_cache).expanduser()
+                if xdg_cache_path.is_absolute():
+                    return xdg_cache_path / "kicad-mcp"
+                logger.warning("Ignoring relative XDG_CACHE_HOME: %s", xdg_cache)
             return Path.home() / ".cache" / "kicad-mcp"
         elif PlatformHelper.is_macos():
             return Path.home() / "Library" / "Caches" / "kicad-mcp"

--- a/tests/test_platform_helper.py
+++ b/tests/test_platform_helper.py
@@ -89,6 +89,24 @@ class TestPathGeneration:
             expected = Path.home() / "Library" / "Application Support" / "kicad-mcp"
             assert config_dir == expected
 
+    def test_config_dir_ignores_relative_xdg_config_home(self, monkeypatch):
+        """Relative XDG_CONFIG_HOME should be ignored on Linux."""
+        monkeypatch.setattr(PlatformHelper, "is_linux", staticmethod(lambda: True))
+        monkeypatch.setattr(PlatformHelper, "is_windows", staticmethod(lambda: False))
+        monkeypatch.setattr(PlatformHelper, "is_macos", staticmethod(lambda: False))
+        monkeypatch.setenv("XDG_CONFIG_HOME", "relative/path")
+
+        assert PlatformHelper.get_config_dir() == Path.home() / ".config" / "kicad-mcp"
+
+    def test_cache_dir_ignores_relative_xdg_cache_home(self, monkeypatch):
+        """Relative XDG_CACHE_HOME should be ignored on Linux."""
+        monkeypatch.setattr(PlatformHelper, "is_linux", staticmethod(lambda: True))
+        monkeypatch.setattr(PlatformHelper, "is_windows", staticmethod(lambda: False))
+        monkeypatch.setattr(PlatformHelper, "is_macos", staticmethod(lambda: False))
+        monkeypatch.setenv("XDG_CACHE_HOME", "relative/cache")
+
+        assert PlatformHelper.get_cache_dir() == Path.home() / ".cache" / "kicad-mcp"
+
     def test_python_executable_is_valid(self):
         """Test that Python executable path is valid"""
         exe = PlatformHelper.get_python_executable()


### PR DESCRIPTION
## What changed
- Validate `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` before using them on Linux.
- Ignore relative values for these env vars and fall back to standard defaults (`~/.config/kicad-mcp` and `~/.cache/kicad-mcp`).
- Expand `~` in XDG paths so user-home based values are handled correctly.
- Added unit tests for relative XDG config/cache env vars to ensure fallback behavior remains stable.

## Why
- The XDG Base Directory spec expects absolute paths for `XDG_CONFIG_HOME` and `XDG_CACHE_HOME`.
- Relative values currently produce relative application paths, which can lead to surprising config/cache locations depending on the current working directory.
- Falling back to conventional defaults makes path behavior predictable and safer.

## Testing
- ✅ `scripts/clone_and_test.sh mixelpixx/KiCAD-MCP-Server` (pass: 15 passed, 1 skipped)
