### PR TITLE
fix: parse quoted KiCad library table URIs with spaces

### DIFF
--- a/python/commands/library.py
+++ b/python/commands/library.py
@@ -91,14 +91,19 @@ class LibraryManager:
             with open(table_path, "r") as f:
                 content = f.read()
 
-            # Simple regex-based parser for lib entries
-            # Pattern: (lib (name "NAME")(type TYPE)(uri "URI")...)
-            lib_pattern = r'\(lib\s+\(name\s+"?([^")\s]+)"?\)\s*\(type\s+"?([^")\s]+)"?\)\s*\(uri\s+"?([^")\s]+)"?'
+            # Simple regex-based parser for lib entries. Name, type, and URI
+            # may be quoted or bare; quoted URIs can contain spaces.
+            lib_pattern = (
+                r"\(lib\s+"
+                r'\(name\s+(?:"([^"]+)"|([^"\)\s]+))\)\s*'
+                r'\(type\s+(?:"([^"]+)"|([^"\)\s]+))\)\s*'
+                r'\(uri\s+(?:"([^"]+)"|([^"\)\s]+))'
+            )
 
             for match in re.finditer(lib_pattern, content, re.IGNORECASE):
-                nickname = match.group(1)
-                lib_type = match.group(2)
-                uri = match.group(3)
+                nickname = match.group(1) or match.group(2)
+                lib_type = match.group(3) or match.group(4)
+                uri = match.group(5) or match.group(6)
 
                 if lib_type.lower() == "table":
                     table_uri = uri

