### PR TITLE
fix: prevent import-time crash when ~/.kicad-mcp/ is not writable

### DIFF
--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -15,24 +15,32 @@ import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from annotations import AnnotationLoader
 from resources.resource_definitions import RESOURCE_DEFINITIONS, handle_resource_read
 
 # Import tool schemas, resource definitions, and IPC API annotations
 from schemas.tool_schemas import TOOL_SCHEMAS
-from annotations import AnnotationLoader
 
 _annotation_loader = AnnotationLoader()
 
 # Configure logging
-log_dir = os.path.join(os.path.expanduser("~"), ".kicad-mcp", "logs")
-os.makedirs(log_dir, exist_ok=True)
-log_file = os.path.join(log_dir, "kicad_interface.log")
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[logging.FileHandler(log_file)],
-)
+# Try to set up a file handler in ~/.kicad-mcp/logs. If that directory isn't
+# writable (e.g. sandboxed test environments, restricted CI runners), fall
+# back to console-only logging so importing this module never crashes.
+try:
+    log_dir = os.path.join(os.path.expanduser("~"), ".kicad-mcp", "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    log_file = os.path.join(log_dir, "kicad_interface.log")
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[logging.FileHandler(log_file)],
+    )
+except (OSError, PermissionError):
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
 logger = logging.getLogger("kicad_interface")
 
 # Log Python environment details


### PR DESCRIPTION
## Summary

Fixes an import-time crash in `python/kicad_interface.py` that triggers whenever `~/.kicad-mcp/logs/` cannot be created (sandboxed pytest runners, restricted CI containers, read-only filesystems, hardened sysadmin policies). The unhandled `OSError`/`PermissionError` aborted module import and cascaded into ~100 test failures during pytest collection — making local test runs unusable in any environment that locks down `$HOME`.

## What changed

`python/kicad_interface.py` lines 26–44 — the file `logging.basicConfig` setup is now wrapped in `try`/`except (OSError, PermissionError)` with a console-only fallback:

```python
try:
    log_dir = os.path.join(os.path.expanduser("~"), ".kicad-mcp", "logs")
    os.makedirs(log_dir, exist_ok=True)
    log_file = os.path.join(log_dir, "kicad_interface.log")
    logging.basicConfig(
        level=logging.DEBUG,
        format="%(asctime)s [%(levelname)s] %(message)s",
        handlers=[logging.FileHandler(log_file)],
    )
except (OSError, PermissionError):
    logging.basicConfig(
        level=logging.DEBUG,
        format="%(asctime)s [%(levelname)s] %(message)s",
    )
logger = logging.getLogger("kicad_interface")
```

The diff also includes one isort-driven import reorder applied automatically by the project's pre-commit hook.

## Why this approach (cheap fix vs. lazy `__main__` fix)

Two viable options were considered:

1. **Cheap fix** (this PR): wrap the directory/handler creation in `try/except` and fall back to console logging.
2. **Lazy fix:** move logging setup into `if __name__ == "__main__":`.

Option 2 looks cleaner but is much more invasive — there are ~50 module-level `logger.info(...)` calls (lines 39–42, 46–81, 93–134, etc.) that all run on import and would either need relocating or would silently use Python's default logger config. Option 1 is a 4-line, behavior-preserving change:

- File logging at `~/.kicad-mcp/logs/kicad_interface.log` is still used whenever the directory is writable (production / dev — unchanged).
- Console logging is used when the directory cannot be created (sandbox / CI).
- Catching `OSError` covers `PermissionError`, `FileNotFoundError`, `ReadOnlyFileSystemError`, and other rarer filesystem exceptions.

## Verification

- Pre-commit hooks all green (trailing-whitespace, end-of-file-fixer, mixed-line-ending, check-added-large-files, check-merge-conflict, black, isort, flake8, mypy).
- Reproduced the original crash and confirmed it's fixed:

  ```bash
  HOME=/nonexistent_readonly_path python3 -c "
  import sys; sys.path.insert(0, 'python')
  import logging; logging.disable(logging.CRITICAL)
  import kicad_interface
  print('IMPORT_OK')
  "
  ```

  Before: `PermissionError` raised at `os.makedirs(...)` during import, module never loads.
  After: import proceeds, falls back to console logging, no crash.

- Confirmed via `rg "FileHandler\("` that this is the only import-time `FileHandler` site in `python/`, so no other modules need the same fix.

## Test plan

- [x] CI passes on the existing test matrix.
- [x] Verify pytest collection no longer crashes in sandboxed/CI environments where `$HOME` is read-only.
- [x] Manually confirm in a normal dev environment that `~/.kicad-mcp/logs/kicad_interface.log` is still written to.

## Notes for reviewer

- Single-file change; no API/behavior changes for users with a writable `$HOME`.
- Marked **draft** while I (`@vdawger`) self-review before requesting review.
