### PR TITLE
fix(windows): support KiCad 10.0 pcbnew path (bin/Lib/site-packages)

### DIFF
--- a/python/utils/platform_helper.py
+++ b/python/utils/platform_helper.py
@@ -59,7 +59,12 @@ class PlatformHelper:
             ]
             for pf in program_files:
                 # Check multiple KiCAD versions
-                for version in ["9.0", "9.1", "10.0", "8.0"]:
+                for version in ["10.0", "9.0", "9.1", "8.0"]:
+                    # KiCad 10.0+ Windows: bin/Lib/site-packages
+                    path = pf / version / "bin" / "Lib" / "site-packages"
+                    if path.exists():
+                        paths.append(path)
+                    # KiCad 9.x Windows: lib/python3/dist-packages
                     path = pf / version / "lib" / "python3" / "dist-packages"
                     if path.exists():
                         paths.append(path)


### PR DESCRIPTION
## Summary

- Add `bin/Lib/site-packages` path detection for KiCad 10.0 on Windows
- Prioritise version 10.0 in the search order so the newer layout is found first
- Both the old `lib/python3/dist-packages` (KiCad 9.x) and the new `bin/Lib/site-packages` (KiCad 10.0) layouts are now supported side-by-side

## Problem

KiCad 10.0 on Windows moved `pcbnew.py` from  
`C:\Program Files\KiCad.0\lib\python3\dist-packages`  
to  
`C:\Program Files\KiCad.0in\Lib\site-packages`

Without this path the MCP Python subprocess fails to find the pcbnew module and exits immediately, causing every tool call to return `Python process for KiCAD scripting is not running`.

## Test plan

- [ ] Install KiCad 10.0 on Windows; confirm `bin/Lib/site-packages` is detected
- [ ] Confirm KiCad 9.x path still works (`lib/python3/dist-packages` still checked)
- [ ] Set `KICAD_PYTHON=C:\Program Files\KiCad.0in\python.exe` in env and verify pcbnew imports correctly (the bundled Python 3.11 is required — system Python 3.13 causes a DLL version conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
