### PR TITLE
fix: escape newlines in WireManager.add_text

### DIFF
--- a/python/commands/wire_manager.py
+++ b/python/commands/wire_manager.py
@@ -1045,7 +1045,15 @@ class WireManager:
     ) -> bool:
         """Add a free-form text annotation (SCH_TEXT) to a KiCad schematic."""
         try:
-            text_escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+            # KiCad's parser rejects raw newlines inside quoted string literals,
+            # so escape them along with backslashes and quotes. Order matters:
+            # backslashes first, otherwise we double-escape our own escapes.
+            text_escaped = (
+                text.replace("\\", "\\\\")
+                .replace('"', '\\"')
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+            )
             uid = str(uuid.uuid4())
             font_attrs = f"\n\t\t\t\t(size {font_size} {font_size})"
             if bold:

--- a/tests/test_add_schematic_text.py
+++ b/tests/test_add_schematic_text.py
@@ -136,6 +136,39 @@ class TestWireManagerAddText:
         content = sch.read_text(encoding="utf-8")
         assert r"He said \"hello\"" in content
 
+    def test_escapes_newlines_in_multiline_text(self, tmp_path):
+        """Raw newlines in quoted string literals break kicad-cli's parser
+        (silently in eeschema, but kicad-cli sch reports 'Failed to load
+        schematic'). They must be escaped to the two-character \\n sequence."""
+        from commands.wire_manager import WireManager
+
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text(_MINIMAL_SCH, encoding="utf-8")
+
+        WireManager.add_text(sch, "line one\nline two\r\nline three", [10.0, 10.0])
+
+        content = sch.read_text(encoding="utf-8")
+        # The text S-expression's quoted argument must not contain a literal
+        # newline. Find the (text "...") and check its first quoted arg.
+        text_start = content.index('(text "') + len('(text "')
+        # Find matching close-quote, respecting backslash escapes.
+        i = text_start
+        while i < len(content):
+            if content[i] == "\\":
+                i += 2
+                continue
+            if content[i] == '"':
+                break
+            i += 1
+        quoted = content[text_start:i]
+        assert (
+            "\n" not in quoted and "\r" not in quoted
+        ), f"Quoted text still contains a raw newline: {quoted!r}"
+        assert "\\n" in quoted, "Newline should be escaped to \\n"
+
+        # And the file must round-trip through the s-expression parser cleanly.
+        sexpdata.loads(content)
+
     def test_result_is_valid_sexp(self, tmp_path):
         from commands.wire_manager import WireManager
 


### PR DESCRIPTION
## Summary

`WireManager.add_text` only escaped `\\` and `"` before writing the user's text into a quoted KiCad string literal. If the text contained a newline (which is a perfectly reasonable thing for a multi-line annotation block), the literal newline ended up *inside* the quoted string in the `.kicad_sch` file:

```
(text "Aerospace PDB
Stackup notes:
  L1: power
  L2: GND" ...)
```

eeschema *silently tolerates* this when loading the file in the GUI — but the kicad-cli s-expression parser refuses it: `Failed to load schematic`. So any project written with multi-line annotations through the MCP couldn't be processed by `kicad-cli sch erc`, `kicad-cli sch export`, or any downstream automation.

## Fix

Add `\n` and `\r` to the same escape chain as `\\` and `"`. Order matters: backslashes first, otherwise the newly-introduced `\\n` gets mangled into `\\\\n`.

```python
text_escaped = (
    text.replace("\\", "\\\\")
    .replace('"', '\\"')
    .replace("\n", "\\n")
    .replace("\r", "\\r")
)
```

## Tests

New regression test `test_escapes_newlines_in_multiline_text`:

- Writes `"line one\nline two\r\nline three"` through `add_text`
- Confirms the resulting quoted-string literal in the file contains **no raw `\n` or `\r`**
- Confirms the file round-trips cleanly through `sexpdata.loads(...)`

End-to-end smoke (run outside this PR): a 4-line annotation written through the patched `add_text` is now accepted by `kicad-cli sch erc` (exit 0), where the previous behaviour failed parse.

## Note on related-but-not-fixed gaps

`_make_hierarchical_label_text` and `_make_sheet_pin_text` in the same module embed `text` / `pin_name` *without any escaping* — so they have the same gap for unescaped quotes/newlines/backslashes. Out of scope for this PR (which is targeting the documented `add_text` bug), but happy to fold into this PR or follow up with a separate one if you'd prefer the bigger sweep.

## Test plan

- [x] `pytest tests/test_add_schematic_text.py` — 31/31 pass including the new `test_escapes_newlines_in_multiline_text`
- [x] Manual: write a 4-line annotation, run `kicad-cli sch erc` — exit 0 (was: "Failed to load schematic")

This is the third of three PRs from a real-world session — see also #144 (netclass routing) and #145 (schematic pin Y-flip).