### PR TITLE
chore(jlcpcb): bump cache parts range to include cache.z20

### DIFF
--- a/download_jlcpcb.py
+++ b/download_jlcpcb.py
@@ -25,7 +25,7 @@ CACHE_DIR = DATA_DIR / "jlcparts_cache"
 CACHE_DIR.mkdir(exist_ok=True)
 
 BASE_URL = "https://yaqwsx.github.io/jlcparts/data"
-PARTS = [f"cache.z{i:02d}" for i in range(1, 20)] + ["cache.zip"]
+PARTS = [f"cache.z{i:02d}" for i in range(1, 21)] + ["cache.zip"]
 
 TARGET_DB = DATA_DIR / "jlcpcb_parts.db"
 


### PR DESCRIPTION
yaqwsx/jlcparts has added cache.z20 to its pre-built cache; the old range(1, 20) stops at cache.z19 and the extracted archive ends up truncated. Extend to range(1, 21).