### PR TITLE
fix: use KICAD_PYTHON env var instead of hardcoded Windows path

### DIFF
--- a/src/kicad-server.ts
+++ b/src/kicad-server.ts
@@ -306,14 +306,13 @@ class KiCADServer {
 
       // Start the Python process for KiCAD scripting
       console.error(`Starting Python process with script: ${this.kicadScriptPath}`);
-      const pythonExe = "C:\\Program Files\\KiCad\\9.0\\bin\\python.exe";
+      const pythonExe = process.env.KICAD_PYTHON || "python3";
 
       console.error(`Using Python executable: ${pythonExe}`);
       this.pythonProcess = spawn(pythonExe, [this.kicadScriptPath], {
         stdio: ["pipe", "pipe", "pipe"],
         env: {
           ...process.env,
-          PYTHONPATH: "C:/Program Files/KiCad/9.0/lib/python3/dist-packages",
         },
       });
 


### PR DESCRIPTION
## Summary

- `kicad-server.ts` had `C:\Program Files\KiCad\9.0\bin\python.exe` hardcoded as the Python executable, causing the server to fail silently on macOS and Linux
- The `PYTHONPATH` was also hardcoded to a Windows path, overriding the correct value already provided by the environment
- This fix reads `KICAD_PYTHON` from the environment (already set correctly by `setup-macos.sh` and `setup-windows.ps1`) with `python3` as a fallback

## Test plan

- [ ] Run `setup-macos.sh --apply` to configure `KICAD_PYTHON` env var
- [ ] Restart Claude Desktop / Claude Code
- [ ] Verify `check_kicad_ui` MCP tool returns success instead of "Python process for KiCAD scripting is not running"

🤖 Generated with [Claude Code](https://claude.com/claude-code)