### PR TITLE
chore: align Python version floor with KiCad's macOS bundle (3.9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ dmypy.json
 
 # Virtual Environments
 venv/
+.venv/
 env/
 ENV/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Thank you for your interest in contributing to the KiCAD MCP Server! This guide 
 
 - **KiCAD 9.0 or higher** - [Download here](https://www.kicad.org/download/)
 - **Node.js v18+** - [Download here](https://nodejs.org/)
-- **Python 3.10+** - Should come with KiCAD, or install separately
+- **Python 3.9+** - Comes bundled with KiCAD (macOS builds ship Python 3.9; Linux/Windows builds ship Python 3.11)
 - **Git** - For version control
 
 ### Platform-Specific Setup

--- a/README.md
+++ b/README.md
@@ -430,9 +430,9 @@ See [Freerouting Guide](docs/FREEROUTING_GUIDE.md) for setup and usage.
 - Download from [nodejs.org](https://nodejs.org/)
 - Verify: `node --version` and `npm --version`
 
-**Python 3.10 or Higher**
+**Python 3.9 or Higher**
 
-- Usually included with KiCAD
+- Comes bundled with KiCAD (macOS builds ship Python 3.9; Linux/Windows builds ship Python 3.11)
 - Required packages (auto-installed):
   - kicad-python (kipy) >= 0.5.0 (IPC API support, optional but recommended)
   - kicad-skip >= 0.1.0 (schematic support)
@@ -692,7 +692,7 @@ Edit configuration file:
 
 - **Linux:** `/usr/lib/kicad/lib/python3/dist-packages`
 - **Windows:** `C:\Program Files\KiCad\9.0\lib\python3\dist-packages`
-- **macOS:** `/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages`
+- **macOS:** `/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages`
 
 #### Linux Python Detection
 

--- a/config/macos-config.example.json
+++ b/config/macos-config.example.json
@@ -5,7 +5,7 @@
       "args": ["/Users/YOUR_USERNAME/MCP/KiCAD-MCP-Server/dist/index.js"],
       "env": {
         "NODE_ENV": "production",
-        "PYTHONPATH": "/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.11/site-packages",
+        "PYTHONPATH": "/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.9/site-packages",
         "LOG_LEVEL": "info",
         "KICAD_AUTO_LAUNCH": "false"
       },

--- a/docs/CLIENT_CONFIGURATION.md
+++ b/docs/CLIENT_CONFIGURATION.md
@@ -241,7 +241,7 @@ PYTHONPATH=python python3 -c "from utils.platform_helper import PlatformHelper; 
 
 ```bash
 # Typical location
-/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.11/site-packages
+/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.9/site-packages
 
 # Find dynamically
 find /Applications/KiCad -name "pcbnew.py" -type f

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,18 @@
 [project]
 name = "kicad-mcp-server"
 version = "2.1.0"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 
 [tool.black]
 line-length = 100
-target-version = ["py310"]
+target-version = ["py39"]
 
 [tool.isort]
 profile = "black"
 line_length = 100
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.9"
 warn_return_any = false
 warn_unused_configs = true
 check_untyped_defs = false


### PR DESCRIPTION
Mostly cleanup for running on macOS after #89. KiCad ships Python 3.9 on macOS (both v9 and v10), and sicne `pcbnew.so` is compiled against that interpreter the previous `>=3.10` floor was unreachable on macOS. The docs referenced nonexistent `python3.11/site-packages` paths. Lowered the floor and corrected the docs. No source changes needed and all  files in `python/` already compile clean on 3.9. Also add `.venv/` to `.gitignore`.