### PR TITLE
feat(schematic): opt-in Windows interactive schematic reload

### DIFF
--- a/config/windows-config.example.json
+++ b/config/windows-config.example.json
@@ -8,6 +8,7 @@
         "PYTHONPATH": "C:\\Program Files\\KiCad\\9.0\\bin\\Lib\\site-packages",
         "LOG_LEVEL": "info",
         "KICAD_AUTO_LAUNCH": "false",
+        "KICAD_INTERACTIVE_SCHEMATIC": "false",
         "KICAD_MCP_DEV": "0"
       },
       "description": "KiCAD PCB Design Assistant - Note: PYTHONPATH auto-detected if venv exists"

--- a/docs/UI_AUTO_LAUNCH.md
+++ b/docs/UI_AUTO_LAUNCH.md
@@ -185,6 +185,7 @@ Claude:
 | Variable            | Default     | Description                    |
 | ------------------- | ----------- | ------------------------------ |
 | `KICAD_AUTO_LAUNCH` | `false`     | Auto-launch KiCAD when needed  |
+| `KICAD_INTERACTIVE_SCHEMATIC` | `false` | Windows only: after MCP schematic edits, send Revert to reload from disk (PID-scoped; never auto-confirms discard dialogs) |
 | `KICAD_EXECUTABLE`  | auto-detect | Override KiCAD executable path |
 
 ### Custom Executable Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ module = [
     "schematic",
     "PIL",
     "PIL.*",
+    "win32api",
+    "win32con",
+    "win32gui",
+    "win32process",
 ]
 ignore_missing_imports = true
 

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -26,6 +26,7 @@ from commands.library_schematic import LibraryManager as SchematicLibraryManager
 from commands.schematic import SchematicManager
 from commands.wire_manager import WireManager
 from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
+from utils.interactive_schematic import reload_kicad_schematic
 from utils.sexpr_format import dumps as kicad_dumps
 
 logger = logging.getLogger("kicad_interface")
@@ -96,6 +97,10 @@ class SchematicHandlersMixin:
     # mypy can resolve ``self.board`` when type-checking this module in isolation (the
     # module docstring notes the mixin relies on the host's ``self.board``).
     board: Any
