### PR TITLE
docs: add pre-commit hooks setup instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,25 @@ npm test
 pytest
 ```
 
+### Pre-commit Hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to run linters and formatters automatically before each commit. Pre-commit hooks prevent noisy formatting diffs caused by different IDE configurations across contributors, catch common mistakes and type errors before they reach code review, and ensure every commit in the repository meets the same quality baseline — so reviewers can focus on logic and design rather than style issues.
+
+**All contributors must install pre-commit hooks after cloning the repo:**
+
+```bash
+# Install pre-commit (if not already installed)
+pip install pre-commit
+
+# Install the git hooks
+pre-commit install
+
+# (Optional) Run against all files to verify setup
+pre-commit run --all-files
+```
+
+> **Important:** Do not use `git commit --no-verify` to bypass pre-commit hooks. The hooks enforce code quality checks (Black, isort, Prettier, flake8, mypy, ESLint) that must pass before code is merged. If a hook fails, fix the underlying issue rather than skipping the check.
+
 ---
 
 ## Project Structure


### PR DESCRIPTION
## Summary

- Documents the project's pre-commit hook setup in `CONTRIBUTING.md`, explaining what hooks are enforced (Black, isort, Prettier, flake8, mypy, ESLint) and why they matter
- Adds step-by-step installation instructions so contributors can get hooks running immediately after cloning
- Explicitly discourages bypassing hooks with `--no-verify`, directing contributors to fix the underlying issue instead

## Motivation

Contributors using different IDEs or local configs were producing formatting diffs that added noise to code review. Making hook setup a documented, required step ensures every commit meets the same quality baseline before it reaches review.

## Test plan

- [x] Verify `pre-commit install` runs successfully in a fresh clone
- [x] Verify `pre-commit run --all-files` passes on the current state of the repo
- [x] Confirm the rendered CONTRIBUTING.md reads clearly on GitHub

🤖 Generated with [Claude Code](https://claude.ai/claude-code)