### PR TITLE
fix: delete_label matches global_label and hierarchical_label types

### DIFF
--- a/python/commands/wire_manager.py
+++ b/python/commands/wire_manager.py
@@ -25,6 +25,8 @@ _SYM_PTS = Symbol("pts")
 _SYM_XY = Symbol("xy")
 _SYM_AT = Symbol("at")
 _SYM_LABEL = Symbol("label")
+_SYM_GLOBAL_LABEL = Symbol("global_label")
+_SYM_HIERARCHICAL_LABEL = Symbol("hierarchical_label")
 _SYM_STROKE = Symbol("stroke")
 _SYM_WIDTH = Symbol("width")
 _SYM_TYPE = Symbol("type")
@@ -681,8 +683,9 @@ class WireManager:
 
             sch_data = sexpdata.loads(sch_content)
 
+            _LABEL_TYPES = {_SYM_LABEL, _SYM_GLOBAL_LABEL, _SYM_HIERARCHICAL_LABEL}
             for i, item in enumerate(sch_data):
-                if not (isinstance(item, list) and len(item) > 0 and item[0] == _SYM_LABEL):
+                if not (isinstance(item, list) and len(item) > 0 and item[0] in _LABEL_TYPES):
                     continue
 
                 # Second element is the label text


### PR DESCRIPTION
## Summary

- `WireManager.delete_label` only checked `item[0] == Symbol("label")` when scanning the schematic s-expression list
- `global_label` and `hierarchical_label` elements have different symbol types and were silently skipped
- Result: `delete_schematic_net_label` always returned "Label not found" for global and hierarchical labels, even when they existed at the exact coordinates provided

## Fix

Add `Symbol("global_label")` and `Symbol("hierarchical_label")` constants alongside the existing `Symbol("label")`, then use `in` against a set of all three types instead of `==` for a single type.

## Test plan

- [ ] Delete a local `label` → still works
- [ ] Delete a `global_label` → previously failed, now succeeds
- [ ] Delete a `hierarchical_label` → previously failed, now succeeds
- [ ] Deleting with a position filter correctly disambiguates among multiple labels with the same name

🤖 Generated with [Claude Code](https://claude.com/claude-code)