+
+    def _reload_kicad_schematic(self) -> None:
+        """Opt-in: reload open Schematic Editor after external file edits (Windows)."""
+        reload_kicad_schematic()
 
     def _handle_create_schematic(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Create a new schematic"""
@@ -222,6 +227,8 @@ class SchematicHandlersMixin:
                 unit=unit,
                 project_path=derived_project_path,
             )
+
+            self._reload_kicad_schematic()
 
             return {
                 "success": True,
@@ -640,6 +647,7 @@ class SchematicHandlersMixin:
                 changes["propertiesRemoved"] = properties_removed
 
             logger.info(f"Edited schematic component {reference}: {changes}")
+            self._reload_kicad_schematic()
             return {"success": True, "reference": reference, "updated": changes}
 
         except Exception as e:
@@ -931,6 +939,7 @@ class SchematicHandlersMixin:
                 message = "Wire added successfully"
                 if snapped_info:
                     message += "; " + "; ".join(snapped_info)
+                self._reload_kicad_schematic()
                 return {"success": True, "message": message}
             else:
                 return {"success": False, "message": "Failed to add wire"}

--- a/python/utils/interactive_schematic.py
+++ b/python/utils/interactive_schematic.py
@@ -1,0 +1,240 @@
+"""Opt-in Windows interactive schematic reload after MCP file edits.
+
+Sends KiCad Schematic Editor Revert (reload from disk) and auto-confirms only
+the specific reload/revert dialog. Every window handle is PID-scoped to KiCad;
+destructive discard/unsaved dialogs are never auto-confirmed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from typing import Optional
+
+from utils.kicad_process import KiCADProcessManager
+
+logger = logging.getLogger("kicad_interface")
+
+INTERACTIVE_SCHEMATIC = os.environ.get("KICAD_INTERACTIVE_SCHEMATIC", "false").lower() == "true"
+
+if INTERACTIVE_SCHEMATIC:
+    logger.info("KiCAD interactive schematic reload enabled (KICAD_INTERACTIVE_SCHEMATIC=true)")
+
+REVERT_CMD_ID = 20236
+
+# Affirmative labels for reload-from-disk confirmation only.
+_AFFIRMATIVE_LABELS = frozenset(
+    {
+        "Yes",
+        "&Yes",
+        "OK",
+        "&OK",
+        "Ja",
+        "&Ja",
+        "Oui",
+        "&Oui",
+        "Reload",
+        "&Reload",
+        "Neu laden",
+        "&Neu laden",
+    }
+)
+
+# Never auto-click these — data-loss risk (#194 / #244).
+_DESTRUCTIVE_LABELS = frozenset(
+    {
+        "Discard",
+        "&Discard",
+        "Discard Changes",
+        "Don't Save",
+        "Do Not Save",
+        "Do not save",
+        "No",
+        "&No",
+        "Cancel",
+        "&Cancel",
+        "Abort",
+        "&Abort",
+        "Verwerfen",
+        "&Verwerfen",
+        "Nicht speichern",
+    }
+)
+
+_GENERIC_ONLY_TITLES = frozenset(
+    {
+        "Warning",
+        "Information",
+        "Confirmation",
+        "Warnung",
+        "Information",
+        "Bestätigung",
+        "KiCad",
+    }
+)
+
+# Title must match at least one reload-specific keyword (case-insensitive).
+_RELOAD_TITLE_KEYWORDS = re.compile(
+    r"(reload|revert|modified|changed|file change|schematic|"
+    r"neu laden|laden|geändert|verworfen|aktualis)",
+    re.IGNORECASE,
+)
+
+# Title keywords that indicate a discard-unsaved-work dialog — never auto-confirm.
+_DESTRUCTIVE_TITLE_KEYWORDS = re.compile(
+    r"(discard|unsaved|verwerfen|nicht speichern|lose changes|without saving)",
+    re.IGNORECASE,
+)
+
+
+def is_reload_confirmation_title(title: str) -> bool:
+    """True when title looks like a schematic reload/revert prompt, not a generic dialog."""
+    if not title or not title.strip():
+        return False
+    if title.strip() in _GENERIC_ONLY_TITLES:
+        return False
+    if _DESTRUCTIVE_TITLE_KEYWORDS.search(title):
+        return False
+    return bool(_RELOAD_TITLE_KEYWORDS.search(title))
+
+
+def has_destructive_button(labels: list[str]) -> bool:
+    return any(label in _DESTRUCTIVE_LABELS for label in labels)
+
+
+def choose_affirmative_button(labels: list[str]) -> Optional[str]:
+    for label in labels:
+        if label in _AFFIRMATIVE_LABELS:
+            return label
+    return None
+
+
+def reload_kicad_schematic() -> None:
+    """Reload open Schematic Editor from disk after an external MCP edit (Windows, opt-in)."""
+    if not INTERACTIVE_SCHEMATIC:
+        return
+    if os.name != "nt":
+        return
+
+    try:
+        import win32api
+        import win32con
+        import win32gui
+        import win32process
+    except ImportError:
+        logger.warning("pywin32 not available — interactive schematic reload disabled")
+        return
+
+    kicad_pids = KiCADProcessManager.get_running_pids()
+    if not kicad_pids:
+        logger.debug("reload_kicad_schematic: no KiCad process found")
+        return
+
+    def _hwnd_pid(hwnd: int) -> int:
+        _, pid = win32process.GetWindowThreadProcessId(hwnd)
+        return pid
+
+    def _owned_by_kicad(hwnd: int) -> bool:
+        try:
+            return _hwnd_pid(hwnd) in kicad_pids
+        except Exception:
+            return False
+
+    def _button_labels(hwnd: int) -> list[str]:
+        labels: list[str] = []
+
+        def _visit(child: int, _: object) -> None:
+            try:
+                text = win32gui.GetWindowText(child)
+                if text:
+                    labels.append(text)
+            except Exception:
+                pass
+
+        try:
+            win32gui.EnumChildWindows(hwnd, _visit, None)
+        except Exception:
+            pass
+        return labels
+
+    def _try_confirm_reload_dialog(hwnd: int, title: str) -> bool:
+        if not is_reload_confirmation_title(title):
+            return False
+        labels = _button_labels(hwnd)
+        if has_destructive_button(labels):
+            logger.warning(
+                "reload_kicad_schematic: refusing auto-confirm on destructive dialog "
+                f"'{title}' (buttons={labels!r})"
+            )
+            return False
+        affirmative = choose_affirmative_button(labels)
+        if not affirmative:
+            logger.debug(
+                f"reload_kicad_schematic: reload dialog '{title}' has no safe affirmative "
+                f"button (buttons={labels!r})"
+            )
+            return False
+        for child in _iter_child_buttons(hwnd):
+            if win32gui.GetWindowText(child) == affirmative:
+                win32api.PostMessage(child, win32con.BM_CLICK, 0, 0)
+                logger.info(
+                    f"reload_kicad_schematic: confirmed reload dialog '{title}' "
+                    f"via '{affirmative}' hwnd={hex(hwnd)}"
+                )
+                return True
+        return False
+
+    def _iter_child_buttons(hwnd: int):
+        buttons: list[int] = []
+
+        def _visit(child: int, _: object) -> None:
+            buttons.append(child)
+
+        try:
+            win32gui.EnumChildWindows(hwnd, _visit, None)
+        except Exception:
+            pass
+        return buttons
+
+    def _scan_reload_dialogs() -> bool:
+        confirmed = False
+
+        def _check(hwnd: int, _: object) -> None:
+            nonlocal confirmed
+            if confirmed:
+                return
+            if not win32gui.IsWindowVisible(hwnd) or not _owned_by_kicad(hwnd):
+                return
+            title = win32gui.GetWindowText(hwnd)
+            if _try_confirm_reload_dialog(hwnd, title):
+                confirmed = True
+
+        win32gui.EnumWindows(_check, None)
+        return confirmed
+
+    schematic_hwnd: Optional[int] = None
+
+    def _find_schematic(hwnd: int, _: object) -> None:
+        nonlocal schematic_hwnd
+        if schematic_hwnd is not None or not _owned_by_kicad(hwnd):
+            return
+        title = win32gui.GetWindowText(hwnd)
+        if "Schematic Editor" in title or title.lower() == "eeschema":
+            schematic_hwnd = hwnd
+
+    win32gui.EnumWindows(_find_schematic, None)
+    if schematic_hwnd is None:
+        logger.debug("reload_kicad_schematic: Schematic Editor window not found")
+        return
+
+    win32api.PostMessage(schematic_hwnd, win32con.WM_COMMAND, REVERT_CMD_ID, 0)
+    logger.info(f"reload_kicad_schematic: sent Revert to hwnd={hex(schematic_hwnd)}")
+
+    for _ in range(8):
+        time.sleep(0.15)
+        if _scan_reload_dialogs():
+            return
+
+    logger.debug("reload_kicad_schematic: no reload confirmation dialog appeared after Revert")

--- a/python/utils/interactive_schematic.py
+++ b/python/utils/interactive_schematic.py
@@ -75,10 +75,16 @@ _GENERIC_ONLY_TITLES = frozenset(
     }
 )
 
