### PR TITLE
fix(windows): derive PYTHONPATH from the detected KiCAD python (#84)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -72,6 +72,29 @@ function getWindowsKiCadPythonCandidates(): string[] {
 }
 
 /**
+ * Derive the KiCAD bundled-Python site-packages path for a detected python.exe,
+ * so PYTHONPATH follows the *same* install we picked (any version, Program Files
+ * or per-user %LOCALAPPDATA%) instead of a hardcoded KiCad 9.0 path.
+ *
+ * KiCAD on Windows installs python at `<root>/<version>/bin/python.exe`, with
+ * pcbnew under `<...>/bin/Lib/site-packages` (older/alt layouts use
+ * `<version>/lib/python3/dist-packages`). Returns the first existing candidate,
+ * or undefined if pythonExe isn't a KiCAD bundled python.
+ */
+function deriveKiCadSitePackages(pythonExe: string): string | undefined {
+  if (process.platform !== "win32") return undefined;
+  const lower = pythonExe.toLowerCase();
+  if (!lower.endsWith("python.exe") || !lower.includes("kicad")) return undefined;
+  const binDir = dirname(pythonExe); // <root>/<version>/bin
+  const versionDir = dirname(binDir); // <root>/<version>
+  const candidates = [
+    join(binDir, "Lib", "site-packages"),
+    join(versionDir, "lib", "python3", "dist-packages"),
+  ];
+  return candidates.find((p) => existsSync(p));
+}
+
+/**
  * Find the Python executable to use.
  * Prioritizes project venvs, then explicit overrides, then KiCAD-bundled Python
  * before falling back to system Python.
@@ -475,12 +498,21 @@ export class KiCADMcpServer {
       if (!isValid) {
         throw new Error("Prerequisites validation failed. See logs above for details.");
       }
+      // PYTHONPATH precedence: explicit env override → site-packages derived
+      // from the detected KiCAD python (any version / install location) →
+      // legacy 9.0 fallback as a last resort.
+      const derivedSitePackages = deriveKiCadSitePackages(pythonExe);
+      if (derivedSitePackages && !process.env.PYTHONPATH) {
+        logger.info(`Using KiCAD site-packages: ${derivedSitePackages}`);
+      }
       this.pythonProcess = spawn(pythonExe, [this.kicadScriptPath], {
         stdio: ["pipe", "pipe", "pipe"],
         env: {
           ...process.env,
           PYTHONPATH:
-            process.env.PYTHONPATH || "C:/Program Files/KiCad/9.0/lib/python3/dist-packages",
+            process.env.PYTHONPATH ||
+            derivedSitePackages ||
+            "C:/Program Files/KiCad/9.0/lib/python3/dist-packages",
         },
       });
 


### PR DESCRIPTION
Addresses the recurring manual-fixup in #84.

## Problem
`findPythonExecutable` already auto-detects KiCAD's bundled python across versions (10.0/9.0/…) and across both `C:\Program Files\KiCad` and per-user `%LOCALAPPDATA%\Programs\KiCad`. But the Python subprocess spawn still defaulted `PYTHONPATH` to a hardcoded `C:/Program Files/KiCad/9.0/lib/python3/dist-packages`. So a KiCad 10 (or per-user) user whose `python.exe` was found correctly still got the wrong `PYTHONPATH` and a `pcbnew` import failure unless they set `PYTHONPATH` by hand — exactly the edits people keep posting in this thread.

## Fix
`deriveKiCadSitePackages(pythonExe)`: for a detected KiCAD python at `<root>/<version>/bin/python.exe`, return the matching site-packages (`<...>/bin/Lib/site-packages`, or the older `lib/python3/dist-packages` layout), verified to exist. Use it as the `PYTHONPATH` default.

Precedence (top wins): explicit `PYTHONPATH` env override → derived KiCAD site-packages → legacy 9.0 string as last resort. So it **cannot regress below current behavior** — it only improves the default when no env override is set.

Path math verified for both install locations:
- `…\Local\Programs\KiCad\10.0\bin\python.exe` → `…\Local\Programs\KiCad\10.0\bin\Lib\site-packages`
- `C:\Program Files\KiCad\10.0\bin\python.exe` → `C:\Program Files\KiCad\10.0\bin\Lib\site-packages`

`tsc` builds clean. Gated to Windows + a path containing `kicad`, so venv/system pythons are unaffected.

## Verification ask
I can't exercise a real KiCAD spawn in CI. @scorp508 / @66-firebat / @NiNjA-CodE — if any of you can run this branch on KiCad 10 (Program Files or per-user) **without** manually setting `PYTHONPATH` and confirm `pcbnew` imports, that's the confirmation I'd want before merging.