--- a/python/commands/library_symbol.py
+++ b/python/commands/library_symbol.py
@@ -127,14 +127,19 @@ class SymbolLibraryManager:
             with open(table_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
-            # Simple regex-based parser for lib entries
-            # Pattern: (lib (name "NAME")(type TYPE)(uri "URI")...)
-            lib_pattern = r'\(lib\s+\(name\s+"?([^")\s]+)"?\)\s*\(type\s+"?([^")\s]+)"?\)\s*\(uri\s+"?([^")\s]+)"?'
+            # Simple regex-based parser for lib entries. Name, type, and URI
+            # may be quoted or bare; quoted URIs can contain spaces.
+            lib_pattern = (
+                r"\(lib\s+"
+                r'\(name\s+(?:"([^"]+)"|([^"\)\s]+))\)\s*'
+                r'\(type\s+(?:"([^"]+)"|([^"\)\s]+))\)\s*'
+                r'\(uri\s+(?:"([^"]+)"|([^"\)\s]+))'
+            )
 
             for match in re.finditer(lib_pattern, content, re.IGNORECASE):
-                nickname = match.group(1)
-                lib_type = match.group(2)
-                uri = match.group(3)
+                nickname = match.group(1) or match.group(2)
+                lib_type = match.group(3) or match.group(4)
+                uri = match.group(5) or match.group(6)
 
                 if lib_type.lower() == "table":
                     table_uri = uri
@@ -554,9 +559,7 @@ class SymbolLibraryCommands:
             if value:
                 start = Path(value).expanduser().parent
                 for ancestor in [start, *start.parents]:
-                    if (ancestor / "sym-lib-table").exists() or list(
-                        ancestor.glob("*.kicad_pro")
-                    ):
+                    if (ancestor / "sym-lib-table").exists() or list(ancestor.glob("*.kicad_pro")):
                         return ancestor
                 return start
 

--- a/tests/test_kicad_3rd_party_env_resolution.py
+++ b/tests/test_kicad_3rd_party_env_resolution.py
@@ -26,14 +26,29 @@ from commands.library import LibraryManager
 from commands.library_symbol import SymbolLibraryManager
 
 
+def _make_footprint_manager() -> LibraryManager:
+    manager = LibraryManager.__new__(LibraryManager)
+    manager.project_path = None
+    manager.libraries = {}
+    manager.footprint_cache = {}
+    return manager
+
+
+def _make_symbol_manager() -> SymbolLibraryManager:
+    manager = SymbolLibraryManager.__new__(SymbolLibraryManager)
+    manager.project_path = None
+    manager.libraries = {}
+    manager.symbol_cache = {}
+    return manager
+
+
 @pytest.mark.unit
 def test_symbol_manager_resolves_unprefixed_kicad_3rd_party(monkeypatch, tmp_path):
     monkeypatch.setenv("KICAD_3RD_PARTY", str(tmp_path))
     target = tmp_path / "EasyEDA.kicad_sym"
     target.touch()
 
-    manager = SymbolLibraryManager.__new__(SymbolLibraryManager)
-    manager.project_path = None
+    manager = _make_symbol_manager()
 
     resolved = manager._resolve_uri("${KICAD_3RD_PARTY}/EasyEDA.kicad_sym")
     assert resolved == str(target)
@@ -45,8 +60,7 @@ def test_library_manager_resolves_unprefixed_kicad_3rd_party(monkeypatch, tmp_pa
     target_dir = tmp_path / "EasyEDA.pretty"
     target_dir.mkdir()
 
-    manager = LibraryManager.__new__(LibraryManager)
-    manager.project_path = None
+    manager = _make_footprint_manager()
 
     resolved = manager._resolve_uri("${KICAD_3RD_PARTY}/EasyEDA.pretty")
     assert resolved == str(target_dir)
@@ -64,12 +78,57 @@ def test_versioned_and_unprefixed_forms_both_work(monkeypatch, tmp_path):
     fp_target = tmp_path / "Mixed.pretty"
     fp_target.mkdir()
 
-    sym_mgr = SymbolLibraryManager.__new__(SymbolLibraryManager)
-    sym_mgr.project_path = None
-    fp_mgr = LibraryManager.__new__(LibraryManager)
-    fp_mgr.project_path = None
+    sym_mgr = _make_symbol_manager()
+    fp_mgr = _make_footprint_manager()
 
     assert sym_mgr._resolve_uri("${KICAD10_3RD_PARTY}/Mixed.kicad_sym") == str(sym_target)
     assert sym_mgr._resolve_uri("${KICAD_3RD_PARTY}/Mixed.kicad_sym") == str(sym_target)
     assert fp_mgr._resolve_uri("${KICAD10_3RD_PARTY}/Mixed.pretty") == str(fp_target)
     assert fp_mgr._resolve_uri("${KICAD_3RD_PARTY}/Mixed.pretty") == str(fp_target)
+
+
+@pytest.mark.unit
+def test_footprint_table_parses_quoted_uri_with_spaces(tmp_path):
+    """A quoted fp-lib-table URI with spaces must remain one complete path."""
+    library_dir = tmp_path / "OneDrive - Company" / "KiCad Libs" / "Vendor.pretty"
+    library_dir.mkdir(parents=True)
+    table_path = tmp_path / "fp-lib-table"
+    table_path.write_text(
+        "\n".join(
+            [
+                "(fp_lib_table",
+                f'  (lib (name "Vendor")(type "KiCad")(uri "{library_dir}")(options "")(descr ""))',
+                ")",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    manager = _make_footprint_manager()
+    manager._parse_fp_lib_table(table_path)
+
+    assert manager.libraries["Vendor"] == str(library_dir)
+
+
+@pytest.mark.unit
+def test_symbol_table_parses_quoted_uri_with_spaces(tmp_path):
+    """A quoted sym-lib-table URI with spaces must remain one complete path."""
+    library_file = tmp_path / "OneDrive - Company" / "KiCad Libs" / "Vendor.kicad_sym"
+    library_file.parent.mkdir(parents=True)
+    library_file.write_text("(kicad_symbol_lib (version 20231120))", encoding="utf-8")
+    table_path = tmp_path / "sym-lib-table"
+    table_path.write_text(
+        "\n".join(
+            [
+                "(sym_lib_table",
+                f'  (lib (name "Vendor")(type "KiCad")(uri "{library_file}")(options "")(descr ""))',
+                ")",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    manager = _make_symbol_manager()
+    manager._parse_sym_lib_table(table_path)
+
+    assert manager.libraries["Vendor"] == str(library_file)


### PR DESCRIPTION
## Summary
- Fix fp-lib-table and sym-lib-table parsing so quoted `name`, `type`, and `uri` values are handled correctly.
- Preserve quoted URIs containing spaces, such as OneDrive/company library paths, instead of truncating at the first space.
- Add regression coverage for both footprint and symbol library managers.

## Test Plan
- `python -m pytest -o addopts= tests/test_kicad_3rd_party_env_resolution.py -q`
- `python -m pytest -o addopts= tests/test_kicad_3rd_party_env_resolution.py tests/test_loader_global_sym_lib_table.py -q`
- `python -m pytest -o addopts= tests/test_symbol_library.py tests/test_kicad_3rd_party_env_resolution.py tests/test_loader_global_sym_lib_table.py -q`
- `python -m black --check --workers 1 python/commands/library.py python/commands/library_symbol.py tests/test_kicad_3rd_party_env_resolution.py`
- Docker clean proof from `git archive HEAD`: `python -m pytest -o addopts= tests/test_kicad_3rd_party_env_resolution.py tests/test_loader_global_sym_lib_table.py -q`

## Notes
- Independent of PR #201 and PR #202: this touches only library-table parsing and related tests.
- Does not add new MCP tools or change public tool schemas.