### PR TITLE
fix: resolve lint errors (ESLint + Ruff)

### DIFF
--- a/download_jlcpcb.py
+++ b/download_jlcpcb.py
@@ -11,7 +11,6 @@ KiCad MCP server's JLCPCBPartsManager.
 """
 
 import json
-import os
 import sqlite3
 import subprocess
 import sys
@@ -84,7 +83,7 @@ def convert_to_mcp_format():
         print("ERROR: cache.sqlite3 not found")
         return False
 
-    print(f"Reading source database...")
+    print("Reading source database...")
     src = sqlite3.connect(str(source))
     src.row_factory = sqlite3.Row
 
@@ -142,7 +141,7 @@ def convert_to_mcp_format():
     # Map source columns to our schema
     # jlcparts schema varies but commonly has:
     # lcsc, mfr, description, joint, manufacturer, basic, preferred, stock, price, url, etc.
-    print(f"\nConverting parts to MCP format...")
+    print("\nConverting parts to MCP format...")
     now = int(time.time())
     batch = []
     count = 0
@@ -232,7 +231,7 @@ def convert_to_mcp_format():
         count += len(batch)
 
     # Build FTS index
-    print(f"  Building full-text search index...")
+    print("  Building full-text search index...")
     dst.execute("""
         CREATE VIRTUAL TABLE IF NOT EXISTS components_fts USING fts5(
             lcsc, description, mfr_part, manufacturer,

--- a/python/commands/board/view.py
+++ b/python/commands/board/view.py
@@ -6,7 +6,7 @@ import base64
 import io
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import pcbnew
 from PIL import Image

--- a/python/commands/component.py
+++ b/python/commands/component.py
@@ -2,11 +2,9 @@
 Component-related command implementations for KiCAD interface
 """
 
-import base64
 import logging
 import math
-import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import pcbnew
 from commands.library import LibraryManager
@@ -1002,12 +1000,6 @@ class ComponentCommands:
 
         # Convert spacing to nm
         unit = start_position.get("unit", "mm")
-        scale = 1000000 if unit == "mm" else 25400000  # mm or inch to nm
-        spacing_x_nm = int(spacing_x * scale)
-        spacing_y_nm = int(spacing_y * scale)
-
-        # Get layer ID
-        layer_id = self.board.GetLayerID(layer)
 
         for row in range(rows):
             for col in range(columns):

--- a/python/commands/component_schematic.py
+++ b/python/commands/component_schematic.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import uuid
 from pathlib import Path
 from typing import Optional

--- a/python/commands/connection_schematic.py
+++ b/python/commands/connection_schematic.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 from typing import Optional
 
@@ -104,7 +103,7 @@ class ConnectionManager:
             # Create wire stub using WireManager
             wire_success = WireManager.add_wire(schematic_path, pin_loc, stub_end)
             if not wire_success:
-                logger.error(f"Failed to create wire stub for net connection")
+                logger.error("Failed to create wire stub for net connection")
                 return False
 
             # Add label at the end of the stub using WireManager

--- a/python/commands/design_rules.py
+++ b/python/commands/design_rules.py
@@ -4,7 +4,7 @@ Design rules command implementations for KiCAD interface
 
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import pcbnew
 
@@ -173,8 +173,6 @@ class DesignRuleCommands:
     def run_drc(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Run Design Rule Check using kicad-cli"""
         import json
-        import platform
-        import shutil
         import subprocess
         import tempfile
 

--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -12,7 +12,7 @@ import os
 import re
 import uuid
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional
 
 logger = logging.getLogger("kicad_interface")
 
@@ -549,6 +549,6 @@ if __name__ == "__main__":
     if block and "LM2596S-12" in block:
         print(f"   OK: LM2596S-5 includes parent LM2596S-12 ({len(block)} chars)")
     else:
-        print(f"   FAIL: extends not resolved")
+        print("   FAIL: extends not resolved")
 
     print("\nAll tests passed!")

--- a/python/commands/export.py
+++ b/python/commands/export.py
@@ -2,12 +2,11 @@
 Export command implementations for KiCAD interface
 """
 
-import base64
 import logging
 import os
 import shutil
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import pcbnew
 
@@ -322,8 +321,6 @@ class ExportCommands:
 
     def export_3d(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Export 3D model files using kicad-cli (KiCAD 9.0 compatible)"""
-        import platform
-        import shutil
         import subprocess
 
         try:
@@ -610,7 +607,6 @@ class ExportCommands:
             Path to kicad-cli executable, or None if not found
         """
         import platform
-        import shutil
 
         # Try system PATH first
         cli_path = shutil.which("kicad-cli")

--- a/python/commands/footprint.py
+++ b/python/commands/footprint.py
@@ -107,9 +107,9 @@ class FootprintCreator:
         # ---- header ----
         lines.append(f'(footprint "{name}"')
         lines.append(f"  (version {KICAD9_FOOTPRINT_VERSION})")
-        lines.append(f'  (generator "kicad-mcp")')
-        lines.append(f'  (generator_version "9.0")')
-        lines.append(f'  (layer "F.Cu")')
+        lines.append('  (generator "kicad-mcp")')
+        lines.append('  (generator_version "9.0")')
+        lines.append('  (layer "F.Cu")')
         if description:
             lines.append(f'  (descr "{_esc(description)}")')
         if tags:
@@ -123,20 +123,20 @@ class FootprintCreator:
         val_y = value_position.get("y", 1.27) if value_position else 1.27
 
         lines.append(f'  (property "Reference" "REF**" (at {_fmt(ref_x)} {_fmt(ref_y)} 0)')
-        lines.append(f'    (layer "F.SilkS")')
+        lines.append('    (layer "F.SilkS")')
         lines.append(f'    (uuid "{_new_uuid()}")')
-        lines.append(f"    (effects (font (size 1 1) (thickness 0.15)))")
-        lines.append(f"  )")
+        lines.append("    (effects (font (size 1 1) (thickness 0.15)))")
+        lines.append("  )")
         lines.append(f'  (property "Value" "{_esc(name)}" (at {_fmt(val_x)} {_fmt(val_y)} 0)')
-        lines.append(f'    (layer "F.Fab")')
+        lines.append('    (layer "F.Fab")')
         lines.append(f'    (uuid "{_new_uuid()}")')
-        lines.append(f"    (effects (font (size 1 1) (thickness 0.15)))")
-        lines.append(f"  )")
-        lines.append(f'  (property "Datasheet" "" (at 0 0 0)')
-        lines.append(f'    (layer "F.Fab")')
+        lines.append("    (effects (font (size 1 1) (thickness 0.15)))")
+        lines.append("  )")
+        lines.append('  (property "Datasheet" "" (at 0 0 0)')
+        lines.append('    (layer "F.Fab")')
         lines.append(f'    (uuid "{_new_uuid()}")')
-        lines.append(f"    (effects (font (size 1 1) (thickness 0.15)))")
-        lines.append(f"  )")
+        lines.append("    (effects (font (size 1 1) (thickness 0.15)))")
+        lines.append("  )")
         lines.append("")
 
         # ---- courtyard ----
@@ -462,7 +462,7 @@ def _pad_lines(pad: Dict[str, Any]) -> List[str]:
         layers = (
             _DEFAULT_THT_LAYERS if ptype in ("thru_hole", "np_thru_hole") else _DEFAULT_SMD_LAYERS
         )
-    layers_str = " ".join(f'"{l}"' for l in layers)
+    layers_str = " ".join(f'"{layer_name}"' for layer_name in layers)
 
     lines = [f'  (pad "{number}" {ptype} {shape}']
     lines.append(f"    {at_str}")
@@ -482,7 +482,7 @@ def _pad_lines(pad: Dict[str, Any]) -> List[str]:
         lines.append(f"    (roundrect_rratio {_fmt(rr_ratio)})")
 
     lines.append(f'    (uuid "{_new_uuid()}")')
-    lines.append(f"  )")
+    lines.append("  )")
     return lines
 
 
@@ -493,13 +493,13 @@ def _rect_lines(rect: Dict[str, Any], layer: str, default_width: float = 0.05) -
     y2 = _fmt(rect.get("y2", 1.0))
     w = _fmt(rect.get("width", default_width))
     return [
-        f"  (fp_rect",
+        "  (fp_rect",
         f"    (start {x1} {y1})",
         f"    (end {x2} {y2})",
         f"    (stroke (width {w}) (type default))",
-        f"    (fill none)",
+        "    (fill none)",
         f'    (layer "{layer}")',
         f'    (uuid "{_new_uuid()}")',
-        f"  )",
+        "  )",
         "",
     ]

--- a/python/commands/jlcpcb.py
+++ b/python/commands/jlcpcb.py
@@ -14,7 +14,6 @@ import os
 import secrets
 import string
 import time
-from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
 import requests
@@ -269,7 +268,7 @@ def test_jlcpcb_connection(
     try:
         client = JLCPCBClient(app_id, access_key, secret_key)
         # Test by fetching first page
-        data = client.fetch_parts_page()
+        client.fetch_parts_page()
         logger.info("JLCPCB API connection test successful")
         return True
     except Exception as e:
@@ -292,7 +291,7 @@ if __name__ == "__main__":
         print(f"✓ Retrieved {len(parts)} parts in first page")
 
         if parts:
-            print(f"\nExample part:")
+            print("\nExample part:")
             part = parts[0]
             print(f"  LCSC: {part.get('componentCode')}")
             print(f"  MFR Part: {part.get('componentModelEn')}")

--- a/python/commands/jlcpcb_parts.py
+++ b/python/commands/jlcpcb_parts.py
@@ -7,7 +7,6 @@ and component selection.
 
 import json
 import logging
-import os
 import sqlite3
 from datetime import datetime
 from pathlib import Path
@@ -353,7 +352,7 @@ class JLCPCBPartsManager:
             if part.get("price_json"):
                 try:
                     part["price_breaks"] = json.loads(part["price_json"])
-                except:
+                except Exception:
                     part["price_breaks"] = []
             return part
         return None
@@ -457,7 +456,7 @@ class JLCPCBPartsManager:
             try:
                 prices = json.loads(p.get("price_json", "[]"))
                 price = float(prices[0].get("price", 999)) if prices else 999
-            except:
+            except Exception:
                 price = 999
             stock = p.get("stock", 0)
 
@@ -481,7 +480,7 @@ if __name__ == "__main__":
 
     # Get stats
     stats = manager.get_database_stats()
-    print(f"\nDatabase Statistics:")
+    print("\nDatabase Statistics:")
     print(f"  Total parts: {stats['total_parts']}")
     print(f"  Basic parts: {stats['basic_parts']}")
     print(f"  Extended parts: {stats['extended_parts']}")

--- a/python/commands/jlcsearch.py
+++ b/python/commands/jlcsearch.py
@@ -225,7 +225,7 @@ if __name__ == "__main__":
         print(f"✓ Found {len(resistors)} resistors")
 
         if resistors:
-            print(f"\nExample resistor:")
+            print("\nExample resistor:")
             r = resistors[0]
             print(f"  LCSC: C{r.get('lcsc')}")
             print(f"  MFR: {r.get('mfr')}")

--- a/python/commands/library.py
+++ b/python/commands/library.py
@@ -5,7 +5,6 @@ Handles parsing fp-lib-table files, discovering footprints,
 and providing search functionality for component placement.
 """
 
-import glob
 import logging
 import os
 import re

--- a/python/commands/library_schematic.py
+++ b/python/commands/library_schematic.py
@@ -4,7 +4,6 @@ import logging
 # Symbol class might not be directly importable in the current version
 import os
 
-from skip import Schematic
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +88,7 @@ class LibraryManager:
             # 3. Filtering symbols based on the query
 
             # For now, this is a placeholder implementation
-            libraries = LibraryManager.list_available_libraries(search_paths)
+            LibraryManager.list_available_libraries(search_paths)
 
             results = []
             logger.warning(

--- a/python/commands/library_symbol.py
+++ b/python/commands/library_symbol.py
@@ -592,7 +592,6 @@ class SymbolLibraryCommands:
 
 if __name__ == "__main__":
     # Test the symbol library manager
-    import json
 
     logging.basicConfig(level=logging.INFO)
 

--- a/python/commands/pin_locator.py
+++ b/python/commands/pin_locator.py
@@ -494,7 +494,7 @@ if __name__ == "__main__":
     if r1_pin1 and c1_pin1:
         # R1 is not rotated, pins should be at y offset from symbol center
         # C1 is rotated 90°, pins should be at x offset from symbol center
-        print(f"\n  Pin offset analysis:")
+        print("\n  Pin offset analysis:")
         print(f"    R1 (0°):  pin 1 y-offset = {r1_pin1[1] - 100}")
         print(f"    C1 (90°): pin 1 x-offset = {c1_pin1[0] - 150}")
 

--- a/python/commands/routing.py
+++ b/python/commands/routing.py
@@ -4,8 +4,7 @@ Routing-related command implementations for KiCAD interface
 
 import logging
 import math
-import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import pcbnew
 
@@ -884,9 +883,6 @@ class RoutingCommands:
 
             offset_x = target_pos.x - source_pos.x
             offset_y = target_pos.y - source_pos.y
-
-            # Build mapping from source refs to target refs
-            ref_mapping = dict(zip(source_refs, target_refs))
 
             # Collect all nets connected to source components
             source_nets = set()

--- a/python/commands/schematic_analysis.py
+++ b/python/commands/schematic_analysis.py
@@ -8,7 +8,7 @@ and checking connectivity in KiCad schematic files.
 import logging
 import math
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import sexpdata
 from commands.pin_locator import PinLocator

--- a/python/commands/svg_import.py
+++ b/python/commands/svg_import.py
@@ -62,7 +62,6 @@ def _parse_path_tokens(tokens: List[str]) -> List[Polygon]:
 
     i = 0
     cmd = "M"
-    num_tokens = []
 
     # --- helpers ---
     def consume(n: int) -> List[float]:
@@ -547,13 +546,12 @@ def import_svg_to_pcb(
         vb = _get_attr(root, "viewBox")
         if vb:
             parts = [float(v) for v in re.split(r"[\s,]+", vb.strip()) if v]
-            svg_x0, svg_y0, svg_w, svg_h = parts[0], parts[1], parts[2], parts[3]
+            _, _, svg_w, svg_h = parts[0], parts[1], parts[2], parts[3]
         else:
             w_str = _get_attr(root, "width", "100") or "100"
             h_str = _get_attr(root, "height", "100") or "100"
             svg_w = float(re.sub(r"[^\d.]", "", w_str) or 100)
             svg_h = float(re.sub(r"[^\d.]", "", h_str) or 100)
-            svg_x0, svg_y0 = 0.0, 0.0
 
         if svg_w == 0 or svg_h == 0:
             return {"success": False, "message": "SVG has zero width or height"}

--- a/python/commands/symbol_creator.py
+++ b/python/commands/symbol_creator.py
@@ -348,7 +348,7 @@ class SymbolCreator:
         board_str = "yes" if on_board else "no"
 
         lines.append(f'  (symbol "{name}"')
-        lines.append(f"    (exclude_from_sim no)")
+        lines.append("    (exclude_from_sim no)")
         lines.append(f"    (in_bom {bom_str})")
         lines.append(f"    (on_board {board_str})")
 
@@ -367,15 +367,15 @@ class SymbolCreator:
             lines.extend(_rect_sym_lines(rect))
         for pl in polylines:
             lines.extend(_polyline_lines(pl))
-        lines.append(f"    )")
+        lines.append("    )")
 
         # Sub-symbol _1_1: pins
         lines.append(f'    (symbol "{name}_1_1"')
         for pin in pins:
             lines.extend(_pin_lines(pin))
-        lines.append(f"    )")
+        lines.append("    )")
 
-        lines.append(f"  )")
+        lines.append("  )")
         return "\n".join(lines)
 
     def _remove_symbol(self, content: str, name: str) -> str:
@@ -413,10 +413,10 @@ def _property_block(key: str, value: str, x: float, y: float, visible: bool = Tr
     return [
         f'    (property "{_esc(key)}" "{_esc(value)}"',
         f"      (at {_fmt(x)} {_fmt(y)} 0)",
-        f"      (effects",
-        f"        (font (size 1.27 1.27))",
+        "      (effects",
+        "        (font (size 1.27 1.27))",
         f"      ){hide}",
-        f"    )",
+        "    )",
     ]
 
 
@@ -428,12 +428,12 @@ def _rect_sym_lines(rect: Dict[str, Any]) -> List[str]:
     w = _fmt(rect.get("width", 0.254))
     fill = rect.get("fill", "background")
     return [
-        f"      (rectangle",
+        "      (rectangle",
         f"        (start {x1} {y1})",
         f"        (end {x2} {y2})",
         f"        (stroke (width {w}) (type default))",
         f"        (fill (type {fill}))",
-        f"      )",
+        "      )",
     ]
 
 
@@ -442,16 +442,16 @@ def _polyline_lines(pl: Dict[str, Any]) -> List[str]:
     w = _fmt(pl.get("width", 0.254))
     fill = pl.get("fill", "none")
     lines = [
-        f"      (polyline",
-        f"        (pts",
+        "      (polyline",
+        "        (pts",
     ]
     for pt in pts:
         lines.append(f'          (xy {_fmt(pt["x"])} {_fmt(pt["y"])})')
     lines += [
-        f"        )",
+        "        )",
         f"        (stroke (width {w}) (type default))",
         f"        (fill (type {fill}))",
-        f"      )",
+        "      )",
     ]
     return lines
 
@@ -472,10 +472,10 @@ def _pin_lines(pin: Dict[str, Any]) -> List[str]:
         f"        (at {x} {y} {angle})",
         f"        (length {length})",
         f'        (name "{_esc(pin_name)}"',
-        f"          (effects (font (size 1.27 1.27)))",
-        f"        )",
+        "          (effects (font (size 1.27 1.27)))",
+        "        )",
         f'        (number "{_esc(pin_number)}"',
-        f"          (effects (font (size 1.27 1.27)))",
-        f"        )",
-        f"      )",
+        "          (effects (font (size 1.27 1.27)))",
+        "        )",
+        "      )",
     ]

--- a/python/commands/wire_dragger.py
+++ b/python/commands/wire_dragger.py
@@ -7,9 +7,8 @@ All methods operate on in-memory sexpdata lists (no disk I/O).
 import logging
 import math
 import uuid
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Tuple
 
-import sexpdata
 from sexpdata import Symbol
 
 logger = logging.getLogger("kicad_interface")

--- a/python/commands/wire_manager.py
+++ b/python/commands/wire_manager.py
@@ -7,7 +7,6 @@ manipulate the .kicad_sch file directly.
 """
 
 import logging
-import math
 import tempfile
 import uuid
 from pathlib import Path
@@ -723,7 +722,7 @@ if __name__ == "__main__":
 
         sch = Schematic(str(test_path))
         wire_count = len(list(sch.wire)) if hasattr(sch, "wire") else 0
-        print(f"  ✓ Loaded successfully")
+        print("  ✓ Loaded successfully")
         print(f"  ✓ Wire count: {wire_count}")
     except Exception as e:
         print(f"  ✗ Failed: {e}")

--- a/python/kicad_api/factory.py
+++ b/python/kicad_api/factory.py
@@ -6,7 +6,6 @@ Auto-detects available backends and provides fallback mechanism.
 
 import logging
 import os
-from pathlib import Path
 from typing import Optional
 
 from kicad_api.base import APINotAvailableError, KiCADBackend

--- a/python/kicad_api/ipc_backend.py
+++ b/python/kicad_api/ipc_backend.py
@@ -532,7 +532,7 @@ class IPCBoardAPI(BoardAPI):
                         if loaded_fp:
                             logger.info(f"Found footprint '{fp_name}' in library '{lib}'")
                             return loaded_fp
-                    except:
+                    except Exception:
                         continue
 
             logger.warning(f"Footprint '{footprint_path}' not found in any library")
@@ -561,7 +561,6 @@ class IPCBoardAPI(BoardAPI):
 
             # Get the pcbnew board instance
             # We need to get the actual board file path
-            project = board.get_project()
             board_path = None
 
             # Try to get the board path from kipy
@@ -1071,7 +1070,7 @@ class IPCBoardAPI(BoardAPI):
         """
         try:
             from kipy.board_types import Zone, ZoneFillMode, ZoneType
-            from kipy.geometry import PolyLine, PolyLineNode, Vector2
+            from kipy.geometry import PolyLine, PolyLineNode
             from kipy.proto.board.board_types_pb2 import BoardLayer
             from kipy.util.units import from_mm
 
@@ -1154,7 +1153,6 @@ class IPCBoardAPI(BoardAPI):
     def get_zones(self) -> List[Dict[str, Any]]:
         """Get all zones on the board."""
         try:
-            from kipy.util.units import to_mm
 
             board = self._get_board()
             zones = board.get_zones()
@@ -1168,7 +1166,7 @@ class IPCBoardAPI(BoardAPI):
                             "net": zone.net.name if zone.net else "",
                             "priority": zone.priority if hasattr(zone, "priority") else 0,
                             "layers": (
-                                [str(l) for l in zone.layers] if hasattr(zone, "layers") else []
+                                [str(layer) for layer in zone.layers] if hasattr(zone, "layers") else []
                             ),
                             "filled": zone.filled if hasattr(zone, "filled") else False,
                             "id": str(zone.id) if hasattr(zone, "id") else "",

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -12,6 +12,7 @@ import logging
 import os
 import sys
 import traceback
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from resources.resource_definitions import RESOURCE_DEFINITIONS, handle_resource_read
@@ -81,10 +82,10 @@ utils_dir = os.path.join(os.path.dirname(__file__))
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)
 
-from utils.kicad_process import KiCADProcessManager, check_and_launch_kicad
+from utils.kicad_process import KiCADProcessManager, check_and_launch_kicad  # noqa: E402
 
 # Import platform helper and add KiCAD paths
-from utils.platform_helper import PlatformHelper
+from utils.platform_helper import PlatformHelper  # noqa: E402
 
 logger.info(f"Detecting KiCAD Python paths for {PlatformHelper.get_platform_name()}...")
 paths_added = PlatformHelper.add_kicad_to_python_path()
@@ -119,7 +120,7 @@ if KICAD_BACKEND in ("auto", "ipc"):
         ipc_backend = IPCBackend()
         if ipc_backend.connect():
             USE_IPC_BACKEND = True
-            logger.info(f"✓ Using IPC backend - real-time UI sync enabled!")
+            logger.info("✓ Using IPC backend - real-time UI sync enabled!")
             logger.info(f"  KiCAD version: {ipc_backend.get_version()}")
         else:
             logger.info("IPC backend available but KiCAD not running with IPC enabled")
@@ -206,21 +207,20 @@ try:
     logger.info("Importing command handlers...")
     from commands.board import BoardCommands
     from commands.component import ComponentCommands
-    from commands.component_schematic import ComponentManager
     from commands.connection_schematic import ConnectionManager
     from commands.datasheet_manager import DatasheetManager
     from commands.design_rules import DesignRuleCommands
     from commands.export import ExportCommands
     from commands.footprint import FootprintCreator
     from commands.freerouting import FreeroutingCommands
-    from commands.jlcpcb import JLCPCBClient, test_jlcpcb_connection
+    from commands.jlcpcb import JLCPCBClient
     from commands.jlcpcb_parts import JLCPCBPartsManager
     from commands.library import (
         LibraryCommands,
     )
     from commands.library import LibraryManager as FootprintLibraryManager
     from commands.library_schematic import LibraryManager as SchematicLibraryManager
-    from commands.library_symbol import SymbolLibraryCommands, SymbolLibraryManager
+    from commands.library_symbol import SymbolLibraryCommands
     from commands.project import ProjectCommands
     from commands.routing import RoutingCommands
     from commands.schematic import SchematicManager
@@ -1277,7 +1277,7 @@ class KiCADInterface:
         try:
             search_paths = params.get("searchPaths")
 
-            libraries = LibraryManager.list_available_libraries(search_paths)
+            libraries = SchematicLibraryManager.list_available_libraries(search_paths)
             return {"success": True, "libraries": libraries}
         except Exception as e:
             logger.error(f"Error listing schematic libraries: {str(e)}")
@@ -3900,7 +3900,7 @@ print("ok")
                 if part.get("price_json"):
                     try:
                         part["price_breaks"] = json.loads(part["price_json"])
-                    except:
+                    except Exception:
                         part["price_breaks"] = []
 
             return {"success": True, "parts": parts, "count": len(parts)}
@@ -3954,7 +3954,7 @@ print("ok")
             if original_part and original_part.get("price_breaks"):
                 try:
                     reference_price = float(original_part["price_breaks"][0].get("price", 0))
-                except:
+                except Exception:
                     pass
 
             alternatives = self.jlcpcb_parts.suggest_alternatives(lcsc_number, limit)
@@ -3964,7 +3964,7 @@ print("ok")
                 if part.get("price_json"):
                     try:
                         part["price_breaks"] = json.loads(part["price_json"])
-                    except:
+                    except Exception:
                         part["price_breaks"] = []
 
             return {

--- a/python/parsers/kicad_mod_parser.py
+++ b/python/parsers/kicad_mod_parser.py
@@ -18,7 +18,7 @@ KiCad S-expression file format reference:
 import logging
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("kicad_interface")
 

--- a/python/resources/resource_definitions.py
+++ b/python/resources/resource_definitions.py
@@ -5,10 +5,9 @@ Resources follow the MCP 2025-06-18 specification, providing
 read-only access to project data for LLM context.
 """
 
-import base64
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 logger = logging.getLogger("kicad_interface")
 

--- a/python/test_ipc_backend.py
+++ b/python/test_ipc_backend.py
@@ -42,7 +42,7 @@ def test_connection():
         print("✓ IPCBackend created")
 
         if backend.connect():
-            print(f"✓ Connected to KiCAD via IPC")
+            print("✓ Connected to KiCAD via IPC")
             print(f"  Version: {backend.get_version()}")
             return backend
         else:

--- a/python/tests/test_delete_schematic_component.py
+++ b/python/tests/test_delete_schematic_component.py
@@ -8,7 +8,6 @@ them on *separate* lines, so every real-world delete returned "not found".
 
 import re
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -125,13 +124,13 @@ class TestDeleteDetectionRegex:
         """Regression: old line-by-line regex must NOT match the multi-line format."""
         # The old code used re.match on individual lines; simulate that here.
         lines = PLACED_RESISTOR_MULTILINE.split("\n")
-        matches = [l for l in lines if re.match(r"\s*\(symbol\s+\(lib_id\s+\"", l)]
+        matches = [line for line in lines if re.match(r"\s*\(symbol\s+\(lib_id\s+\"", line)]
         assert matches == [], "Old regex should not match multi-line KiCAD format"
 
     def test_old_regex_matches_inline_format(self):
         """Old regex did work on single-line (inline) format."""
         lines = PLACED_RESISTOR_INLINE.split("\n")
-        matches = [l for l in lines if re.match(r"\s*\(symbol\s+\(lib_id\s+\"", l)]
+        matches = [line for line in lines if re.match(r"\s*\(symbol\s+\(lib_id\s+\"", line)]
         assert len(matches) == 1
 
     def test_new_pattern_matches_multiline_format(self):

--- a/python/tests/test_move_with_wire_preservation.py
+++ b/python/tests/test_move_with_wire_preservation.py
@@ -9,7 +9,6 @@ import shutil
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 import sexpdata
@@ -18,7 +17,7 @@ from sexpdata import Symbol
 # Make python/ importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from commands.wire_dragger import EPS, WireDragger, _coords_match, _rotate
+from commands.wire_dragger import EPS, WireDragger, _rotate
 
 TEMPLATE_PATH = Path(__file__).resolve().parent.parent / "templates" / "empty.kicad_sch"
 
@@ -302,7 +301,6 @@ class TestDragWires:
         """A wire whose endpoints don't match any old pin is not changed."""
         wire = _make_wire(50, 50, 60, 50)
         sch = _make_sch_data([wire])
-        original_start = (50.0, 50.0)
         result = WireDragger.drag_wires(sch, {(0.0, 3.81): (10.0, 23.81)})
         assert result["endpoints_moved"] == 0
         updated = next(i for i in sch if isinstance(i, list) and i and i[0] == Symbol("wire"))

--- a/python/tests/test_schematic_analysis.py
+++ b/python/tests/test_schematic_analysis.py
@@ -5,16 +5,13 @@ Unit tests use mock data / synthetic S-expressions.
 Integration tests parse real .kicad_sch files via sexpdata.
 """
 
-import os
 import shutil
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 import sexpdata
-from sexpdata import Symbol
 
 # Ensure the python/ package is importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -59,7 +56,7 @@ def _make_temp_schematic(extra_sexp: str = "") -> Path:
     return tmp
 
 
-import uuid as _uuid
+import uuid as _uuid  # noqa: E402
 
 
 def _make_resistor_sexp(ref: str, x: float, y: float, rotation: float = 0) -> str:

--- a/python/tests/test_schematic_component_fields.py
+++ b/python/tests/test_schematic_component_fields.py
@@ -3,9 +3,7 @@ Tests for get_schematic_component and edit_schematic_component fieldPositions su
 """
 
 import re
-import shutil
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/python/tests/test_schematic_tools.py
+++ b/python/tests/test_schematic_tools.py
@@ -163,7 +163,7 @@ class TestDeleteWireIntegration:
         sch = tmp_path / "test.kicad_sch"
         sch.write_text(_WIRE_SCH, encoding="utf-8")
 
-        result = self.WireManager.delete_wire(sch, [10.0, 20.0], [30.0, 20.0], tolerance=0.0)
+        self.WireManager.delete_wire(sch, [10.0, 20.0], [30.0, 20.0], tolerance=0.0)
         # tolerance=0.0 means exact float equality — may still match on most
         # platforms, but the key thing is that a *distant* miss is rejected
         sch2 = tmp_path / "test2.kicad_sch"
@@ -268,7 +268,6 @@ def _make_handler_under_test(handler_name: str):
     This works because every _handle_* method starts with a params dict check
     before doing any file I/O or heavy imports.
     """
-    import importlib.util
     import types
 
     # We monkey-patch sys.modules to avoid pcbnew/skip side effects
@@ -302,7 +301,6 @@ class TestHandlerParamValidation:
 
     def _make_iface_stub(self):
         """Return a stub that exposes only the handler methods under test."""
-        import importlib
         import types
 
         # Build a minimal namespace that satisfies the imports inside each handler

--- a/python/tests/test_wire_connectivity.py
+++ b/python/tests/test_wire_connectivity.py
@@ -11,7 +11,6 @@ Covers:
 
 import sys
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/python/tests/test_wire_junction_changes.py
+++ b/python/tests/test_wire_junction_changes.py
@@ -10,7 +10,7 @@ import shutil
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 import sexpdata
@@ -119,7 +119,6 @@ class TestHandlerDispatch:
     @pytest.fixture(autouse=True)
     def load_handler_map(self):
         # Import only the dispatch table without initialising KiCAD connections
-        import importlib
         import types
 
         # Patch heavy imports before loading kicad_interface
@@ -317,7 +316,6 @@ class TestPinSnapping:
         # get_all_symbol_pins won't be called because symbol list is empty in fixture.
         # Instead we patch find_nearest_pin indirectly by providing all_pins via the
         # skip.Schematic stub that returns one symbol with a known pin.
-        import types
 
         skip_mod = sys.modules["skip"]
 
@@ -382,7 +380,7 @@ class TestPinSnapping:
     @patch("commands.wire_manager.WireManager.add_wire", return_value=True)
     def test_snap_miss_leaves_coords_unchanged(self, mock_wire):
         """Point beyond tolerance should not be snapped."""
-        with patch("commands.wire_manager.WireManager.add_wire", return_value=True) as mw:
+        with patch("commands.wire_manager.WireManager.add_wire", return_value=True):
             result = self.iface._handle_add_schematic_wire(
                 {
                     "schematicPath": str(self.sch_path),

--- a/python/utils/kicad_process.py
+++ b/python/utils/kicad_process.py
@@ -6,7 +6,6 @@ Detects if KiCAD is running and provides auto-launch functionality.
 
 import ctypes
 import logging
-import os
 import platform
 import subprocess
 import time
@@ -110,7 +109,7 @@ class KiCADProcessManager:
                             )
                             if "kicad_interface.py" not in cmdline.stdout:
                                 return True
-                        except:
+                        except Exception:
                             pass
                 return False
 

--- a/python/utils/platform_helper.py
+++ b/python/utils/platform_helper.py
@@ -86,9 +86,9 @@ class PlatformHelper:
             # This is where pcbnew.py typically lives on modern systems
             candidates.extend(
                 [
-                    Path(f"/usr/lib/python3/dist-packages"),
+                    Path("/usr/lib/python3/dist-packages"),
                     Path(f"/usr/lib/python{py_version}/dist-packages"),
-                    Path(f"/usr/local/lib/python3/dist-packages"),
+                    Path("/usr/local/lib/python3/dist-packages"),
                     Path(f"/usr/local/lib/python{py_version}/dist-packages"),
                 ]
             )

--- a/src/kicad-server.ts
+++ b/src/kicad-server.ts
@@ -1,10 +1,8 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { spawn, ChildProcess } from "child_process";
 import { existsSync } from "fs";
-import path from "path";
 
 // Import all tool definitions for reference
 // import { registerBoardTools } from './tools/board.js';
@@ -456,14 +454,14 @@ class KiCADServer {
                 isError: true,
               });
             }
-          } catch (e) {
+          } catch {
             // Not a complete JSON yet, keep collecting data
           }
         });
       }
 
       // Set a timeout
-      const timeout = setTimeout(() => {
+      setTimeout(() => {
         console.error(`Command timeout: ${request.command}`);
 
         // Clear listeners

--- a/src/resources/board.ts
+++ b/src/resources/board.ts
@@ -6,9 +6,7 @@
  */
 
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 import { logger } from "../logger.js";
-import { createJsonResponse, createBinaryResponse } from "../utils/resource-helpers.js";
 
 // Command function type for KiCAD script calls
 type CommandFunction = (command: string, params: Record<string, unknown>) => Promise<any>;

--- a/src/resources/library.ts
+++ b/src/resources/library.ts
@@ -6,7 +6,6 @@
  */
 
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 import { logger } from "../logger.js";
 
 // Command function type for KiCAD script calls

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,6 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import express from "express";
 import { spawn, exec, execSync, ChildProcess } from "child_process";
 import { existsSync } from "fs";
 import { join, dirname } from "path";
@@ -26,7 +25,6 @@ import { registerFootprintTools } from "./tools/footprint.js";
 import { registerSymbolCreatorTools } from "./tools/symbol-creator.js";
 import { registerUITools } from "./tools/ui.js";
 import { registerFreeroutingTools } from "./tools/freerouting.js";
-import { registerRouterTools } from "./tools/router.js";
 
 // Import resource registration functions
 import { registerProjectResources } from "./resources/project.js";
@@ -137,7 +135,7 @@ function findPythonExecutable(scriptPath: string): string {
         logger.info(`Resolved system Python via which: ${result}`);
         return result;
       }
-    } catch (e) {
+    } catch {
       logger.warn("Failed to resolve python3 via which command");
     }
 

--- a/tests/test_platform_helper.py
+++ b/tests/test_platform_helper.py
@@ -5,7 +5,6 @@ These are unit tests that work on all platforms.
 """
 
 import os
-import platform
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- Remove 11 unused TypeScript imports/variables flagged by ESLint
- Fix 142 Python Ruff lint errors: unused imports (F401), f-string placeholders (F541), bare excepts (E722), ambiguous variable names (E741), unused locals (F841), import sorting, and more
- No behavioral changes — all fixes are safe cleanup

## Details
**TypeScript (ESLint):** Removed unused `McpServer`, `path`, `express`, `registerRouterTools`, `z`, `createJsonResponse`, `createBinaryResponse` imports. Removed unused catch bindings and an unused `timeout` variable.

**Python (Ruff):** 142 errors across 38 files. Auto-fixed 107 (import sorting, f-string cleanup, unused imports). Manually fixed 35 (bare `except:` → `except Exception:`, ambiguous `l` → descriptive names, unused local variables, undefined name references).

## Test plan
- [x] ESLint passes with zero warnings
- [x] Ruff passes with zero errors
- [x] No side-effect imports removed
- [x] No behavioral changes