### PR TITLE
fix: connect MCP transport before warm-up to prevent client timeout

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -538,14 +538,13 @@ export class KiCADMcpServer {
         });
       }
 
-      // ——— Phase 2: wait for Python READY, then send warm-up ———
+      // ——— Phase 2: wait for Python READY ———
       logger.info("Waiting for Python process to be ready...");
       await this.waitForReady(120_000);
-      logger.info("Python process is ready. Sending warm-up command...");
-      await this.runWarmup(120_000);
-      logger.info("Warm-up complete — pcbnew/wxApp initialised");
-
-      // ——— Phase 3: only now connect to MCP transport ———
+      logger.info("Python process is ready.");
+      // ——— Phase 3: connect MCP transport immediately ———
+      // The transport must be live before any client timeout fires,
+      // regardless of how long warm-up takes.
       logger.info("Connecting MCP server to STDIO transport...");
       try {
         await this.server.connect(this.stdioTransport);
@@ -554,6 +553,14 @@ export class KiCADMcpServer {
         logger.error(`Failed to connect to STDIO transport: ${error}`);
         throw error;
       }
+      // ——— Phase 4: background warm-up (does not block MCP) ———
+      // Warm-up can take 55-125 s (wxApp + symbol library parse), but
+      // the MCP transport is already live so the client timeout does not
+      // apply.  Tools invoked during warm-up will work; the first
+      // search_symbols may be slower if warm-up hasn't completed yet.
+      logger.info("Sending warm-up command (background)...");
+      await this.runWarmup(120_000);
+      logger.info("Warm-up complete — pcbnew/wxApp initialised");
 
 
       // Write a ready message to stderr (for debugging)


### PR DESCRIPTION
## Problem

On macOS cold-start, the MCP client has a **30s connection timeout**. The startup sequence in `server.ts` connects the MCP transport only **after** warm-up completes (55–125s). The client kills the node process before the transport ever connects.

PR #210 fixed the Python-side by daemon-threading `_warm_cache`, but the Node-side still blocks transport connect on warm-up completion:

```
Phase 2: wait for READY → warm-up (55-125s, blocks)  ← client timeout fires here
Phase 3: connect MCP transport                        ← never reached
```

## Fix

Swap phases — connect transport **before** warm-up:

```
Phase 2: wait for READY                    (~0.7s)
Phase 3: connect MCP transport             (instant)
Phase 4: warm-up — pcbnew + symbol cache   (background, does not block MCP)
```

One file changed: `src/server.ts` — reorder the startup phases, no logic changes.

## Verified on macOS (Apple Silicon, KiCad 10.0.1)

| Metric | Before (main) | After (this PR) |
|---|---|---|
| Python init | ~0.7s | ~0.7s |
| MCP transport connect | After warm-up (55-125s) | **Instant** (before warm-up) |
| Warm-up | Blocks transport | Runs in background |
| `KiCAD MCP SERVER READY` | After warm-up | After warm-up (unchanged) |

Startup log confirming the new ordering:
```
18:46:03,784  Waiting for Python process to be ready...
18:46:04,460  Python process is ready.              ← +0.7s
18:46:04,460  Connecting MCP server to STDIO transport...
18:46:04,461  Successfully connected to STDIO transport  ← instant
18:46:04,461  Sending warm-up command (background)...
18:46:04,516  Warm-up complete — pcbnew/wxApp initialised
18:46:04,516  KiCAD MCP SERVER READY
```

## Test suite

Full suite run on macOS (Apple Silicon), `fix/transport-before-warmup` branch:

```
874 passed, 19 failed, 11 skipped in 2533.79s (42m)
```

All 19 failures are **pre-existing** — unrelated to this change:

| Test file | Failures | Root cause |
|---|---|---|
| `test_auto_save_guard.py` | 7 | `pcbnew` not importable outside KiCad process |
| `test_swig_dehydration.py` | 5 | `pcbnew` not importable outside KiCad process |
| `test_sync_schematic_to_board_footprints.py` | 5 | `pcbnew` not importable outside KiCad process |
| `test_mil_unit_support.py` | 1 | Pre-existing: `mil` missing from schema enum |
| `test_schematic_field_justify.py` | 1 | Pre-existing schema mismatch |

**0 new failures.** TypeScript compiles clean (`tsc --noEmit` passes, `npm run build` succeeds).

## Relationship to other PRs

- **PR #210** (merged): fixed Python-side by daemon-threading `_warm_cache` + fixing the O(n²) paren parser. This PR fixes the complementary Node-side transport ordering that #210 did not touch.
- **PR #206** (open, mine): this is a clean extract of the surviving `server.ts` change from #206. All Python-side changes in #206 are now covered by #210. **#206 can be closed.**

Closes #206.