### PR TITLE
fix(schemas): include mil in the remaining unit enums

### DIFF
--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -311,7 +311,7 @@ BOARD_TOOLS = [
                         "y": {"type": "number", "description": "Y coordinate"},
                         "unit": {
                             "type": "string",
-                            "enum": ["mm", "inch"],
+                            "enum": ["mm", "mil", "inch"],
                             "default": "mm",
                             "description": "Unit for x/y (default mm)",
                         },
@@ -793,7 +793,7 @@ COMPONENT_TOOLS = [
                         "y2": {"type": "number"},
                         "unit": {
                             "type": "string",
-                            "enum": ["mm", "inch"],
+                            "enum": ["mm", "mil", "inch"],
                             "default": "mm",
                         },
                     },
@@ -1022,7 +1022,7 @@ ROUTING_TOOLS = [
                         "y2": {"type": "number", "description": "Bottom Y coordinate"},
                         "unit": {
                             "type": "string",
-                            "enum": ["mm", "inch"],
+                            "enum": ["mm", "mil", "inch"],
                             "default": "mm",
                         },
                     },


### PR DESCRIPTION
`test_mil_unit_support` is currently red on main: `add_mounting_hole`, `check_courtyard_overlaps`, and `query_zones` still only allow `mm`/`inch` in their `unit` enums, while `test_python_tool_schema_unit_enums_include_mil` expects every unit enum to include mil.

mil itself already works everywhere else, the nm scaling and the IPC position conversion both handle it.