### PR TITLE
fix: extend timeout for schematic query commands on large files

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -522,6 +522,9 @@ export class KiCADMcpServer {
         "export_pdf",
         "export_3d",
         "sync_schematic_to_board",
+        "list_schematic_nets",
+        "list_schematic_labels",
+        "get_schematic_view",
       ];
       if (longRunningCommands.includes(command)) {
         commandTimeout = 600000; // 10 minutes for long operations


### PR DESCRIPTION
## Summary

- Adds `list_schematic_nets`, `list_schematic_labels`, and `get_schematic_view` to the `longRunningCommands` list in `src/server.ts`.
- These three commands now use the extended 10-minute timeout instead of the default 30-second timeout.

## Problem

On larger schematic files, `list_schematic_nets`, `list_schematic_labels`, and `get_schematic_view` regularly exceed the default 30-second command timeout and fail. The infrastructure to handle long-running commands already exists (used by `run_drc`, `export_gerber`, `export_pdf`, `export_3d`, and `sync_schematic_to_board`), but these three schematic query commands were not included.

## Solution

Add the three commands to the existing `longRunningCommands` array so they receive the same 600-second (10-minute) timeout as other known long-running operations. This is a minimal, targeted change — three lines added, no behavior change for any other commands.

## Test plan

- [x] Verified the diff is exactly 3 lines added to the `longRunningCommands` array
- [x] Run `npm run build` to confirm TypeScript compiles without errors
- [x] Test `list_schematic_nets`, `list_schematic_labels`, and `get_schematic_view` against a large schematic file that previously timed out