### PR TITLE
fix: add_label falls back gracefully on sub-sheet schematics

### DIFF
--- a/python/commands/wire_manager.py
+++ b/python/commands/wire_manager.py
@@ -316,8 +316,9 @@ class WireManager:
                     break
 
             if sheet_instances_index is None:
-                logger.error("No sheet_instances section found in schematic")
-                return False
+                # Sub-sheets in hierarchical designs don't have (sheet_instances).
+                # Fall back to appending before the final closing paren of (kicad_sch ...).
+                sheet_instances_index = len(sch_data)
 
             # Insert label
             sch_data.insert(sheet_instances_index, label_sexp)


### PR DESCRIPTION
## Summary

- `WireManager.add_label` returned `False` with a logged error whenever the schematic had no `(sheet_instances)` block
- Sub-sheets in hierarchical KiCad designs never have `(sheet_instances)` — only the top-level schematic does
- This made it impossible to add any net label (local, global, or hierarchical) to any sub-sheet

## Fix

When `sheet_instances_index` is `None`, fall back to `len(sch_data)` as the insertion index, which appends before the final closing paren of `(kicad_sch ...)`.

## Test plan

- [x] Add a net label to a top-level schematic → still works
- [x] Add a net label to a sub-sheet schematic → previously returned False, now succeeds
- [x] Verify the output file is valid KiCad s-expression (parseable by KiCad)

🤖 Generated with [Claude Code](https://claude.com/claude-code)