### PR TITLE
feat(view): save 2D board view to file instead of base64

### DIFF
--- a/python/commands/board/view.py
+++ b/python/commands/board/view.py
@@ -124,36 +124,44 @@ class BoardViewCommands:
 
             plotter.ClosePlot()
 
+            # Determine output path next to the PCB file
+            board_dir = os.path.dirname(self.board.GetFileName())
+            board_name = os.path.splitext(os.path.basename(self.board.GetFileName()))[0]
+
             # Convert SVG to requested format
             if format == "svg":
-                with open(temp_svg, "r") as f:
-                    svg_data = f.read()
-                os.remove(temp_svg)
-                return {"success": True, "imageData": svg_data, "format": "svg"}
+                output_path = os.path.join(board_dir, f"{board_name}_2d_view.svg")
+                if os.path.exists(output_path):
+                    os.remove(output_path)
+                os.rename(temp_svg, output_path)
+                return {
+                    "success": True,
+                    "format": "svg",
+                    "filePath": output_path,
+                    "message": f"2D view saved to {output_path}",
+                }
             else:
-                # Use PIL to convert SVG to PNG/JPG
+                # Use cairosvg to convert SVG to PNG
                 from cairosvg import svg2png
 
                 png_data = svg2png(url=temp_svg, output_width=width, output_height=height)
                 os.remove(temp_svg)
 
                 if format == "jpg":
-                    # Convert PNG to JPG
+                    output_path = os.path.join(board_dir, f"{board_name}_2d_view.jpg")
                     img = Image.open(io.BytesIO(png_data))
-                    jpg_buffer = io.BytesIO()
-                    img.convert("RGB").save(jpg_buffer, format="JPEG")
-                    jpg_data = jpg_buffer.getvalue()
-                    return {
-                        "success": True,
-                        "imageData": base64.b64encode(jpg_data).decode("utf-8"),
-                        "format": "jpg",
-                    }
+                    img.convert("RGB").save(output_path, format="JPEG")
                 else:
-                    return {
-                        "success": True,
-                        "imageData": base64.b64encode(png_data).decode("utf-8"),
-                        "format": "png",
-                    }
+                    output_path = os.path.join(board_dir, f"{board_name}_2d_view.png")
+                    with open(output_path, "wb") as f:
+                        f.write(png_data)
+
+                return {
+                    "success": True,
+                    "format": format,
+                    "filePath": output_path,
+                    "message": f"2D view saved to {output_path}",
+                }
 
         except Exception as e:
             logger.error(f"Error getting board 2D view: {str(e)}")

