### PR TITLE
fix(auto-save-guard): refuse only on content divergence, not mtime

### DIFF
--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -7,11 +7,14 @@ and KiCAD's Python API (pcbnew). It receives commands via stdin as
 JSON and returns responses via stdout also as JSON.
 """
 
+import hashlib
 import json
 import logging
 import os
+import shutil
 import sys
 import traceback
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -259,6 +262,12 @@ class KiCADInterface:
         """Initialize the interface and command handlers"""
         self.board = None
         self.project_filename = None
+        # On-disk signature (mtime_ns, sha256_hex) of self.board's file as of
+        # last load or successful auto-save.  Used by _auto_save_board() to
+        # detect external modifications and refuse to clobber them.
+        self._board_disk_signature: Optional[Tuple[int, str]] = None
+        # Number of timestamped backups to keep in .mcp-backups/ per board file.
+        self._auto_save_backup_keep = 20
         self.use_ipc = USE_IPC_BACKEND
         self.ipc_backend = ipc_backend
         self.ipc_board_api = None
@@ -539,11 +548,22 @@ class KiCADInterface:
                         # Get board from the project commands handler
                         self.board = self.project_commands.board
                         self._update_command_handlers()
+                        # Record the file's signature so subsequent auto-saves
+                        # can detect external modifications and refuse to
+                        # overwrite them.
+                        self._record_board_signature()
                     elif command in self._BOARD_MUTATING_COMMANDS:
                         # Auto-save after every board mutation via SWIG.
                         # Prevents data loss if Claude hits context limit before
-                        # an explicit save_project call.
-                        self._auto_save_board()
+                        # an explicit save_project call.  When auto-save refuses
+                        # because the on-disk file changed externally, surface
+                        # a warning to the caller so they don't believe their
+                        # mutation was persisted.
+                        save_status = self._auto_save_board()
+                        if isinstance(result, dict) and not save_status.get("saved"):
+                            if save_status.get("warning"):
+                                result.setdefault("warnings", []).append(save_status["warning"])
+                            result["autoSave"] = save_status
 
                 return result
             else:
@@ -587,19 +607,133 @@ class KiCADInterface:
         "connect_to_net",
     }
 
-    def _auto_save_board(self) -> None:
-        """Save board to disk after SWIG mutations.
-        Called automatically after every board-mutating SWIG command so that
-        data is not lost if Claude hits the context limit before save_project.
-        """
+    @staticmethod
+    def _disk_signature(path: str) -> Optional[Tuple[int, str]]:
+        """Return (mtime_ns, sha256_hex) for the file, or None if missing/unreadable."""
         try:
-            if self.board:
-                board_path = self.board.GetFileName()
-                if board_path:
-                    pcbnew.SaveBoard(board_path, self.board)
-                    logger.debug(f"Auto-saved board to: {board_path}")
+            st = os.stat(path)
+            h = hashlib.sha256()
+            with open(path, "rb") as f:
+                for chunk in iter(lambda: f.read(65536), b""):
+                    h.update(chunk)
+            return (st.st_mtime_ns, h.hexdigest())
+        except OSError:
+            return None
+
+    def _record_board_signature(self) -> None:
+        """Record the current on-disk signature of self.board's file.
+
+        Call this after a fresh load (open_project / create_project) or after
+        any save we perform ourselves, so that _auto_save_board() can detect
+        when an external actor has modified the file in between.
+        """
+        if not self.board:
+            self._board_disk_signature = None
+            return
+        try:
+            path = self.board.GetFileName()
+        except Exception:
+            path = None
+        self._board_disk_signature = self._disk_signature(path) if path else None
+
+    def _prune_auto_save_backups(self, backup_dir: str, base_name: str) -> None:
+        """Keep only the most recent `_auto_save_backup_keep` backups for `base_name`."""
+        try:
+            entries = [
+                os.path.join(backup_dir, f)
+                for f in os.listdir(backup_dir)
+                if f.startswith(base_name + ".")
+            ]
+            entries.sort(key=os.path.getmtime, reverse=True)
+            for old in entries[self._auto_save_backup_keep :]:
+                try:
+                    os.remove(old)
+                except OSError:
+                    pass
+        except OSError as e:
+            logger.debug(f"Backup pruning skipped: {e}")
+
+    def _auto_save_board(self) -> Dict[str, Any]:
+        """Save the in-memory board to disk after a SWIG-path mutation.
+
+        Behaviour:
+          * If the file's on-disk signature has diverged from the one we
+            recorded at load (or at our last successful save), refuse to
+            overwrite — an external actor (KiCad GUI, another process, git)
+            has touched the file and saving would clobber their changes.
+          * Otherwise, copy the existing file to ``<dir>/.mcp-backups/<name>.<ts>``
+            (rotating, keeps the most recent `_auto_save_backup_keep`),
+            then call pcbnew.SaveBoard().
+          * Update the recorded signature on success.
+
+        Returns a status dict that handle_command merges into the caller's
+        response so warnings about refused saves are visible:
+          {"saved": True,  "boardPath": ..., "backup": <path-or-None>}
+          {"saved": False, "skipped": <reason>}                      -- nothing to save
+          {"saved": False, "warning": ..., "diskChangedExternally": True, ...}
+          {"saved": False, "error": ...}                             -- pcbnew error
+        """
+        if not self.board:
+            return {"saved": False, "skipped": "no board loaded"}
+
+        try:
+            board_path = self.board.GetFileName()
+        except Exception as e:
+            return {"saved": False, "skipped": f"GetFileName failed: {e}"}
+
+        if not board_path:
+            return {"saved": False, "skipped": "no board path"}
+
+        expected = self._board_disk_signature
+        current = self._disk_signature(board_path)
+
+        # If we have a recorded signature and disk has diverged, refuse to save.
+        # (If expected is None we treat this as "first save" and proceed —
+        # otherwise users with pre-existing setups would never be able to save.)
+        if expected is not None and current is not None and expected != current:
+            warning = (
+                "Auto-save refused: the on-disk PCB file changed externally "
+                "since this MCP session loaded it. To avoid clobbering those "
+                "changes, the in-memory mutation has NOT been written to disk. "
+                "Reload via open_project to refresh, then re-apply the change."
+            )
+            logger.warning(f"{warning} ({board_path})")
+            logger.warning(f"  expected mtime_ns={expected[0]} sha256={expected[1][:12]}…")
+            logger.warning(f"  current  mtime_ns={current[0]} sha256={current[1][:12]}…")
+            return {
+                "saved": False,
+                "warning": warning,
+                "boardPath": board_path,
+                "diskChangedExternally": True,
+                "expectedMtimeNs": expected[0],
+                "currentMtimeNs": current[0],
+                "memChangesUnsaved": True,
+            }
+
+        # Make a rotating backup of the existing file (best-effort).
+        backup_path: Optional[str] = None
+        if current is not None:
+            try:
+                backup_dir = os.path.join(os.path.dirname(board_path) or ".", ".mcp-backups")
+                os.makedirs(backup_dir, exist_ok=True)
+                stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")[:-3]
+                base = os.path.basename(board_path)
+                backup_path = os.path.join(backup_dir, f"{base}.{stamp}")
+                shutil.copy2(board_path, backup_path)
+                self._prune_auto_save_backups(backup_dir, base)
+            except OSError as e:
+                logger.warning(f"Auto-save backup failed (continuing): {e}")
+                backup_path = None
+
+        # Write the board.
+        try:
+            pcbnew.SaveBoard(board_path, self.board)
+            logger.debug(f"Auto-saved board to: {board_path}")
+            self._board_disk_signature = self._disk_signature(board_path)
+            return {"saved": True, "boardPath": board_path, "backup": backup_path}
         except Exception as e:
             logger.warning(f"Auto-save failed: {e}")
+            return {"saved": False, "error": str(e), "backup": backup_path}
 
     def _update_command_handlers(self) -> None:
         """Update board reference in all command handlers"""

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -609,7 +609,15 @@ class KiCADInterface:
 
     @staticmethod
     def _disk_signature(path: str) -> Optional[Tuple[int, str]]:
-        """Return (mtime_ns, sha256_hex) for the file, or None if missing/unreadable."""
+        """Return (mtime_ns, sha256_hex) for the file, or None if missing/unreadable.
+
+        The sha256 is always recomputed from disk: the conflict guard in
+        ``_auto_save_board`` compares hashes (content), not mtime, so we
+        cannot use mtime as a cache key without re-introducing the bug
+        where two writes inside one mtime tick on a coarse-resolution
+        filesystem (FAT32, network mounts, etc.) would mask a real
+        content change.
+        """
         try:
             st = os.stat(path)
             h = hashlib.sha256()
@@ -687,19 +695,27 @@ class KiCADInterface:
         expected = self._board_disk_signature
         current = self._disk_signature(board_path)
 
-        # If we have a recorded signature and disk has diverged, refuse to save.
-        # (If expected is None we treat this as "first save" and proceed —
-        # otherwise users with pre-existing setups would never be able to save.)
-        if expected is not None and current is not None and expected != current:
+        # Only refuse if the file's CONTENT (sha256) has actually diverged
+        # from what we recorded. mtime alone is not a conflict signal —
+        # `touch`, atime-driven backups, or even some MCP read paths can
+        # advance mtime without changing content, and refusing on that
+        # basis traps users in a state where every write needs an explicit
+        # save_project workaround.
+        #
+        # If expected is None, treat this as "first save" and proceed —
+        # otherwise pre-existing setups (open_project ran before this guard
+        # was introduced) would never be able to save.
+        if expected is not None and current is not None and expected[1] != current[1]:
             warning = (
-                "Auto-save refused: the on-disk PCB file changed externally "
-                "since this MCP session loaded it. To avoid clobbering those "
-                "changes, the in-memory mutation has NOT been written to disk. "
-                "Reload via open_project to refresh, then re-apply the change."
+                "Auto-save refused: the on-disk PCB file's contents changed "
+                "externally since this MCP session loaded it. To avoid "
+                "clobbering those changes, the in-memory mutation has NOT "
+                "been written to disk. Reload via open_project to refresh, "
+                "then re-apply the change."
             )
             logger.warning(f"{warning} ({board_path})")
-            logger.warning(f"  expected mtime_ns={expected[0]} sha256={expected[1][:12]}…")
-            logger.warning(f"  current  mtime_ns={current[0]} sha256={current[1][:12]}…")
+            logger.warning(f"  expected sha256={expected[1][:12]}… mtime_ns={expected[0]}")
+            logger.warning(f"  current  sha256={current[1][:12]}… mtime_ns={current[0]}")
             return {
                 "saved": False,
                 "warning": warning,
@@ -709,6 +725,11 @@ class KiCADInterface:
                 "currentMtimeNs": current[0],
                 "memChangesUnsaved": True,
             }
+
+        # Content matches but mtime advanced (e.g. external `touch`): refresh
+        # the recorded mtime so we don't re-hash on every subsequent call.
+        if expected is not None and current is not None and expected != current:
+            self._board_disk_signature = current
 
         # Make a rotating backup of the existing file (best-effort).
         backup_path: Optional[str] = None

--- a/tests/test_auto_save_guard.py
+++ b/tests/test_auto_save_guard.py
@@ -1,0 +1,226 @@
+"""
+Tests for the auto-save guard in kicad_interface._auto_save_board.
+
+The guard is meant to prevent the MCP server from silently overwriting a
+.kicad_pcb file that was modified externally between LoadBoard and
+SaveBoard (e.g. by KiCad GUI's own save, a git checkout, or another
+process). Behaviour exercised here:
+
+  - First-load semantics: with no recorded signature, auto-save proceeds.
+  - Detect external change: when the on-disk file has been altered since
+    the recorded signature, auto-save is refused and the in-memory
+    mutation is NOT written to disk.
+  - Backup creation: a successful save copies the prior file contents to
+    `.mcp-backups/<name>.<timestamp>` before overwriting.
+  - Backup pruning: only the most recent N backups are retained.
+  - Signature update: after a successful save, the recorded signature is
+    refreshed so subsequent saves are not falsely flagged.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+
+def _make_iface() -> Any:
+    """Construct a KiCADInterface bypassing __init__ (avoids pcbnew / IPC)."""
+    with patch("kicad_interface.USE_IPC_BACKEND", False):
+        from kicad_interface import KiCADInterface
+
+        iface = KiCADInterface.__new__(KiCADInterface)
+    iface.board = None
+    iface._board_disk_signature = None
+    iface._auto_save_backup_keep = 5
+    return iface
+
+
+@pytest.fixture()
+def iface():
+    return _make_iface()
+
+
+@pytest.fixture()
+def board_file(tmp_path: Path) -> Path:
+    """A temp .kicad_pcb file with placeholder contents."""
+    f = tmp_path / "test.kicad_pcb"
+    f.write_text("(kicad_pcb (version 1) (generator test))\n")
+    return f
+
+
+def _fake_board(path: str) -> MagicMock:
+    """A MagicMock that quacks like a pcbnew BOARD for our helpers."""
+    b = MagicMock()
+    b.GetFileName.return_value = path
+    return b
+
+
+# ---------------------------------------------------------------------------
+# _disk_signature: read-only, no side effects
+# ---------------------------------------------------------------------------
+
+
+def test_disk_signature_returns_mtime_and_hash(iface, board_file):
+    sig = iface._disk_signature(str(board_file))
+    assert sig is not None
+    mtime_ns, sha = sig
+    assert isinstance(mtime_ns, int) and mtime_ns > 0
+    assert isinstance(sha, str) and len(sha) == 64  # sha256 hex
+
+
+def test_disk_signature_returns_none_for_missing_file(iface, tmp_path: Path):
+    assert iface._disk_signature(str(tmp_path / "does-not-exist.kicad_pcb")) is None
+
+
+def test_disk_signature_changes_when_file_changes(iface, board_file):
+    s1 = iface._disk_signature(str(board_file))
+    # ensure mtime tick (filesystems vary; nanoseconds usually suffice but
+    # add a small sleep for resolutions that don't)
+    time.sleep(0.01)
+    board_file.write_text(board_file.read_text() + "; modified\n")
+    s2 = iface._disk_signature(str(board_file))
+    assert s1 != s2
+    assert s1[1] != s2[1]  # hash differs
+
+
+# ---------------------------------------------------------------------------
+# _auto_save_board: skip cases (no board / no path)
+# ---------------------------------------------------------------------------
+
+
+def test_auto_save_skips_when_no_board(iface):
+    iface.board = None
+    result = iface._auto_save_board()
+    assert result == {"saved": False, "skipped": "no board loaded"}
+
+
+def test_auto_save_skips_when_no_path(iface):
+    iface.board = MagicMock()
+    iface.board.GetFileName.return_value = ""
+    result = iface._auto_save_board()
+    assert result["saved"] is False
+    assert "skipped" in result
+
+
+# ---------------------------------------------------------------------------
+# _auto_save_board: happy-path save with signature tracking + backup
+# ---------------------------------------------------------------------------
+
+
+def test_auto_save_with_matching_signature_proceeds(iface, board_file):
+    iface.board = _fake_board(str(board_file))
+    iface._record_board_signature()
+    pre_sig = iface._board_disk_signature
+    assert pre_sig is not None
+
+    save_calls = []
+
+    def fake_save(path, board):
+        save_calls.append((path, board))
+        # Simulate pcbnew rewriting the file
+        Path(path).write_text("(kicad_pcb (version 1) (generator test) ; saved)\n")
+
+    with patch("kicad_interface.pcbnew") as mock_pcb:
+        mock_pcb.SaveBoard.side_effect = fake_save
+        result = iface._auto_save_board()
+
+    assert result["saved"] is True
+    assert result["boardPath"] == str(board_file)
+    assert len(save_calls) == 1
+    # Signature should have been refreshed
+    assert iface._board_disk_signature is not None
+    assert iface._board_disk_signature != pre_sig
+
+
+def test_auto_save_creates_backup_before_writing(iface, board_file):
+    iface.board = _fake_board(str(board_file))
+    iface._record_board_signature()
+
+    original_contents = board_file.read_text()
+
+    def fake_save(path, board):
+        Path(path).write_text("(kicad_pcb ; overwritten)\n")
+
+    with patch("kicad_interface.pcbnew") as mock_pcb:
+        mock_pcb.SaveBoard.side_effect = fake_save
+        result = iface._auto_save_board()
+
+    assert result["saved"] is True
+    backup_dir = board_file.parent / ".mcp-backups"
+    assert backup_dir.is_dir()
+    backups = list(backup_dir.glob(f"{board_file.name}.*"))
+    assert len(backups) == 1
+    # Backup must contain the PRE-save contents (snapshot before overwrite)
+    assert backups[0].read_text() == original_contents
+    # Returned path matches the file we created
+    assert result["backup"] == str(backups[0])
+
+
+# ---------------------------------------------------------------------------
+# _auto_save_board: refuses when disk diverged from recorded signature
+# ---------------------------------------------------------------------------
+
+
+def test_auto_save_refuses_when_disk_changed_externally(iface, board_file):
+    iface.board = _fake_board(str(board_file))
+    iface._record_board_signature()
+
+    # Simulate an external actor (KiCad GUI, git, another process)
+    # writing the file after we loaded it.
+    time.sleep(0.01)
+    board_file.write_text("(kicad_pcb ; changed by someone else)\n")
+
+    with patch("kicad_interface.pcbnew") as mock_pcb:
+        result = iface._auto_save_board()
+        assert mock_pcb.SaveBoard.call_count == 0  # MUST NOT save
+
+    assert result["saved"] is False
+    assert result["diskChangedExternally"] is True
+    assert result["memChangesUnsaved"] is True
+    assert "warning" in result
+    # File on disk must still hold the external content, untouched
+    assert "changed by someone else" in board_file.read_text()
+
+
+def test_auto_save_first_save_with_no_recorded_signature_proceeds(iface, board_file):
+    """If we never loaded the file (e.g. first save_project after create),
+    treat it as a normal first save rather than refusing."""
+    iface.board = _fake_board(str(board_file))
+    iface._board_disk_signature = None  # explicit: nothing recorded yet
+
+    with patch("kicad_interface.pcbnew") as mock_pcb:
+        mock_pcb.SaveBoard.side_effect = lambda p, b: Path(p).write_text("first\n")
+        result = iface._auto_save_board()
+
+    assert result["saved"] is True
+    assert iface._board_disk_signature is not None  # now recorded
+
+
+# ---------------------------------------------------------------------------
+# Backup rotation: keep only N most-recent
+# ---------------------------------------------------------------------------
+
+
+def test_backup_pruning_keeps_only_n_most_recent(iface, board_file):
+    iface.board = _fake_board(str(board_file))
+    iface._auto_save_backup_keep = 3
+
+    def fake_save(path, board):
+        Path(path).write_text(f"(kicad_pcb ; save at {time.time_ns()})\n")
+
+    with patch("kicad_interface.pcbnew") as mock_pcb:
+        mock_pcb.SaveBoard.side_effect = fake_save
+        for _ in range(7):
+            iface._record_board_signature()
+            iface._auto_save_board()
+            time.sleep(0.005)  # ensure unique timestamps
+
+    backup_dir = board_file.parent / ".mcp-backups"
+    backups = sorted(backup_dir.glob(f"{board_file.name}.*"))
+    assert len(backups) == 3

