### PR TITLE
fix: center global/hierarchical labels vertically (omit 'bottom' justification)

### DIFF
--- a/python/commands/wire_manager.py
+++ b/python/commands/wire_manager.py
@@ -318,6 +318,10 @@ class WireManager:
             # Orientation-aware justify: KiCAD flips horizontal alignment for 180°/270°
             justify_h = Symbol("right") if orientation in (180, 270) else Symbol("left")
 
+            justify_expr = [Symbol("justify"), justify_h]
+            if label_type == "label":
+                justify_expr.append(Symbol("bottom"))
+
             label_sexp = [
                 Symbol(label_type),
                 text,
@@ -325,7 +329,7 @@ class WireManager:
                 [
                     Symbol("effects"),
                     [Symbol("font"), [Symbol("size"), 1.27, 1.27]],
-                    [Symbol("justify"), justify_h, Symbol("bottom")],
+                    justify_expr,
                 ],
                 [Symbol("uuid"), str(uuid.uuid4())],
             ]


### PR DESCRIPTION
### Description
This PR fixes the vertical misalignment (shifting/collisions) of global and hierarchical labels created via the KiCad MCP Server.

In KiCad, local labels have their connection hook points at the baseline of the text, so they require the `bottom` justification property `(justify <left/right> bottom)` to float correctly above wires. However, global and hierarchical labels have their connection points vertically centered relative to their graphical outlines (boxes/arrows). Applying `bottom` justification to them shifts their text upward/downward, causing collision with their graphical borders.

This change restricts `Symbol("bottom")` to local labels only. Global and hierarchical labels now omit the vertical parameter inside their `(effects (justify ...))` expression, which defaults to standard vertical centering in KiCad.

### Verification
Verified that:
- Local labels (`label`) are created with `(justify <left/right> bottom)`.
- Global and hierarchical labels are created with `(justify <left/right>)` and render vertically centered.
