### PR TITLE
fix: resolve project-local sym-lib-table for schematics in sub-folders

### DIFF
--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -718,9 +718,17 @@ class KiCADInterface:
             x = component.get("x", 0)
             y = component.get("y", 0)
 
-            # Derive project path from schematic path for project-local library resolution
+            # Derive project path from schematic path for project-local library resolution.
+            # Walk up from the schematic file to find the directory that owns the project
+            # (contains sym-lib-table or a .kicad_pro file).  Schematics stored in a
+            # sub-folder (e.g. sheets/) would otherwise resolve to the wrong directory and
+            # miss any project-local sym-lib-table entries.
             schematic_file = Path(schematic_path)
             derived_project_path = schematic_file.parent
+            for ancestor in schematic_file.parents:
+                if (ancestor / "sym-lib-table").exists() or list(ancestor.glob("*.kicad_pro")):
+                    derived_project_path = ancestor
+                    break
 
             loader = DynamicSymbolLoader(project_path=derived_project_path)
             loader.add_component(


### PR DESCRIPTION
## Summary

- `_handle_add_schematic_component` derived the project path as `Path(schematicPath).parent`
- In a hierarchical project, sub-sheet schematics live in a sub-folder (e.g. `sheets/`), so `.parent` resolves to that sub-folder — not the project root
- `DynamicSymbolLoader` searches the project root for `sym-lib-table` to find project-local libraries (declared with `${KIPRJMOD}`)
- With the wrong project path, any project-local library is invisible, producing: _"Symbol 'X' not found in library 'Y'"_ even when the library file and `sym-lib-table` entry both exist

## Fix

Walk the ancestor chain from the schematic file upward until a directory is found containing either `sym-lib-table` or a `*.kicad_pro` file, then use that as the project root. Falls back to `schematic.parent` if nothing is found (preserves existing behaviour for top-level schematics).

## Test plan

- [x] Place a component from a standard library (e.g. `Device:R`) in a top-level schematic → still works
- [x] Place a component from a project-local library in a top-level schematic → still works  
- [x] Place a component from a project-local library in a **sub-folder schematic** → previously failed with "not found", now resolves via `sym-lib-table`

🤖 Generated with [Claude Code](https://claude.com/claude-code)