+# Main editor frames — not modal reload confirmations.
+_MAIN_WINDOW_TITLE_MARKERS = (
+    "Schematic Editor",
+    "eeschema",
+)
+
 # Title must match at least one reload-specific keyword (case-insensitive).
 _RELOAD_TITLE_KEYWORDS = re.compile(
-    r"(reload|revert|modified|changed|file change|schematic|"
-    r"neu laden|laden|geändert|verworfen|aktualis)",
+    r"(reload|revert|modified|changed|file change|"
+    r"neu laden|geändert|aktualis|reload schematic|schematic file|schematic modified)",
     re.IGNORECASE,
 )
 
@@ -94,6 +100,8 @@ def is_reload_confirmation_title(title: str) -> bool:
     if not title or not title.strip():
         return False
     if title.strip() in _GENERIC_ONLY_TITLES:
+        return False
+    if any(marker in title for marker in _MAIN_WINDOW_TITLE_MARKERS):
         return False
     if _DESTRUCTIVE_TITLE_KEYWORDS.search(title):
         return False
@@ -198,12 +206,12 @@ def reload_kicad_schematic() -> None:
             pass
         return buttons
 
-    def _scan_reload_dialogs() -> bool:
+    def _scan_reload_dialogs(skip_hwnd: Optional[int] = None) -> bool:
         confirmed = False
 
         def _check(hwnd: int, _: object) -> None:
             nonlocal confirmed
-            if confirmed:
+            if confirmed or hwnd == skip_hwnd:
                 return
             if not win32gui.IsWindowVisible(hwnd) or not _owned_by_kicad(hwnd):
                 return
@@ -234,7 +242,7 @@ def reload_kicad_schematic() -> None:
 
     for _ in range(8):
         time.sleep(0.15)
-        if _scan_reload_dialogs():
+        if _scan_reload_dialogs(skip_hwnd=schematic_hwnd):
             return
 
     logger.debug("reload_kicad_schematic: no reload confirmation dialog appeared after Revert")

--- a/python/utils/kicad_process.py
+++ b/python/utils/kicad_process.py
@@ -121,12 +121,7 @@ class KiCADProcessManager:
                 return result.returncode == 0
 
             elif system == "Windows":
-                processes = KiCADProcessManager._windows_list_processes()
-                for proc in processes:
-                    name = (proc.get("name") or "").lower()
-                    if name in ("pcbnew.exe", "kicad.exe"):
-                        return True
-                return False
+                return bool(KiCADProcessManager.get_running_pids())
 
             else:
                 logger.warning(f"Process detection not implemented for {system}")
@@ -135,6 +130,22 @@ class KiCADProcessManager:
         except Exception as e:
             logger.error(f"Error checking if KiCAD is running: {e}")
             return False
