### PR TITLE
Add query_zones tool for auditing copper pours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### New MCP Tools
 
+- `query_zones` — Query copper zones (filled pours) on the board with optional
+  filters by net, layer, or bounding box. Returns one entry per zone with its
+  net, layers, priority, fill state, min thickness, bounding box, and filled
+  area. Complements `query_traces`, which only reports tracks/vias and silently
+  omits power-plane and GND pours — making layer-usage audits incomplete on any
+  board that uses copper zones.
+
 - `set_schematic_component_property` — Add or update a single custom property
   (BOM / sourcing field) on a placed schematic symbol. Convenience wrapper
   around `edit_schematic_component` for the common case of attaching one MPN /

--- a/python/commands/routing.py
+++ b/python/commands/routing.py
@@ -707,6 +707,113 @@ class RoutingCommands:
                 "errorDetails": str(e),
             }
 
+    def query_zones(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Query copper zones (filled pours) by net, layer, or bounding box.
+
+        Returns one entry per zone with its net, layers, priority, fill state,
+        and bounding box. Useful for auditing power planes / GND pours that
+        ``query_traces`` does not report (zones are PCB_ZONE_T, not tracks).
+        """
+        try:
+            if not self.board:
+                return {
+                    "success": False,
+                    "message": "No board is loaded",
+                    "errorDetails": "Load or create a board first",
+                }
+
+            net_name = params.get("net")
+            layer = params.get("layer")
+            bbox = params.get("boundingBox")
+
+            scale = 1000000  # nm -> mm
+            target_layer_id = None
+            if layer:
+                target_layer_id = self.board.GetLayerID(layer)
+
+            bbox_box = None
+            if bbox:
+                bbox_unit = bbox.get("unit", "mm")
+                bbox_scale = scale if bbox_unit == "mm" else 25400000
+                bbox_box = (
+                    int(bbox.get("x1", 0) * bbox_scale),
+                    int(bbox.get("y1", 0) * bbox_scale),
+                    int(bbox.get("x2", 0) * bbox_scale),
+                    int(bbox.get("y2", 0) * bbox_scale),
+                )
+
+            zones_out = []
+            for zone in list(self.board.Zones()):
+                try:
+                    z_net = zone.GetNetname()
+                    if net_name and z_net != net_name:
+                        continue
+
+                    # A zone can span multiple copper layers; collect them.
+                    layer_names = []
+                    try:
+                        layer_set = zone.GetLayerSet()
+                        seq = layer_set.CuStack() if hasattr(layer_set, "CuStack") else layer_set.Seq()
+                        for lid in seq:
+                            layer_names.append(self.board.GetLayerName(lid))
+                    except Exception:
+                        layer_names = [self.board.GetLayerName(zone.GetLayer())]
+
+                    if target_layer_id is not None:
+                        if target_layer_id not in [self.board.GetLayerID(n) for n in layer_names]:
+                            continue
+
+                    bb = zone.GetBoundingBox()
+                    bb_x1, bb_y1 = bb.GetLeft(), bb.GetTop()
+                    bb_x2, bb_y2 = bb.GetRight(), bb.GetBottom()
+
+                    if bbox_box is not None:
+                        x1, y1, x2, y2 = bbox_box
+                        # Reject if no overlap with filter bbox.
+                        if bb_x2 < x1 or bb_x1 > x2 or bb_y2 < y1 or bb_y1 > y2:
+                            continue
+
+                    entry = {
+                        "uuid": zone.m_Uuid.AsString(),
+                        "net": z_net,
+                        "netCode": zone.GetNetCode(),
+                        "layers": layer_names,
+                        "priority": zone.GetAssignedPriority() if hasattr(zone, "GetAssignedPriority") else 0,
+                        "isFilled": bool(zone.IsFilled()),
+                        "minThickness": zone.GetMinThickness() / scale,
+                        "boundingBox": {
+                            "x1": bb_x1 / scale,
+                            "y1": bb_y1 / scale,
+                            "x2": bb_x2 / scale,
+                            "y2": bb_y2 / scale,
+                            "unit": "mm",
+                        },
+                    }
+                    # Area is only available when zone is filled.
+                    try:
+                        entry["filledArea"] = zone.GetFilledArea() / (scale * scale)
+                    except Exception:
+                        pass
+
+                    zones_out.append(entry)
+                except Exception as zone_err:
+                    logger.warning(f"Skipping invalid zone object: {zone_err}")
+                    continue
+
+            return {
+                "success": True,
+                "zoneCount": len(zones_out),
+                "zones": zones_out,
+            }
+
+        except Exception as e:
+            logger.error(f"Error querying zones: {str(e)}")
+            return {
+                "success": False,
+                "message": "Failed to query zones",
+                "errorDetails": str(e),
+            }
+
     def modify_trace(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Modify properties of an existing trace
 

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -343,6 +343,7 @@ class KiCADInterface:
             "add_via": self.routing_commands.add_via,
             "delete_trace": self.routing_commands.delete_trace,
             "query_traces": self.routing_commands.query_traces,
+            "query_zones": self.routing_commands.query_zones,
             "modify_trace": self.routing_commands.modify_trace,
             "copy_routing_pattern": self.routing_commands.copy_routing_pattern,
             "get_nets_list": self.routing_commands.get_nets_list,

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -856,6 +856,39 @@ ROUTING_TOOLS = [
         },
     },
     {
+        "name": "query_zones",
+        "title": "Query Zones",
+        "description": "Queries copper zones (filled pours) on the board with optional filters by net, layer, or bounding box. Returns one entry per zone with net, layers, priority, fill state, and bounding box. Useful for auditing power planes and GND pours, which 'query_traces' does not include.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "net": {
+                    "type": "string",
+                    "description": "Filter by net name (e.g., 'GND', '+3V3')",
+                },
+                "layer": {
+                    "type": "string",
+                    "description": "Filter by layer name (e.g., 'In1.Cu', 'B.Cu'). Matches zones that include this layer in their layer set.",
+                },
+                "boundingBox": {
+                    "type": "object",
+                    "description": "Filter to zones whose bounding box overlaps this region",
+                    "properties": {
+                        "x1": {"type": "number", "description": "Left X coordinate"},
+                        "y1": {"type": "number", "description": "Top Y coordinate"},
+                        "x2": {"type": "number", "description": "Right X coordinate"},
+                        "y2": {"type": "number", "description": "Bottom Y coordinate"},
+                        "unit": {
+                            "type": "string",
+                            "enum": ["mm", "inch"],
+                            "default": "mm",
+                        },
+                    },
+                },
+            },
+        },
+    },
+    {
         "name": "modify_trace",
         "title": "Modify Trace",
         "description": "Modifies properties of an existing trace. Find trace by UUID or position, then change width, layer, or net assignment.",

--- a/src/tools/routing.ts
+++ b/src/tools/routing.ts
@@ -182,6 +182,40 @@ export function registerRoutingTools(server: McpServer, callKicadScript: Functio
     },
   );
 
+  // Query zones tool
+  server.tool(
+    "query_zones",
+    "Query copper zones (filled pours) on the board with optional filters by net, layer, or bounding box. Returns zone net, layers, priority, fill state, and bounding box. Useful for auditing power planes and GND pours that query_traces does not include.",
+    {
+      net: z.string().optional().describe("Filter by net name"),
+      layer: z
+        .string()
+        .optional()
+        .describe("Filter by layer name (matches zones that include this layer)"),
+      boundingBox: z
+        .object({
+          x1: z.number(),
+          y1: z.number(),
+          x2: z.number(),
+          y2: z.number(),
+          unit: z.enum(["mm", "inch"]).optional(),
+        })
+        .optional()
+        .describe("Filter to zones whose bounding box overlaps this region"),
+    },
+    async (args: any) => {
+      const result = await callKicadScript("query_zones", args);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
   // Get nets list tool
   server.tool(
     "get_nets_list",


### PR DESCRIPTION
## Summary

- `query_traces` silently omits `PCB_ZONE_T` objects, so layer-usage audits miss power planes and GND pours entirely on any board that uses copper zones.
- This PR adds a new `query_zones` tool that complements `query_traces` by iterating `board.Zones()` and returning each zone's net, layers, priority, fill state, min thickness, bounding box, and filled area.
- The filter surface (`net`, `layer`, `boundingBox`) is symmetric with `query_traces`, so callers can mix the two for a complete picture of a layer's usage.

### Why

Hit this while auditing a 6-layer board with In1/In4 as GND planes and In2 as a power layer. `query_traces` reported In1 and In4 as empty because all the copper there lives in zones, leading to incorrect recommendations. With `query_zones` the audit completes correctly without having to parse `.kicad_pcb` S-expressions manually.

### Implementation

- `python/commands/routing.py` — `RoutingCommands.query_zones()` using `pcbnew` API (`Zones()`, `GetLayerSet().CuStack()`, `GetBoundingBox()`, `IsFilled()`, `GetFilledArea()`). Defensive fallbacks for older pcbnew bindings.
- `python/kicad_interface.py` — command dispatch entry.
- `python/schemas/tool_schemas.py` — MCP tool schema.
- `src/tools/routing.ts` — MCP tool registration mirroring `query_traces`.
- `CHANGELOG.md` — entry under Unreleased.

### Output shape

```json
{
  "success": true,
  "zoneCount": 1,
  "zones": [
    {
      "uuid": "bbad52c1-...",
      "net": "GND",
      "netCode": 1,
      "layers": ["In1.Cu"],
      "priority": 0,
      "isFilled": true,
      "minThickness": 0.25,
      "boundingBox": { "x1": 150.56, "y1": 24.35, "x2": 230.56, "y2": 118.35, "unit": "mm" },
      "filledArea": 5720.23
    }
  ]
}
```

## Test plan

- [x] Manual test against a real 6-layer KiCad 9 board (44 zones detected across F.Cu/In1.Cu/In2.Cu/In3.Cu/In4.Cu/B.Cu); results match S-expression parsing of the same `.kicad_pcb`.
- [x] `layer=In1.Cu` filter returns only the matching GND pour.
- [x] `npm run build` passes with no TS errors.
- [ ] Add a regression test once maintainers point me at the preferred fixture board.