### PR TITLE
Fix KiCad 10 standard symbol library discovery on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **KiCad 10 standard symbol libraries are now discoverable**: `search_symbols`,
+  `list_symbol_libraries`, and `add_schematic_component` previously returned no
+  results for stdlib symbols (`Device:R`, `RF_Module:ESP32-WROOM-DA`,
+  `Connector_Generic:*`, etc.) on KiCad 10 installations. Two underlying
+  causes:
+  1. `_find_kicad_symbol_dir` (in `library_symbol.py` and
+     `dynamic_symbol_loader.py`) hard-coded only KiCad 8.0 / 9.0 install
+     paths, so `${KICAD10_SYMBOL_DIR}` and the matching `KICAD10_SYMBOL_DIR`
+     env var never resolved. Added `C:/Program Files/KiCad/10.0/share/kicad/symbols`
+     and `KICAD10_SYMBOL_DIR` env-var support.
+  2. The `sym-lib-table` regex used `[^")\s]+` for the URI capture, which
+     rejects any URI containing a space. KiCad's default global table on
+     Windows references the stdlib via
+     `(lib (name "KiCad") (type "Table") (uri "C:/Program Files/KiCad/10.0/share/kicad/template/sym-lib-table"))`
+     — the space in `Program Files` caused the Table reference to be
+     skipped silently, hiding the entire stdlib. Regex now matches either
+     a quoted value (allowing spaces) or a bare token.
+
 - **Schematic symbol lookup**: `get_schematic_component`,
   `edit_schematic_component`, `set_schematic_component_property`,
   `remove_schematic_component_property`, and `delete_schematic_component`

--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -36,6 +36,7 @@ class DynamicSymbolLoader:
     def find_kicad_symbol_libraries(self) -> List[Path]:
         """Find all KiCad symbol library directories"""
         possible_paths = [
+            Path("C:/Program Files/KiCad/10.0/share/kicad/symbols"),
             Path("/usr/share/kicad/symbols"),
             Path("/usr/local/share/kicad/symbols"),
             Path("C:/Program Files/KiCad/9.0/share/kicad/symbols"),
@@ -88,14 +89,18 @@ class DynamicSymbolLoader:
             with open(table_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
+            # name and uri may be "quoted" (allowing spaces, e.g. Windows
+            # "C:/Program Files/...") or bare. Capture both forms.
             lib_pattern = (
-                r'\(lib\s+\(name\s+"?([^"\)\s]+)"?\)\s*\(type\s+[^)]+\)\s*\(uri\s+"?([^"\)\s]+)"?'
+                r'\(lib\s+\(name\s+(?:"([^"]+)"|([^"\)\s]+))\)\s*'
+                r'\(type\s+[^)]+\)\s*'
+                r'\(uri\s+(?:"([^"]+)"|([^"\)\s]+))'
             )
             for match in re.finditer(lib_pattern, content, re.IGNORECASE):
-                nickname = match.group(1)
+                nickname = match.group(1) or match.group(2)
                 if nickname != library_name:
                     continue
-                uri = match.group(2)
+                uri = match.group(3) or match.group(4)
                 resolved = self._resolve_sym_uri(uri)
                 if resolved and Path(resolved).exists():
                     return Path(resolved)

--- a/python/commands/library_symbol.py
+++ b/python/commands/library_symbol.py
@@ -114,12 +114,18 @@ class SymbolLibraryManager:
 
             # Simple regex-based parser for lib entries
             # Pattern: (lib (name "NAME")(type TYPE)(uri "URI")...)
-            lib_pattern = r'\(lib\s+\(name\s+"?([^")\s]+)"?\)\s*\(type\s+"?([^")\s]+)"?\)\s*\(uri\s+"?([^")\s]+)"?'
+            # Each value can be either "quoted" (allowing spaces, e.g. "C:/Program Files/...")
+            # or bare (no whitespace). Capture both forms via alternation.
+            lib_pattern = (
+                r'\(lib\s+\(name\s+(?:"([^"]+)"|([^"\)\s]+))\)\s*'
+                r'\(type\s+(?:"([^"]+)"|([^"\)\s]+))\)\s*'
+                r'\(uri\s+(?:"([^"]+)"|([^"\)\s]+))'
+            )
 
             for match in re.finditer(lib_pattern, content, re.IGNORECASE):
-                nickname = match.group(1)
-                lib_type = match.group(2)
-                uri = match.group(3)
+                nickname = match.group(1) or match.group(2)
+                lib_type = match.group(3) or match.group(4)
+                uri = match.group(5) or match.group(6)
 
                 if lib_type.lower() == "table":
                     table_uri = uri
@@ -193,6 +199,7 @@ class SymbolLibraryManager:
     def _find_kicad_symbol_dir(self) -> Optional[str]:
         """Find KiCAD symbol directory"""
         possible_paths = [
+            "C:/Program Files/KiCad/10.0/share/kicad/symbols",
             "/usr/share/kicad/symbols",
             "/usr/local/share/kicad/symbols",
             "C:/Program Files/KiCad/9.0/share/kicad/symbols",
@@ -201,6 +208,8 @@ class SymbolLibraryManager:
         ]
 
         # Check environment variable
+        if "KICAD10_SYMBOL_DIR" in os.environ:
+            possible_paths.insert(0, os.environ["KICAD10_SYMBOL_DIR"])
         if "KICAD9_SYMBOL_DIR" in os.environ:
             possible_paths.insert(0, os.environ["KICAD9_SYMBOL_DIR"])
         if "KICAD8_SYMBOL_DIR" in os.environ:


### PR DESCRIPTION
## Summary

On a fresh KiCad 10 / Windows install, `search_symbols`, `list_symbol_libraries`, and `add_schematic_component` returned no results for any stdlib symbol (`Device:R`, `RF_Module:ESP32-WROOM-DA`, `Connector_Generic:*`, etc.). Two independent root causes:

- **Hard-coded install paths.** `_find_kicad_symbol_dir` in `library_symbol.py` and `dynamic_symbol_loader.py` only knew about KiCad 8.0/9.0 paths and only consulted `KICAD8_SYMBOL_DIR` / `KICAD9_SYMBOL_DIR`. Added the KiCad 10.0 path and a `KICAD10_SYMBOL_DIR` env var.
- **`sym-lib-table` regex rejected URIs with spaces.** The capture used `[^")\s]+`, but KiCad's default global table on Windows references the stdlib via a quoted URI containing `Program Files`. The regex silently skipped that Table entry, hiding the entire stdlib. Regex now accepts either a quoted value (allowing spaces) or a bare token, applied to `name`, `type`, and `uri`.

## Test plan

- [ ] On Windows + KiCad 10, run `search_symbols` for `Device:R` and confirm a hit.
- [ ] On Windows + KiCad 10, run `list_symbol_libraries` and confirm stdlib libraries appear.
- [ ] On Windows + KiCad 9, confirm prior behavior is unchanged (regex still parses 9.0 tables; old env vars still honored).
- [ ] On Linux/macOS, confirm `/usr/share/kicad/symbols` discovery still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)