### PR TITLE
fix: resolve kicad_interface.py path using import.meta.url (Linux/macOS)

### DIFF
--- a/src/kicad-server.ts
+++ b/src/kicad-server.ts
@@ -24,8 +24,8 @@ class KiCADServer {
 
   constructor() {
     // Set absolute path to the Python KiCAD interface script
-    // Using a hardcoded path to avoid cwd() issues when running from Cline
-    this.kicadScriptPath = "c:/repo/KiCAD-MCP/python/kicad_interface.py";
+    this.kicadScriptPath = process.env.KICAD_SCRIPT_PATH ||
+      path.join(path.dirname(new URL(import.meta.url).pathname), "../python/kicad_interface.py");
 
     // Check if script exists
     if (!existsSync(this.kicadScriptPath)) {

--- a/src/kicad-server.ts
+++ b/src/kicad-server.ts
@@ -4,6 +4,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { spawn, ChildProcess } from "child_process";
 import { existsSync } from "fs";
+import { fileURLToPath } from "url";
 import path from "path";
 
 // Import all tool definitions for reference
@@ -25,7 +26,7 @@ class KiCADServer {
   constructor() {
     // Set absolute path to the Python KiCAD interface script
     this.kicadScriptPath = process.env.KICAD_SCRIPT_PATH ||
-      path.join(path.dirname(new URL(import.meta.url).pathname), "../python/kicad_interface.py");
+      path.join(path.dirname(fileURLToPath(import.meta.url)), "../python/kicad_interface.py");
 
     // Check if script exists
     if (!existsSync(this.kicadScriptPath)) {


### PR DESCRIPTION
## Summary

- `kicadScriptPath` was hardcoded to `c:/repo/KiCAD-MCP/python/kicad_interface.py`, crashing on startup for Linux and macOS users (and any Windows user who didn't clone to exactly that path)
- Replace with `fileURLToPath(import.meta.url)`-based resolution so the path is always derived relative to the compiled `dist/kicad-server.js`, regardless of platform or working directory
- Adds `KICAD_SCRIPT_PATH` env var override for custom installs

## Root cause

```ts
// before — hardcoded Windows dev path, breaks everyone else
this.kicadScriptPath = "c:/repo/KiCAD-MCP/python/kicad_interface.py";

// after — resolves relative to dist/kicad-server.js, works on all platforms
this.kicadScriptPath = process.env.KICAD_SCRIPT_PATH ||
  path.join(path.dirname(fileURLToPath(import.meta.url)), "../python/kicad_interface.py");
```

`fileURLToPath` is used instead of `.pathname` because on Windows, `new URL(import.meta.url).pathname` returns `/C:/...` (with a leading slash), which breaks `path.join`. `fileURLToPath` handles the drive-letter stripping correctly, so **existing Windows users are unaffected** — they get the same resolved path they'd expect.

## Test plan

- [ ] Verified working on Ubuntu 24.04 with KiCad 9.0.8 — `open_project` returns `success: true` via SWIG backend
- [ ] `fileURLToPath` is Node.js built-in, no new dependencies
- [ ] `KICAD_PYTHON` + `LD_PRELOAD` env vars passed through `...process.env` spread (already in source) handle `libstdc++` version mismatch on systems with Conda/pyenv

— *comment posted by Claude*