### PR TITLE
test(swig-dehydration): init _board_disk_signature in test fixture

### DIFF
--- a/tests/test_swig_dehydration.py
+++ b/tests/test_swig_dehydration.py
@@ -58,6 +58,12 @@ def _make_iface() -> Any:
         iface = KiCADInterface.__new__(KiCADInterface)
         iface.use_ipc = False
         iface.ipc_board_api = None
+        # __init__ is skipped here, so initialise the auto-save signature
+        # attribute that _auto_save_board's content-divergence guard reads.
+        # (The guard came from the #151/#172 auto-save work that #173 was
+        # merged on top of; without this the dehydration recovery test trips
+        # an AttributeError before reaching the code under test.)
+        iface._board_disk_signature = None
         return iface
 
 


### PR DESCRIPTION
## Summary

Repairs a test that fails after #173 merged.

`test_swig_dehydration.py::test_auto_save_recovers_when_save_leaves_board_dehydrated` builds a `KiCADInterface` via `__new__` (skipping `__init__`). When #173 was rebased onto the #151/#172 auto-save guard, the merged `_auto_save_board` now reads `self._board_disk_signature` — an attribute `__init__` sets to `None`. The `_make_iface` fixture didn't initialise it, so the test tripped an `AttributeError` before reaching the dehydration-recovery code it's meant to exercise.

## Fix

Initialise `_board_disk_signature = None` in `_make_iface`, matching the pattern already used in `tests/test_auto_save_guard.py::iface`. Test-only change — no production code touched.

## Verification

`pytest tests/test_swig_dehydration.py` → all pass in isolation.