### PR TITLE
refactor: remove dead list_library_symbols stub in LibraryManager

### DIFF
--- a/python/commands/library_schematic.py
+++ b/python/commands/library_schematic.py
@@ -47,31 +47,9 @@ class LibraryManager:
         return {"paths": libraries, "names": library_names}
 
     @staticmethod
-    def list_library_symbols(library_path: str) -> List[Any]:
-        """List all symbols in a library"""
-        try:
-            # kicad-skip doesn't provide a direct way to simply list symbols in a library
-            # without loading each one. We might need to implement this using KiCAD's Python API
-            # directly, or by using a different approach.
-            # For now, this is a placeholder implementation.
-
-            # A potential approach would be to load the library file using KiCAD's Python API
-            # or by parsing the library file format.
-            # KiCAD symbol libraries are .kicad_sym files which are S-expression format
-            logger.warning(
-                f"Attempted to list symbols in library {library_path}. This requires advanced implementation."
-            )
-            return []
-        except Exception as e:
-            logger.error(f"Error listing symbols in library {library_path}: {e}")
-            return []
-
-    @staticmethod
     def get_symbol_details(library_path: str, symbol_name: str) -> Dict[str, Any]:
         """Get detailed information about a symbol"""
         try:
-            # Similar to list_library_symbols, this might require a more direct approach
-            # using KiCAD's Python API or by parsing the symbol library.
             logger.warning(
                 f"Attempted to get details for symbol {symbol_name} in library {library_path}. This requires advanced implementation."
             )
@@ -143,15 +121,6 @@ if __name__ == "__main__":
     # Example Usage (for testing)
     # List available libraries
     libraries = LibraryManager.list_available_libraries()
-    if libraries["paths"]:
-        first_lib = libraries["paths"][0]
-        lib_name = libraries["names"][0]
-        print(f"Testing with first library: {lib_name} ({first_lib})")
-
-        # List symbols in the first library
-        symbols = LibraryManager.list_library_symbols(first_lib)
-        # This will report that it requires advanced implementation
-
     # Get default symbol for a component type
     resistor_sym = LibraryManager.get_default_symbol_for_component_type("resistor")
     print(f"Default symbol for resistor: {resistor_sym['library']}/{resistor_sym['symbol']}")


### PR DESCRIPTION
## Summary
- `LibraryManager.list_library_symbols` in `python/commands/library_schematic.py` was a placeholder static method that logged a warning and returned `[]`. It had no dispatch entry and no production caller.
- The live tool of the same name is wired through `python/commands/library_symbol.py` (dispatched at `kicad_interface.py:359`) and is unaffected.
- Also removed a stale comment in `get_symbol_details` and an obsolete `__main__` self-test block that called the stub.

## Changes
- `python/commands/library_schematic.py` — delete the stub method, stale comment, and `__main__` self-test reference (31 lines total).

## Test plan
- [x] `.venv/bin/pytest tests/ -v` — 520 passed, no new failures
- [x] `.venv/bin/mypy python/` — no issues in 48 source files
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)