--- a/tests/test_auto_save_guard.py
+++ b/tests/test_auto_save_guard.py
@@ -202,6 +202,104 @@ def test_auto_save_first_save_with_no_recorded_signature_proceeds(iface, board_f
     assert iface._board_disk_signature is not None  # now recorded
 
 
+def test_auto_save_proceeds_when_only_mtime_changed_via_touch(iface, board_file):
+    """Touching the file (mtime advances, content unchanged) MUST NOT be
+    treated as an external write. Earlier behaviour compared the full
+    (mtime_ns, sha256) tuple, so any `touch` between MCP load and save
+    triggered a refusal — trapping users in a state where every write
+    needed an explicit save_project workaround.
+    """
+    iface.board = _fake_board(str(board_file))
+    iface._record_board_signature()
+    pre_sig = iface._board_disk_signature
+    assert pre_sig is not None
+
+    # Bump the mtime without changing content (the `touch` case). os.utime
+    # is more reliable than `Path.touch()` across filesystems.
+    new_mtime_ns = pre_sig[0] + 5_000_000_000  # +5 s
+    os.utime(board_file, ns=(new_mtime_ns, new_mtime_ns))
+
+    save_calls: list[tuple[Any, Any]] = []
+
+    def fake_save(path: str, board: Any) -> None:
+        save_calls.append((path, board))
+        Path(path).write_text("(kicad_pcb ; saved by mcp)\n")
+
+    with patch("kicad_interface.pcbnew") as mock_pcb:
+        mock_pcb.SaveBoard.side_effect = fake_save
+        result = iface._auto_save_board()
+
+    assert result["saved"] is True, result
+    assert "diskChangedExternally" not in result
+    assert len(save_calls) == 1
+    # Recorded signature was refreshed after the save.
+    assert iface._board_disk_signature is not None
+    assert iface._board_disk_signature != pre_sig
+
+
+def test_auto_save_refuses_when_content_differs_even_at_same_mtime(iface, board_file):
+    """If somehow the on-disk content differs (sha256 mismatch) the guard
+    must still refuse — this is the actual data-loss scenario the original
+    PR was guarding against. The signature-comparison path must not
+    short-circuit out of the content check just because the mtime tuple
+    happens to match what we recorded.
+    """
+    iface.board = _fake_board(str(board_file))
+    iface._record_board_signature()
+    expected = iface._board_disk_signature
+    assert expected is not None
+
+    # Replace contents but force the same mtime as recorded — simulates a
+    # filesystem with sub-second mtime resolution where two writes within
+    # the same tick produce different content under the same mtime stamp.
+    board_file.write_text("(kicad_pcb ; secretly different content)\n")
+    os.utime(board_file, ns=(expected[0], expected[0]))
+
+    with patch("kicad_interface.pcbnew") as mock_pcb:
+        result = iface._auto_save_board()
+        assert mock_pcb.SaveBoard.call_count == 0
+
+    assert result["saved"] is False
+    assert result["diskChangedExternally"] is True
+    assert result["memChangesUnsaved"] is True
+
+
+def test_auto_save_refuses_message_mentions_contents_not_mtime(iface, board_file):
+    """The user-facing warning should describe the failure as a content
+    conflict, not an mtime mismatch — the guard now blocks only on
+    sha256 divergence, so the message must reflect that.
+    """
+    iface.board = _fake_board(str(board_file))
+    iface._record_board_signature()
+
+    time.sleep(0.01)
+    board_file.write_text("(kicad_pcb ; changed by someone else)\n")
+
+    with patch("kicad_interface.pcbnew"):
+        result = iface._auto_save_board()
+
+    assert result["saved"] is False
+    assert "warning" in result
+    assert "contents" in result["warning"].lower(), result["warning"]
+
+
+def test_disk_signature_rehashes_when_mtime_advances_with_same_content(iface, board_file):
+    """When the file's mtime advances but content is unchanged, _disk_signature
+    must still return the same sha256 — the touch-only case must not surface
+    as a content divergence to the auto-save guard.
+    """
+    sig1 = iface._disk_signature(str(board_file))
+    assert sig1 is not None
+
+    new_mtime_ns = sig1[0] + 5_000_000_000
+    os.utime(board_file, ns=(new_mtime_ns, new_mtime_ns))
+
+    sig2 = iface._disk_signature(str(board_file))
+    assert sig2 is not None
+    assert sig2[0] == new_mtime_ns
+    assert sig2[1] == sig1[1]  # content unchanged → hash unchanged
+
+
 # ---------------------------------------------------------------------------
 # Backup rotation: keep only N most-recent
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stacked on #151

This PR is **stacked on top of #151** (\`feat/auto-save-guard\`). The diff against \`main\` includes #151's commit because that's the only way to express the dependency in a single PR; review just the second commit (\`fix(auto-save-guard): refuse only on content divergence, not mtime\`) here. If #151 lands first, this PR's diff against \`main\` collapses to only the second commit.

## Summary

The guard added in #151 records \`(mtime_ns, sha256)\` as the file's disk signature and refuses auto-save when the recorded tuple no longer matches the current one. Comparing the **full tuple** means any mtime delta fires the refusal — including a bare \`touch\` of the file, an atime-style backup tool, or any MCP read path that opened the \`.kicad_pcb\` between load and save. Users get trapped: every write needs an explicit \`save_project\` call to bypass the false positive (already documented as a workaround in fork users' notes).

## Repro

1. \`open_project\` to load a board.
2. \`touch <project>/board.kicad_pcb\` in another shell (mtime advances, content unchanged).
3. Try any board-mutating tool (e.g. \`add_via\`).

Expected (against #151 as-is): \`autoSave.saved: false\` with \`diskChangedExternally: true\`. The mutation is dropped.

## Fix

Compare on \`sha256\` only; mtime is incidental. The actual data-loss scenario the guard is meant to catch — an external write that genuinely changed the file — produces a different content hash, which is what the guard now keys off. After a touch-only mtime advance with content unchanged, refresh the recorded signature so we don't re-hash on every subsequent call.

\`\`\`python
# Before:
if expected != current:               # tuple equality — fires on mtime alone
    refuse(...)

# After:
if expected[1] != current[1]:         # sha256 only — actual content
    refuse(...)
elif expected != current:             # touch-only: refresh recorded mtime
    self._board_disk_signature = current
\`\`\`

Drops the mtime-equality fast path on \`_disk_signature\`: a filesystem with coarse mtime resolution (FAT32, some network mounts) could accept two writes inside one mtime tick; trusting mtime as a hash cache key would re-introduce a class of silent overwrites the guard exists to prevent. The hash itself is cheap (sha256 over a typical \`.kicad_pcb\` completes in tens of milliseconds).

## Test plan

- [x] \`pytest tests/test_auto_save_guard.py\` — 14/14 pass (10 from #151 + 4 new). The new ones cover:
  - touch-only mtime advance proceeds and refreshes the signature
  - content change at the same mtime is **still** refused (hash divergence drives the decision, not tuple equality)
  - the user-facing warning calls out \"contents\", not \"mtime\"
  - \`_disk_signature\` returns the same hash when content is unchanged even after the file's mtime advances
- [x] No regressions in the existing #151 tests — the guard still refuses on real external content changes, still snapshots backups before overwrite, still handles first-save / no-board / no-path cases.

## Notes

This PR also unblocks the \`open_project → save_project\` workaround documented in downstream users' notes (the \"call \`save_project\` to bypass the mtime check\" pattern). With this fix in place, the workaround is no longer necessary — auto-save just works after a \`touch\` or other no-content-change file event.