### PR TITLE
style: apply prettier formatting to kicad-server.ts

### DIFF
--- a/src/kicad-server.ts
+++ b/src/kicad-server.ts
@@ -25,7 +25,8 @@ class KiCADServer {
 
   constructor() {
     // Set absolute path to the Python KiCAD interface script
-    this.kicadScriptPath = process.env.KICAD_SCRIPT_PATH ||
+    this.kicadScriptPath =
+      process.env.KICAD_SCRIPT_PATH ||
       path.join(path.dirname(fileURLToPath(import.meta.url)), "../python/kicad_interface.py");
 
     // Check if script exists


### PR DESCRIPTION
## Summary

Post-merge cleanup for #155: the merged change tripped the prettier pre-commit hook because the `||` fallback was on the same line as the assignment. Prettier wants the RHS on its own line when the expression wraps.

```ts
// before (fails prettier)
this.kicadScriptPath = process.env.KICAD_SCRIPT_PATH ||
  path.join(path.dirname(fileURLToPath(import.meta.url)), "../python/kicad_interface.py");

// after
this.kicadScriptPath =
  process.env.KICAD_SCRIPT_PATH ||
  path.join(path.dirname(fileURLToPath(import.meta.url)), "../python/kicad_interface.py");
```

No behavior change — formatting only.

## Test plan

- [x] `pre-commit run --files src/kicad-server.ts` passes (prettier + eslint)
- [x] `npm run build` succeeds
- [x] `pytest tests/ -v` — 689 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)