### PR TITLE
Treat PWR_FLAG anchors as connected in orphan-wire detection

### DIFF
--- a/python/commands/board/layers.py
+++ b/python/commands/board/layers.py
@@ -64,7 +64,7 @@ class BoardLayerCommands:
             # Enable inner copper layers by increasing copper layer count (KiCAD 9.0 API)
             if position == "inner":
                 current_count = self.board.GetCopperLayerCount()
-                needed_count = 2 + number  # F.Cu + B.Cu + inner layers
+                needed_count = 2 + (number or 0)  # F.Cu + B.Cu + inner layers
                 if needed_count > current_count:
                     self.board.SetCopperLayerCount(needed_count)
 

--- a/python/commands/wire_connectivity.py
+++ b/python/commands/wire_connectivity.py
@@ -236,7 +236,7 @@ def _parse_virtual_connections(
                 if not hasattr(symbol, "property") or not hasattr(symbol.property, "Reference"):
                     continue
                 ref = symbol.property.Reference.value
-                if not ref.startswith("#PWR"):
+                if not (ref.startswith("#PWR") or ref.startswith("#FLG")):
                     continue
                 if ref.startswith("_TEMPLATE"):
                     continue


### PR DESCRIPTION
PWR_FLAG instances use a #FLG reference prefix, not #PWR, so their pin positions were never registered as virtual connection anchors in _parse_virtual_connections. As a result, find_orphaned_wires reported wire ends terminating on a PWR_FLAG as dangling. Other call sites (schematic_analysis.py:127, kicad_interface.py:3814) already recognize #FLG as a power symbol; align this site with them.

Also coerce a previously-validated Optional[int] to int in board/layers.py so the file passes mypy (required by the pre-commit hook); behavior is unchanged because the value is already None-checked above.