### PR TITLE
fix(board-view): frame get_board_2d_view to the board, not the A4 sheet

### DIFF
--- a/python/commands/board/view.py
+++ b/python/commands/board/view.py
@@ -198,6 +198,14 @@ class BoardViewCommands:
                     output_svg,
                     "--mode-single",
                     "--black-and-white",
+                    # Render the board, not the drawing sheet. kicad-cli's
+                    # default (page-size-mode 0) plots only the area inside the
+                    # sheet, so board geometry past the page edge is left out.
+                    # Mode 2 sizes the output to the board's bounding box;
+                    # --exclude-drawing-sheet drops the title block.
+                    "--exclude-drawing-sheet",
+                    "--page-size-mode",
+                    "2",
                 ]
                 if layers:
                     cmd += ["--layers", ",".join(layers)]

--- a/tests/test_get_board_2d_view_save_to_file.py
+++ b/tests/test_get_board_2d_view_save_to_file.py
@@ -80,6 +80,19 @@ def test_inline_png_returns_base64_image_data(tmp_path):
 
 
 @pytest.mark.unit
+def test_export_frames_to_board_area(tmp_path):
+    """The export drops the drawing sheet and crops to the board area, so a small
+    board isn't rendered on a mostly-empty A4 page (kicad-cli's default)."""
+    cmd, root, board_path = _make_view_cmd(tmp_path)
+    w1, w2, w3 = _patch_kicad_cli(root)
+    with w1, w2 as run, w3, patch("commands.board.view._svg_to_png", return_value=_FAKE_PNG):
+        cmd.get_board_2d_view({"pcbPath": str(board_path), "format": "png"})
+    argv = run.call_args[0][0]
+    assert "--exclude-drawing-sheet" in argv
+    assert argv[argv.index("--page-size-mode") + 1] == "2"
+
+
+@pytest.mark.unit
 def test_inline_svg_returns_base64_image_data(tmp_path):
     """responseMode='inline' with format='svg' returns base64-encoded SVG in imageData."""
     cmd, root, board_path = _make_view_cmd(tmp_path)


### PR DESCRIPTION
`get_board_2d_view` exports with kicad-cli's default `--page-size-mode 0` (the full drawing sheet), which plots only what fits inside the sheet. A board that extends past the page edge is **silently clipped** -- part of the board is missing from the image -- and even a board that fits is rendered small on a mostly-empty page.

`--exclude-drawing-sheet` and `--page-size-mode 2` (board area only) size the output to the board's bounding box, so the whole board renders, framed tightly.

Both flags have existed since KiCad 7 (confirmed in the 9.0 CLI docs), so the change is safe across KiCad 7-10. One caveat: `--page-size-mode` is a no-op on KiCad 9.0.0 (KiCad #20014), where you get the drawing-sheet removal but not the crop. It works fully on 9.0.1+ and 10.