+
+    @staticmethod
+    def get_running_pids() -> set[int]:
+        """Return PIDs of running KiCad GUI processes (Windows only)."""
+        if platform.system() != "Windows":
+            return set()
+        names = {"kicad.exe", "pcbnew.exe", "eeschema.exe"}
+        pids: set[int] = set()
+        for proc in KiCADProcessManager._windows_list_processes():
+            if (proc.get("name") or "").lower() not in names:
+                continue
+            try:
+                pids.add(int(proc["pid"]))
+            except (TypeError, ValueError):
+                pass
+        return pids
 
     @staticmethod
     def get_executable_path() -> Optional[Path]:

--- a/tests/test_interactive_schematic.py
+++ b/tests/test_interactive_schematic.py
@@ -19,6 +19,8 @@ def test_reload_title_rejects_generic_or_destructive() -> None:
     assert not is_reload_confirmation_title("Confirmation")
     assert not is_reload_confirmation_title("Discard unsaved changes?")
     assert not is_reload_confirmation_title("Save changes before closing?")
+    assert not is_reload_confirmation_title("* FOG.kicad_sch - Schematic Editor")
+    assert not is_reload_confirmation_title("eeschema")
 
 
 def test_destructive_buttons_block_auto_confirm() -> None:

--- a/tests/test_interactive_schematic.py
+++ b/tests/test_interactive_schematic.py
@@ -1,0 +1,29 @@
+"""Tests for opt-in interactive schematic reload helpers."""
+
+from utils.interactive_schematic import (
+    choose_affirmative_button,
+    has_destructive_button,
+    is_reload_confirmation_title,
+)
+
+
+def test_reload_title_accepts_specific_prompts() -> None:
+    assert is_reload_confirmation_title("Schematic file modified — reload?")
+    assert is_reload_confirmation_title("Reload schematic from disk")
+    assert is_reload_confirmation_title("Datei geändert — neu laden")
+
+
+def test_reload_title_rejects_generic_or_destructive() -> None:
+    assert not is_reload_confirmation_title("Warning")
+    assert not is_reload_confirmation_title("Information")
+    assert not is_reload_confirmation_title("Confirmation")
+    assert not is_reload_confirmation_title("Discard unsaved changes?")
+    assert not is_reload_confirmation_title("Save changes before closing?")
+
+
+def test_destructive_buttons_block_auto_confirm() -> None:
+    assert has_destructive_button(["Discard", "Cancel"])
+    assert has_destructive_button(["Yes", "No"])
+    assert not has_destructive_button(["Yes", "OK"])
+    assert choose_affirmative_button(["Cancel", "Reload"]) == "Reload"
+    assert choose_affirmative_button(["Discard", "Cancel"]) is None

--- a/tests/test_interactive_schematic.py
+++ b/tests/test_interactive_schematic.py
@@ -1,6 +1,11 @@
 """Tests for opt-in interactive schematic reload helpers."""
 
-from utils.interactive_schematic import (
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from utils.interactive_schematic import (  # noqa: E402
     choose_affirmative_button,
     has_destructive_button,
     is_reload_confirmation_title,

--- a/tests/test_interactive_schematic.py
+++ b/tests/test_interactive_schematic.py
@@ -19,7 +19,7 @@ def test_reload_title_rejects_generic_or_destructive() -> None:
     assert not is_reload_confirmation_title("Confirmation")
     assert not is_reload_confirmation_title("Discard unsaved changes?")
     assert not is_reload_confirmation_title("Save changes before closing?")
-    assert not is_reload_confirmation_title("* FOG.kicad_sch - Schematic Editor")
+    assert not is_reload_confirmation_title("* board.kicad_sch - Schematic Editor")
     assert not is_reload_confirmation_title("eeschema")
 
 


### PR DESCRIPTION
## Summary

Opt-in Windows interactive schematic reload after MCP file edits — addresses PR #208 review (option 1: hardened auto-reload).

- **KICAD_INTERACTIVE_SCHEMATIC=true** (default off) enables reload after schematic add / edit / wire tools
- Sends Schematic Editor Revert (WM_COMMAND 20236), then auto-confirms only the reload/revert dialog
- No background dialog watcher — reload runs only on explicit post-edit hook

## Safety (per review)

| Requirement | Implementation |
|-------------|----------------|
| PID-scoped windows | KiCADProcessManager.get_running_pids() + GetWindowThreadProcessId on every hwnd |
| No generic dialogs | Rejects titles that are only Warning/Information/Confirmation; requires reload-specific keywords |
| No destructive auto-confirm | Skips dialogs with Discard/Don't Save/No/Cancel buttons or destructive title keywords |
| test_backend_metadata.py | Untouched — not deleted |

## Test plan

- [x] npm run build passes
- [x] tests/test_interactive_schematic.py (3 tests)
- [x] tests/test_backend_metadata.py still present and passing
- [ ] With KICAD_INTERACTIVE_SCHEMATIC=true on Windows: MCP add/edit component updates schematic without manual Revert
- [ ] Dialog offering discard of unsaved edits is not auto-confirmed