### PR TITLE
fix(server): close Python backend and exit gracefully when stdin closes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,12 @@ function parseCommandLineArgs(args: string[]) {
  * Setup graceful shutdown handlers
  */
 function setupGracefulShutdown(server: KiCADMcpServer) {
+  // Handle stdin close (EOF) when parent process exits
+  process.stdin.on("close", async () => {
+    logger.info("process.stdin closed. Shutting down...");
+    await shutdownServer(server);
+  });
+
   // Handle termination signals
   process.on("SIGINT", async () => {
     logger.info("Received SIGINT signal. Shutting down...");


### PR DESCRIPTION
### Description
This PR resolves a process leak (zombie Node and Python processes) that accumulates over time when using specific Model Context Protocol clients.

### Context & Problem
While some CLI clients (like `claude-code`) automatically force-terminate children on exit, the new `antigravity-cli` (released in May 2026) handles sessions differently: when a session is closed or exited (via `/quit`), the client closes the `stdin` stream of the Node.js server but does not force-kill the process. 

Since the KiCad MCP Node.js server spawns and communicates with a child Python process (`kicad_interface.py`), the active process loop prevents the Node.js process from exiting naturally on EOF, leaving both `node` and `python` zombie processes dangling in memory. Over multiple assistant sessions, this accumulates indefinitely.

### Solution
Added an explicit listener to `process.stdin` for the `close` event inside the `setupGracefulShutdown` handler:
```typescript
process.stdin.on("close", async () => {
  logger.info("process.stdin closed. Shutting down...");
  await shutdownServer(server);
});
```
This ensures that as soon as the client closes the STDIO pipe, the Node.js server gracefully triggers `server.stop()`, kills the Python child process, and exits cleanly.