--- a/python/commands/board/view.py
+++ b/python/commands/board/view.py
@@ -73,7 +73,12 @@ class BoardViewCommands:
             }
 
     def get_board_2d_view(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        """Get a 2D image of the PCB"""
+        """Get a 2D image of the PCB.
+
+        responseMode controls how the image is returned:
+        - "inline" (default): image bytes are base64-encoded and returned as ``imageData``.
+        - "file": image is written next to the .kicad_pcb file and ``filePath`` is returned.
+        """
         try:
             if not self.board:
                 return {
@@ -87,6 +92,7 @@ class BoardViewCommands:
             height = params.get("height", 600)
             format = params.get("format", "png")
             layers = params.get("layers", [])
+            response_mode = params.get("responseMode", "inline")
 
             # Create plot controller
             plotter = pcbnew.PLOT_CONTROLLER(self.board)
@@ -128,39 +134,43 @@ class BoardViewCommands:
             board_dir = os.path.dirname(self.board.GetFileName())
             board_name = os.path.splitext(os.path.basename(self.board.GetFileName()))[0]
 
-            # Convert SVG to requested format
+            # --- Render to bytes (shared for both response modes) ---
             if format == "svg":
-                output_path = os.path.join(board_dir, f"{board_name}_2d_view.svg")
-                if os.path.exists(output_path):
-                    os.remove(output_path)
-                os.rename(temp_svg, output_path)
+                with open(temp_svg, "rb") as f:
+                    image_bytes = f.read()
+                os.remove(temp_svg)
+                mime_format = "svg"
+            else:
+                from cairosvg import svg2png
+
+                image_bytes = svg2png(url=temp_svg, output_width=width, output_height=height)
+                os.remove(temp_svg)
+
+                if format == "jpg":
+                    img = Image.open(io.BytesIO(image_bytes))
+                    buf = io.BytesIO()
+                    img.convert("RGB").save(buf, format="JPEG")
+                    image_bytes = buf.getvalue()
+                mime_format = format
+
+            # --- Package response according to responseMode ---
+            if response_mode == "file":
+                output_path = os.path.join(board_dir, f"{board_name}_2d_view.{mime_format}")
+                with open(output_path, "wb") as f:
+                    f.write(image_bytes)
                 return {
                     "success": True,
-                    "format": "svg",
+                    "format": mime_format,
                     "filePath": output_path,
                     "message": f"2D view saved to {output_path}",
                 }
             else:
-                # Use cairosvg to convert SVG to PNG
-                from cairosvg import svg2png
-
-                png_data = svg2png(url=temp_svg, output_width=width, output_height=height)
-                os.remove(temp_svg)
-
-                if format == "jpg":
-                    output_path = os.path.join(board_dir, f"{board_name}_2d_view.jpg")
-                    img = Image.open(io.BytesIO(png_data))
-                    img.convert("RGB").save(output_path, format="JPEG")
-                else:
-                    output_path = os.path.join(board_dir, f"{board_name}_2d_view.png")
-                    with open(output_path, "wb") as f:
-                        f.write(png_data)
-
+                # inline mode: base64-encode and return imageData
+                image_b64 = base64.b64encode(image_bytes).decode("utf-8")
                 return {
                     "success": True,
-                    "format": format,
-                    "filePath": output_path,
-                    "message": f"2D view saved to {output_path}",
+                    "format": mime_format,
+                    "imageData": image_b64,
                 }
 
         except Exception as e:

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -228,7 +228,16 @@ BOARD_TOOLS = [
     {
         "name": "get_board_2d_view",
         "title": "Render Board Preview",
-        "description": "Generates a 2D visual representation of the current board state as a PNG image.",
+        "description": (
+            "Generates a 2D visual representation of the current board state as a PNG, JPG, or SVG image. "
+            "Use responseMode to control how the image is returned. "
+            'responseMode="inline" (default) returns the image bytes as a base64-encoded imageData '
+            "string in the JSON response — convenient for small boards but may exceed message-size limits on "
+            "large designs. "
+            'responseMode="file" writes the image next to the .kicad_pcb file as '
+            "<board>_2d_view.<ext> and returns a filePath; callers that can open local files should "
+            "prefer this mode for large boards."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -243,6 +252,27 @@ BOARD_TOOLS = [
                     "description": "Image height in pixels (default: 600)",
                     "minimum": 100,
                     "default": 600,
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["png", "jpg", "svg"],
+                    "description": "Output image format (default: png)",
+                    "default": "png",
+                },
+                "layers": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional list of layer names to include; all enabled layers if omitted",
+                },
+                "responseMode": {
+                    "type": "string",
+                    "enum": ["inline", "file"],
+                    "default": "inline",
+                    "description": (
+                        "How to return the image. "
+                        '"inline" (default): base64-encoded bytes in the imageData response field. '
+                        '"file": write to <board>_2d_view.<ext> next to the PCB and return filePath.'
+                    ),
                 },
             },
         },

--- a/src/tools/board.ts
+++ b/src/tools/board.ts
@@ -362,20 +362,33 @@ export function registerBoardTools(server: McpServer, callKicadScript: CommandFu
   // ------------------------------------------------------
   server.tool(
     "get_board_2d_view",
-    "Render a 2D image of the current PCB board and return it as PNG, JPG or SVG.",
+    [
+      "Render a 2D image of the current PCB board and return it as PNG, JPG or SVG.",
+      "Use responseMode to choose how the image is delivered:",
+      '  "inline" (default) — base64-encoded bytes returned in imageData; works well for small boards.',
+      '  "file" — image written next to the .kicad_pcb as <board>_2d_view.<ext>; filePath is returned.',
+      "Use file mode for large boards to avoid hitting MCP message-size limits.",
+    ].join(" "),
     {
       layers: z.array(z.string()).optional().describe("Optional array of layer names to include"),
       width: z.number().optional().describe("Optional width of the image in pixels"),
       height: z.number().optional().describe("Optional height of the image in pixels"),
       format: z.enum(["png", "jpg", "svg"]).optional().describe("Image format"),
+      responseMode: z
+        .enum(["inline", "file"])
+        .optional()
+        .describe(
+          'How to return the image: "inline" (default) returns base64 imageData; "file" writes to disk and returns filePath',
+        ),
     },
-    async ({ layers, width, height, format }) => {
+    async ({ layers, width, height, format, responseMode }) => {
       logger.debug("Getting 2D board view");
       const result = await callKicadScript("get_board_2d_view", {
         layers,
         width,
         height,
         format,
+        responseMode,
       });
 
       return {

--- a/tests/test_get_board_2d_view_save_to_file.py
+++ b/tests/test_get_board_2d_view_save_to_file.py
@@ -1,0 +1,83 @@
+"""Test that ``get_board_2d_view`` writes the rendered image to a file
+next to the PCB instead of returning base64-encoded data inline.
+
+The original implementation returned the rendered PNG/JPG/SVG inside the
+JSON response as ``imageData`` (base64), which routinely exceeded MCP
+message-size limits on real boards. The change writes
+``<board_name>_2d_view.<ext>`` next to the ``.kicad_pcb`` and returns a
+``filePath`` pointing at it.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+
+def _make_view_cmd(tmp_path: Path):
+    """Build a BoardViewCommands instance with a fake board."""
+    from commands.board.view import BoardViewCommands
+
+    board_path = tmp_path / "MyBoard.kicad_pcb"
+    board_path.write_text("(kicad_pcb)")
+
+    fake_board = MagicMock()
+    fake_board.GetFileName.return_value = str(board_path)
+    return BoardViewCommands(board=fake_board), tmp_path
+
+
+def _patched_plotter(temp_svg: Path):
+    """Return a context manager that patches PLOT_CONTROLLER to write the
+    given temp SVG when ClosePlot is called.
+    """
+    plotter = MagicMock()
+    plotter.GetPlotFileName.return_value = str(temp_svg)
+    plotter.OpenPlotfile.return_value = True
+    plot_options = MagicMock()
+    plotter.GetPlotOptions.return_value = plot_options
+    return patch("commands.board.view.pcbnew.PLOT_CONTROLLER", return_value=plotter)
+
+
+def test_svg_format_writes_file_next_to_pcb(tmp_path):
+    cmd, root = _make_view_cmd(tmp_path)
+    temp_svg = root / "scratch.svg"
+    temp_svg.write_text("<svg/>")
+
+    with _patched_plotter(temp_svg):
+        result = cmd.get_board_2d_view({"format": "svg"})
+
+    assert result["success"] is True
+    assert result["format"] == "svg"
+    expected = root / "MyBoard_2d_view.svg"
+    assert Path(result["filePath"]).resolve() == expected.resolve()
+    assert expected.exists()
+    # Old contract removed
+    assert "imageData" not in result
+
+
+def test_png_format_writes_file_next_to_pcb(tmp_path):
+    cmd, root = _make_view_cmd(tmp_path)
+    temp_svg = root / "scratch.svg"
+    temp_svg.write_text("<svg/>")
+
+    fake_png_bytes = b"\x89PNG\r\n\x1a\n" + b"fakeimagebytes"
+
+    with (
+        _patched_plotter(temp_svg),
+        patch("cairosvg.svg2png", return_value=fake_png_bytes, create=True),
+    ):
+        # cairosvg is imported lazily inside the function, install a stub if missing
+        if "cairosvg" not in sys.modules:
+            sys.modules["cairosvg"] = MagicMock(svg2png=lambda **kwargs: fake_png_bytes)
+        result = cmd.get_board_2d_view({"format": "png", "width": 1000, "height": 800})
+
+    assert result["success"] is True
+    assert result["format"] == "png"
+    expected = root / "MyBoard_2d_view.png"
+    assert Path(result["filePath"]).resolve() == expected.resolve()
+    assert expected.exists()
+    assert expected.read_bytes() == fake_png_bytes
+    assert "imageData" not in result

--- a/tests/test_get_board_2d_view_save_to_file.py
+++ b/tests/test_get_board_2d_view_save_to_file.py
@@ -1,13 +1,14 @@
-"""Test that ``get_board_2d_view`` writes the rendered image to a file
-next to the PCB instead of returning base64-encoded data inline.
+"""Tests for ``get_board_2d_view`` responseMode parameter.
 
-The original implementation returned the rendered PNG/JPG/SVG inside the
-JSON response as ``imageData`` (base64), which routinely exceeded MCP
-message-size limits on real boards. The change writes
-``<board_name>_2d_view.<ext>`` next to the ``.kicad_pcb`` and returns a
-``filePath`` pointing at it.
+Two modes are supported:
+- ``responseMode="inline"`` (default): image bytes are base64-encoded and returned in the
+  ``imageData`` field of the response.  No file is written to disk.
+- ``responseMode="file"``: image is written next to the ``.kicad_pcb`` file as
+  ``<board_name>_2d_view.<ext>`` and ``filePath`` is returned.  No ``imageData`` field is
+  present.
 """
 
+import base64
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -15,6 +16,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
 
 
 def _make_view_cmd(tmp_path: Path):
@@ -30,54 +36,134 @@ def _make_view_cmd(tmp_path: Path):
 
 
 def _patched_plotter(temp_svg: Path):
-    """Return a context manager that patches PLOT_CONTROLLER to write the
-    given temp SVG when ClosePlot is called.
-    """
+    """Context manager that stubs PLOT_CONTROLLER to return the given temp SVG path."""
     plotter = MagicMock()
     plotter.GetPlotFileName.return_value = str(temp_svg)
     plotter.OpenPlotfile.return_value = True
-    plot_options = MagicMock()
-    plotter.GetPlotOptions.return_value = plot_options
+    plotter.GetPlotOptions.return_value = MagicMock()
     return patch("commands.board.view.pcbnew.PLOT_CONTROLLER", return_value=plotter)
 
 
-def test_svg_format_writes_file_next_to_pcb(tmp_path):
+_FAKE_SVG = b"<svg><rect/></svg>"
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"fakepngbytes"
+
+
+def _install_cairosvg_stub(png_bytes: bytes) -> None:
+    """Inject a cairosvg stub into sys.modules if the real library is absent."""
+    if "cairosvg" not in sys.modules:
+        stub = MagicMock()
+        stub.svg2png.return_value = png_bytes
+        sys.modules["cairosvg"] = stub
+
+
+# ---------------------------------------------------------------------------
+# inline mode tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_inline_png_returns_base64_image_data(tmp_path):
+    """responseMode='inline' with format='png' returns valid base64 in imageData."""
     cmd, root = _make_view_cmd(tmp_path)
     temp_svg = root / "scratch.svg"
-    temp_svg.write_text("<svg/>")
+    temp_svg.write_bytes(_FAKE_SVG)
+    _install_cairosvg_stub(_FAKE_PNG)
+
+    with (
+        _patched_plotter(temp_svg),
+        patch("cairosvg.svg2png", return_value=_FAKE_PNG, create=True),
+    ):
+        result = cmd.get_board_2d_view({"format": "png", "responseMode": "inline"})
+
+    assert result["success"] is True
+    assert result["format"] == "png"
+    assert "imageData" in result
+    decoded = base64.b64decode(result["imageData"])
+    assert decoded == _FAKE_PNG
+    # No file should have been written for inline mode
+    assert not (root / "MyBoard_2d_view.png").exists()
+    assert "filePath" not in result
+
+
+@pytest.mark.unit
+def test_inline_svg_returns_base64_image_data(tmp_path):
+    """responseMode='inline' with format='svg' returns valid base64 in imageData."""
+    cmd, root = _make_view_cmd(tmp_path)
+    temp_svg = root / "scratch.svg"
+    temp_svg.write_bytes(_FAKE_SVG)
 
     with _patched_plotter(temp_svg):
-        result = cmd.get_board_2d_view({"format": "svg"})
+        result = cmd.get_board_2d_view({"format": "svg", "responseMode": "inline"})
+
+    assert result["success"] is True
+    assert result["format"] == "svg"
+    assert "imageData" in result
+    decoded = base64.b64decode(result["imageData"])
+    assert decoded == _FAKE_SVG
+    assert "filePath" not in result
+
+
+@pytest.mark.unit
+def test_default_response_mode_is_inline(tmp_path):
+    """Omitting responseMode defaults to inline behavior (imageData, no filePath)."""
+    cmd, root = _make_view_cmd(tmp_path)
+    temp_svg = root / "scratch.svg"
+    temp_svg.write_bytes(_FAKE_SVG)
+    _install_cairosvg_stub(_FAKE_PNG)
+
+    with (
+        _patched_plotter(temp_svg),
+        patch("cairosvg.svg2png", return_value=_FAKE_PNG, create=True),
+    ):
+        result = cmd.get_board_2d_view({"format": "png"})
+
+    assert result["success"] is True
+    assert "imageData" in result
+    assert "filePath" not in result
+
+
+# ---------------------------------------------------------------------------
+# file mode tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_file_mode_svg_writes_file_and_returns_path(tmp_path):
+    """responseMode='file' with format='svg' writes the file and returns filePath."""
+    cmd, root = _make_view_cmd(tmp_path)
+    temp_svg = root / "scratch.svg"
+    temp_svg.write_bytes(_FAKE_SVG)
+
+    with _patched_plotter(temp_svg):
+        result = cmd.get_board_2d_view({"format": "svg", "responseMode": "file"})
 
     assert result["success"] is True
     assert result["format"] == "svg"
     expected = root / "MyBoard_2d_view.svg"
     assert Path(result["filePath"]).resolve() == expected.resolve()
     assert expected.exists()
-    # Old contract removed
+    assert expected.read_bytes() == _FAKE_SVG
     assert "imageData" not in result
 
 
-def test_png_format_writes_file_next_to_pcb(tmp_path):
+@pytest.mark.unit
+def test_file_mode_png_writes_file_and_returns_path(tmp_path):
+    """responseMode='file' with format='png' writes the PNG and returns filePath."""
     cmd, root = _make_view_cmd(tmp_path)
     temp_svg = root / "scratch.svg"
-    temp_svg.write_text("<svg/>")
-
-    fake_png_bytes = b"\x89PNG\r\n\x1a\n" + b"fakeimagebytes"
+    temp_svg.write_bytes(_FAKE_SVG)
+    _install_cairosvg_stub(_FAKE_PNG)
 
     with (
         _patched_plotter(temp_svg),
-        patch("cairosvg.svg2png", return_value=fake_png_bytes, create=True),
+        patch("cairosvg.svg2png", return_value=_FAKE_PNG, create=True),
     ):
-        # cairosvg is imported lazily inside the function, install a stub if missing
-        if "cairosvg" not in sys.modules:
-            sys.modules["cairosvg"] = MagicMock(svg2png=lambda **kwargs: fake_png_bytes)
-        result = cmd.get_board_2d_view({"format": "png", "width": 1000, "height": 800})
+        result = cmd.get_board_2d_view({"format": "png", "responseMode": "file"})
 
     assert result["success"] is True
     assert result["format"] == "png"
     expected = root / "MyBoard_2d_view.png"
     assert Path(result["filePath"]).resolve() == expected.resolve()
     assert expected.exists()
-    assert expected.read_bytes() == fake_png_bytes
+    assert expected.read_bytes() == _FAKE_PNG
     assert "imageData" not in result


### PR DESCRIPTION
`get_board_2d_view` returns the rendered image as base64 in JSON, which
often blows past tool/message size limits on larger boards.

Save the rendered image (PNG/JPG/SVG) next to the `.kicad_pcb` file as
`<board>_2d_view.<ext>` and return the file path. Image-aware tools can
then open the file directly.

This is a response-shape change: callers receive `filePath` instead of
`imageData`. Happy to gate behind an opt-in flag if maintaining the
base64 path is preferred.

## Test plan
- Manual: `get_board_2d_view` with `format="png"` writes
  `<board>_2d_view.png` next to the PCB and returns its path.
- Same for `format="svg"` and `format="jpg"`.
