### PR TITLE
fix(backend): pin SWIG/IPC backend per loaded project (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **Backend is now pinned per loaded project (SWIG vs IPC)** (#223): commands
+  on a single loaded project previously ran on whichever backend happened to
+  be reachable per call — `create_project`/`open_project`/`add_layer` on SWIG
+  while `save_project` silently upgraded to IPC, saving the live GUI's (stale)
+  board and losing the SWIG-side edits. Now `open_project` pins the session to
+  IPC only when the GUI provably has the same `.kicad_pcb` open; otherwise the
+  whole lifecycle (including `save_project`) stays on SWIG, with a
+  `_backend_note` on responses explaining why IPC wasn't used. IPC-pinned
+  sessions fall back to SWIG (reloading from disk) if the GUI connection
+  drops. `get_backend_state` gains `sessionBackend`/`sessionBoardPath`, and
+  its `backend` field reflects the session pin while a project is loaded.
+
 - **`rotate_component` now treats `angle` as an absolute target rotation**,
   matching its schema description. Previously the IPC backend added the
   supplied angle to the current rotation, so two consecutive

--- a/docs/IPC_BACKEND_STATUS.md
+++ b/docs/IPC_BACKEND_STATUS.md
@@ -152,6 +152,30 @@ Use `check_kicad_ui`, `launch_kicad_ui`, or `get_backend_info` to inspect the
 current live backend status. These responses include `backend`,
 `realtime_sync`, and `ipc_connected`.
 
+### Session Pinning (issue #223)
+
+Once a project is loaded, its entire lifecycle is **pinned to one backend**
+until it is reopened:
+
+- `open_project` pins the session to **ipc** only when the live KiCad GUI
+  provably has the *same* `.kicad_pcb` open (path comparison via the IPC
+  open-documents list). Otherwise — including every `create_project`, since
+  the GUI cannot have a brand-new board open — the session pins to **swig**.
+- A **swig-pinned session never silently upgrades to IPC**, even if KiCad
+  starts later and IPC connects. The GUI's in-memory board would be stale
+  relative to the MCP's edits, and routing `save_project` through IPC would
+  clobber them — the exact lost-edits bug in #223. Affected responses carry a
+  `_backend_note` explaining the pin; to adopt the live GUI, open the board in
+  KiCad and call `open_project` again.
+- An **ipc-pinned session falls back to swig** if the IPC connection drops
+  (e.g. the GUI is closed); the board is reloaded from its last on-disk state.
+- `get_backend_state` reports the pin as `sessionBackend` /
+  `sessionBoardPath`, and its `backend` field reflects the session pin (not
+  just connectivity) whenever a project is loaded.
+
+The runtime-reconnect workflow above still applies when **no project is
+loaded** — connectivity upgrades are only restricted once a board is open.
+
 ### Testing
 
 Run the test script to verify IPC functionality:
@@ -199,7 +223,10 @@ Run the test script to verify IPC functionality:
 4. **Delete trace**: Falls back to SWIG (IPC API doesn't support direct deletion)
 5. **Reconnect still requires IPC prerequisites**: Runtime reconnect only
    succeeds when KiCAD is running with IPC enabled and a board is available
-6. **Some operations may not work as expected**: This is experimental code
+6. **SWIG-pinned sessions stay SWIG**: after `create_project`/`open_project`
+   runs on SWIG, the session does not switch to IPC mid-project (see Session
+   Pinning above) — reopen the project while it is open in the GUI to use IPC
+7. **Some operations may not work as expected**: This is experimental code
 
 ## Troubleshooting
 

--- a/python/kicad_api/ipc_backend.py
+++ b/python/kicad_api/ipc_backend.py
@@ -155,6 +155,22 @@ class IPCBackend(KiCADBackend):
         """Get KiCAD version."""
         return self._version or "unknown"
 
+    def get_open_board_path(self) -> Optional[str]:
+        """Path of the .kicad_pcb currently open in the live KiCad GUI, if any.
+
+        Used to decide whether the GUI session and the MCP's loaded board refer
+        to the same file before routing commands over IPC (issue #223).
+        """
+        if not self.is_connected():
+            return None
+        try:
+            for doc in self._kicad.get_open_documents():
+                if hasattr(doc, "path") and str(doc.path).endswith(".kicad_pcb"):
+                    return str(doc.path)
+        except Exception as e:
+            logger.debug(f"Could not read open documents via IPC: {e}")
+        return None
+
     def register_change_callback(self, callback: Callable) -> None:
         """Register a callback to be called when changes are made."""
         self._on_change_callbacks.append(callback)

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -361,6 +361,12 @@ class KiCADInterface(SchematicHandlersMixin):
         self.use_ipc = USE_IPC_BACKEND
         self.ipc_backend = ipc_backend
         self.ipc_board_api = None
+        # Session backend pin (issue #223): once a project is loaded, every
+        # board command runs on the backend that owns that load ("swig" or
+        # "ipc") until the project is closed or reopened. None = no project
+        # loaded yet; commands then follow connectivity-based routing.
+        self.session_backend: Optional[str] = None
+        self.session_board_path: Optional[str] = None
 
         if self.use_ipc:
             logger.info("Initializing with IPC backend (real-time UI sync enabled)")
@@ -658,6 +664,86 @@ class KiCADInterface(SchematicHandlersMixin):
         "ipc_save_board",
     }
 
+    @staticmethod
+    def _normalize_board_path(path: Any) -> Optional[str]:
+        """Normalize a board file path for cross-backend comparison."""
+        if not path:
+            return None
+        return os.path.normcase(os.path.normpath(os.path.abspath(str(path))))
+
+    def _ipc_board_path_matches(self, path: Any) -> bool:
+        """True when the live KiCad GUI has the same .kicad_pcb open as `path`."""
+        target = self._normalize_board_path(path)
+        if not target:
+            return False
+        backend = getattr(self, "ipc_backend", None)
+        if not backend:
+            return False
+        try:
+            open_path = backend.get_open_board_path()
+        except Exception as e:
+            logger.debug(f"Could not compare IPC board path: {e}")
+            return False
+        return self._normalize_board_path(open_path) == target
+
+    def _pin_session_backend(self, board_path: Any) -> None:
+        """Pin the loaded project's lifecycle to one backend (issue #223).
+
+        Called after a successful create_project/open_project. Pins "ipc" only
+        when the live GUI provably has the SAME board open; otherwise "swig".
+        Once pinned to "swig", the session never silently upgrades to IPC —
+        the GUI's in-memory board may be stale relative to our edits, so an
+        IPC save could clobber them (the exact lost-edits bug in #223).
+        """
+        self.session_board_path = self._normalize_board_path(board_path)
+        # Give IPC a chance even if the startup probe ran before the GUI did.
+        self._try_enable_ipc_backend()
+        backend = getattr(self, "ipc_backend", None)
+        if (
+            self.use_ipc
+            and backend
+            and backend.is_connected()
+            and self._ipc_board_path_matches(self.session_board_path)
+        ):
+            self.session_backend = "ipc"
+            self._refresh_ipc_board_api()
+        else:
+            self.session_backend = "swig"
+        logger.info(
+            "Session backend pinned to %s for %s", self.session_backend, self.session_board_path
+        )
+
+    def _session_allows_ipc(self) -> bool:
+        """Whether the session pin permits routing board commands over IPC."""
+        return getattr(self, "session_backend", None) != "swig"
+
+    def _ipc_session_alive(self) -> bool:
+        backend = getattr(self, "ipc_backend", None)
+        return bool(backend and backend.is_connected())
+
+    def _downgrade_session_to_swig(self) -> None:
+        """Fall back to SWIG when an IPC-pinned session loses its connection.
+
+        Reloads the board from disk so SWIG operates on the last-saved state
+        rather than a stale pre-IPC copy.
+        """
+        logger.warning(
+            "IPC connection lost for the pinned session; falling back to SWIG " "for %s",
+            self.session_board_path,
+        )
+        path = self.session_board_path
+        if path and os.path.exists(path):
+            recovered = self._safe_load_board(path)
+            if recovered is not None:
+                self.board = recovered
+                project_commands = getattr(self, "project_commands", None)
+                if project_commands is not None:
+                    project_commands.board = recovered
+                self._update_command_handlers()
+                self._record_board_signature()
+        self.session_backend = "swig"
+        self.ipc_board_api = None
+
     def _refresh_ipc_board_api(self) -> bool:
         """Refresh the IPC board API after KiCAD or a board becomes available."""
         ipc_backend = getattr(self, "ipc_backend", None)
@@ -703,12 +789,20 @@ class KiCADInterface(SchematicHandlersMixin):
             return False
 
     def _backend_status(self) -> Dict[str, Any]:
-        """Return backend status fields for command responses."""
+        """Return backend status fields for command responses.
+
+        When a project is loaded, the session pin is the truth about which
+        backend serves board commands — reporting connectivity alone misled
+        users in #223 (get_backend_state said "ipc" while every project
+        command actually ran on SWIG).
+        """
         ipc_backend = getattr(self, "ipc_backend", None)
         ipc_connected = ipc_backend.is_connected() if ipc_backend else False
+        session = getattr(self, "session_backend", None)
+        backend = session or ("ipc" if self.use_ipc and ipc_connected else "swig")
         return {
-            "backend": "ipc" if self.use_ipc and ipc_connected else "swig",
-            "realtime_sync": self.use_ipc and ipc_connected,
+            "backend": backend,
+            "realtime_sync": backend == "ipc" and ipc_connected,
             "ipc_connected": ipc_connected,
         }
 
@@ -741,11 +835,26 @@ class KiCADInterface(SchematicHandlersMixin):
         logger.debug(f"Command parameters: {params}")
 
         try:
-            if command in self.IPC_CAPABLE_COMMANDS:
+            if command in self.IPC_CAPABLE_COMMANDS and self._session_allows_ipc():
                 self._try_enable_ipc_backend()
+                # An IPC-pinned session whose connection died (GUI closed)
+                # falls back to SWIG on the last-saved on-disk state.
+                if (
+                    getattr(self, "session_backend", None) == "ipc"
+                    and not self._ipc_session_alive()
+                ):
+                    self._downgrade_session_to_swig()
 
-            # Check if we can use IPC for this command (real-time UI sync)
-            if self.use_ipc and self.ipc_board_api and command in self.IPC_CAPABLE_COMMANDS:
+            # Check if we can use IPC for this command (real-time UI sync).
+            # A session pinned to SWIG never routes board commands over IPC,
+            # even when IPC is connected — the GUI may hold a stale copy of
+            # the board and an IPC save would clobber our edits (#223).
+            if (
+                self.use_ipc
+                and self.ipc_board_api
+                and command in self.IPC_CAPABLE_COMMANDS
+                and self._session_allows_ipc()
+            ):
                 ipc_handler_name = self.IPC_CAPABLE_COMMANDS[command]
                 ipc_handler = getattr(self, ipc_handler_name, None)
 
@@ -762,7 +871,7 @@ class KiCADInterface(SchematicHandlersMixin):
                     return result
 
             # Fall back to SWIG-based handler
-            if self.use_ipc and command in self.IPC_CAPABLE_COMMANDS:
+            if self.use_ipc and command in self.IPC_CAPABLE_COMMANDS and self._session_allows_ipc():
                 logger.warning(
                     f"IPC handler not available for {command}, falling back to SWIG (deprecated)"
                 )
@@ -782,6 +891,20 @@ class KiCADInterface(SchematicHandlersMixin):
                     result["_realtime"] = bool(
                         backend == "ipc" and result.get("realtime", self.use_ipc)
                     )
+                    # Explain why an IPC-capable command ran on SWIG while IPC
+                    # was connected: the session is pinned (#223).
+                    if (
+                        command in self.IPC_CAPABLE_COMMANDS
+                        and getattr(self, "session_backend", None) == "swig"
+                        and self.use_ipc
+                        and self._ipc_session_alive()
+                    ):
+                        result["_backend_note"] = (
+                            "session pinned to swig: the project was loaded via SWIG "
+                            "and the live KiCad GUI does not hold this board, so IPC "
+                            "is not used to avoid divergent board state (issue #223). "
+                            "Reopen the project while it is open in the GUI to pin IPC."
+                        )
 
                 # Update board reference if command was successful
                 if result.get("success", False):
@@ -836,6 +959,13 @@ class KiCADInterface(SchematicHandlersMixin):
                         # overwrite them.
                         self._record_board_signature()
                         self._last_auto_save_status = None
+                        # Pin the session to one backend for this project's
+                        # lifetime (#223). Reports the pin on the result so
+                        # callers can see which backend owns the session.
+                        self._pin_session_backend(self._current_board_path())
+                        result["_backend"] = self.session_backend
+                        result["_realtime"] = self.session_backend == "ipc"
+                        result["sessionBackend"] = self.session_backend
                     elif command == "save_project":
                         self._record_board_signature()
                         self._last_auto_save_status = None
@@ -4977,6 +5107,8 @@ print("ok")
             "loadedBoard": loaded_board,
             "projectPath": project_path,
             "boardPath": board_path,
+            "sessionBackend": getattr(self, "session_backend", None),
+            "sessionBoardPath": getattr(self, "session_board_path", None),
             "dirty": dirty_state["dirty"],
             "dirtyReason": dirty_state["dirtyReason"],
             "diskChangedExternally": dirty_state["diskChangedExternally"],

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -741,6 +741,15 @@ class KiCADInterface(SchematicHandlersMixin):
                     project_commands.board = recovered
                 self._update_command_handlers()
                 self._record_board_signature()
+            else:
+                logger.error(
+                    "Downgrade to SWIG could not reload the board from %s — "
+                    "subsequent SWIG commands operate on the pre-IPC in-memory "
+                    "state, which may be stale",
+                    path,
+                )
+        elif path:
+            logger.warning("Downgrade to SWIG: board file is no longer accessible at %s", path)
         self.session_backend = "swig"
         self.ipc_board_api = None
 
@@ -935,6 +944,12 @@ class KiCADInterface(SchematicHandlersMixin):
                                     "recovered via pcbnew module reload"
                                 )
                             else:
+                                # The load failed for good — drop any pin left
+                                # over from a previously loaded project so a
+                                # stale "ipc" pin can't route later commands
+                                # to the old board's IPC context (#223).
+                                self.session_backend = None
+                                self.session_board_path = None
                                 # Surface the truth — never claim success when
                                 # the board is unusable.
                                 return {
@@ -5229,16 +5244,36 @@ print("ok")
             return {"success": False, "message": str(e)}
 
     def _handle_ipc_save_board(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        """Save board using IPC backend"""
+        """Save board using IPC backend.
+
+        Explicit ipc_* commands deliberately bypass the session pin (#223) —
+        the caller is asking for IPC by name. In a SWIG-pinned session this
+        can overwrite SWIG-side edits with the GUI's board state, so warn.
+        """
         if not self.use_ipc or not self.ipc_board_api:
             return {"success": False, "message": "IPC backend not available"}
 
+        result_note = None
+        if getattr(self, "session_backend", None) == "swig":
+            logger.warning(
+                "ipc_save_board called in a SWIG-pinned session — this bypasses "
+                "the session pin and may overwrite SWIG edits with the GUI "
+                "board state (#223)"
+            )
+            result_note = (
+                "session is pinned to swig; ipc_save_board bypassed the pin and "
+                "saved the GUI's board state, which may not include SWIG-side edits"
+            )
+
         try:
             success = self.ipc_board_api.save()
-            return {
+            result = {
                 "success": success,
                 "message": "Board saved" if success else "Failed to save board",
             }
+            if result_note:
+                result.setdefault("warnings", []).append(result_note)
+            return result
         except Exception as e:
             logger.error(f"Error saving board via IPC: {e}")
             return {"success": False, "message": str(e)}

--- a/tests/test_backend_session_pinning.py
+++ b/tests/test_backend_session_pinning.py
@@ -224,6 +224,32 @@ class TestSessionTransitions:
         assert iface.session_backend == "swig"
         assert result["_backend"] == "swig"
         assert holder.get("swig_saves") == 1
+        # The board must be RELOADED from disk, not left as the stale
+        # pre-IPC copy.
+        assert isinstance(iface.board, _FakeBoard)
+        assert iface.board.GetFileName() == iface.session_board_path
+
+    def test_failed_reopen_clears_stale_pin(self, tmp_path, monkeypatch):
+        """An unrecoverable open after a pinned session must drop the old pin.
+
+        Otherwise a leftover "ipc" pin from the previous project could route
+        later commands to the old board's IPC context.
+        """
+        board_path = tmp_path / "proj" / "proj.kicad_pcb"
+        iface, backend, holder, _, _ = _loaded_iface(
+            tmp_path, gui_board_path=board_path, monkeypatch=monkeypatch
+        )
+        assert iface.session_backend == "ipc"
+
+        # Next open succeeds at the handler level but the board is
+        # SWIG-dehydrated and recovery fails.
+        iface._is_board_healthy = lambda *a, **k: False
+        iface._safe_load_board = lambda path: None
+
+        result = iface.handle_command("open_project", {"path": str(board_path)})
+        assert result["success"] is False
+        assert iface.session_backend is None
+        assert iface.session_board_path is None
 
     def test_reopen_repins(self, tmp_path, monkeypatch):
         iface, backend, holder, board_path, _ = _loaded_iface(

--- a/tests/test_backend_session_pinning.py
+++ b/tests/test_backend_session_pinning.py
@@ -1,0 +1,273 @@
+"""Tests for the session-pinned backend (issue #223).
+
+Once a project is loaded, every board command must run on the backend that
+owns that load ("swig" or "ipc") until the project is closed/reopened. Before
+this fix, create_project/open_project always ran on SWIG while save_project
+silently upgraded to IPC mid-session and saved the GUI's (stale) board —
+losing the SWIG edits.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+import kicad_interface  # noqa: E402
+from kicad_interface import KiCADInterface, KiCADProcessManager  # noqa: E402
+
+
+class _FakeBoard:
+    def __init__(self, filename):
+        self._filename = str(filename)
+
+    def GetFileName(self):
+        return self._filename
+
+
+class _FakeIPCBoardAPI:
+    def get_size(self):
+        return {"width": 10, "height": 20, "unit": "mm"}
+
+
+class _FakeIPCBackend:
+    def __init__(self, open_board_path=None, connected=True):
+        self.connected = connected
+        self.open_board_path = open_board_path
+        self.save_calls = 0
+
+    def connect(self):
+        self.connected = True
+        return True
+
+    def is_connected(self):
+        return self.connected
+
+    def get_board(self):
+        return _FakeIPCBoardAPI()
+
+    def get_open_board_path(self):
+        return self.open_board_path
+
+    def get_version(self):
+        return "10.0-test"
+
+
+def _make_iface(command_routes, ipc_backend, use_ipc=True, board=None):
+    iface = KiCADInterface.__new__(KiCADInterface)
+    iface.use_ipc = use_ipc
+    iface.ipc_backend = ipc_backend
+    iface.ipc_board_api = None
+    iface.board = board
+    iface.command_routes = command_routes
+    iface._board_disk_signature = None
+    iface._current_project_path = None
+    iface._last_auto_save_status = None
+    iface.session_backend = None
+    iface.session_board_path = None
+    # Neutralize machinery irrelevant to routing decisions.
+    iface._is_board_healthy = lambda *a, **k: True
+    iface._update_command_handlers = lambda: None
+    iface._record_board_signature = lambda: None
+    return iface
+
+
+def _project_routes(iface_holder, board_path):
+    """command_routes with fake SWIG create/open/save handlers."""
+
+    def create_project(params):
+        board = _FakeBoard(board_path)
+        iface_holder["iface"].project_commands.board = board
+        return {"success": True, "project": {"boardPath": str(board_path)}}
+
+    def save_project(params):
+        iface_holder["swig_saves"] = iface_holder.get("swig_saves", 0) + 1
+        return {"success": True, "message": "saved via swig"}
+
+    return {
+        "create_project": create_project,
+        "open_project": create_project,
+        "save_project": save_project,
+    }
+
+
+class _ProjectCommandsStub:
+    board = None
+
+
+def _loaded_iface(tmp_path, gui_board_path, monkeypatch, connected=True):
+    """Build an interface and run open_project through handle_command."""
+    board_path = tmp_path / "proj" / "proj.kicad_pcb"
+    board_path.parent.mkdir(parents=True, exist_ok=True)
+    board_path.write_text("(kicad_pcb)")
+
+    holder = {}
+    backend = _FakeIPCBackend(
+        open_board_path=str(gui_board_path) if gui_board_path else None,
+        connected=connected,
+    )
+    routes = _project_routes(holder, board_path)
+    iface = _make_iface(routes, backend)
+    iface.project_commands = _ProjectCommandsStub()
+    holder["iface"] = iface
+    monkeypatch.setattr(KiCADProcessManager, "is_running", staticmethod(lambda: False))
+
+    result = iface.handle_command("open_project", {"path": str(board_path)})
+    assert result["success"] is True
+    return iface, backend, holder, board_path, result
+
+
+@pytest.mark.unit
+class TestSessionPinning:
+    def test_open_without_matching_gui_board_pins_swig(self, tmp_path, monkeypatch):
+        iface, _, _, _, result = _loaded_iface(
+            tmp_path, gui_board_path=None, monkeypatch=monkeypatch
+        )
+        assert iface.session_backend == "swig"
+        assert result["_backend"] == "swig"
+        assert result["sessionBackend"] == "swig"
+
+    def test_open_with_different_gui_board_pins_swig(self, tmp_path, monkeypatch):
+        other = tmp_path / "other" / "other.kicad_pcb"
+        iface, _, _, _, _ = _loaded_iface(tmp_path, gui_board_path=other, monkeypatch=monkeypatch)
+        assert iface.session_backend == "swig"
+
+    def test_open_with_matching_gui_board_pins_ipc(self, tmp_path, monkeypatch):
+        board_path = tmp_path / "proj" / "proj.kicad_pcb"
+        iface, _, _, _, result = _loaded_iface(
+            tmp_path, gui_board_path=board_path, monkeypatch=monkeypatch
+        )
+        assert iface.session_backend == "ipc"
+        assert result["_backend"] == "ipc"
+        assert result["_realtime"] is True
+
+    def test_path_match_is_case_and_separator_insensitive(self, tmp_path, monkeypatch):
+        board_path = tmp_path / "proj" / "proj.kicad_pcb"
+        sloppy = str(board_path).replace("\\", "/").upper()
+        iface, _, _, _, _ = _loaded_iface(tmp_path, gui_board_path=sloppy, monkeypatch=monkeypatch)
+        if sys.platform == "win32":
+            assert iface.session_backend == "ipc"
+        else:
+            # Case differences are significant on POSIX filesystems.
+            assert iface.session_backend == "swig"
+
+
+@pytest.mark.unit
+class TestIssue223Repro:
+    def test_save_after_swig_open_stays_swig_even_with_ipc_connected(self, tmp_path, monkeypatch):
+        """The literal #223 bug: open on SWIG, save must NOT silently go IPC."""
+        iface, backend, holder, _, _ = _loaded_iface(
+            tmp_path, gui_board_path=None, monkeypatch=monkeypatch
+        )
+        assert iface.session_backend == "swig"
+
+        # IPC save handler must not run.
+        def _boom(params):
+            raise AssertionError("IPC save must not be used in a SWIG-pinned session")
+
+        iface._ipc_save_project = _boom
+
+        result = iface.handle_command("save_project", {})
+        assert result["success"] is True
+        assert result["_backend"] == "swig"
+        assert holder.get("swig_saves") == 1
+        assert "_backend_note" in result
+
+    def test_swig_pinned_session_blocks_other_ipc_capable_commands(self, tmp_path, monkeypatch):
+        iface, backend, holder, _, _ = _loaded_iface(
+            tmp_path, gui_board_path=None, monkeypatch=monkeypatch
+        )
+
+        def swig_board_info(params):
+            return {"success": True, "board": {}}
+
+        iface.command_routes["get_board_info"] = swig_board_info
+        iface.ipc_board_api = _FakeIPCBoardAPI()  # IPC fully available...
+
+        result = iface.handle_command("get_board_info", {})
+        assert result["_backend"] == "swig"  # ...but the pin wins
+        assert result["_realtime"] is False
+
+    def test_ipc_pinned_session_routes_save_via_ipc(self, tmp_path, monkeypatch):
+        board_path = tmp_path / "proj" / "proj.kicad_pcb"
+        iface, backend, holder, _, _ = _loaded_iface(
+            tmp_path, gui_board_path=board_path, monkeypatch=monkeypatch
+        )
+        assert iface.session_backend == "ipc"
+
+        def ipc_save(params):
+            holder["ipc_saves"] = holder.get("ipc_saves", 0) + 1
+            return {"success": True, "message": "saved via ipc"}
+
+        iface._ipc_save_project = ipc_save
+
+        result = iface.handle_command("save_project", {})
+        assert result["_backend"] == "ipc"
+        assert holder.get("ipc_saves") == 1
+        assert holder.get("swig_saves") is None
+
+
+@pytest.mark.unit
+class TestSessionTransitions:
+    def test_ipc_pinned_session_downgrades_when_connection_lost(self, tmp_path, monkeypatch):
+        board_path = tmp_path / "proj" / "proj.kicad_pcb"
+        iface, backend, holder, _, _ = _loaded_iface(
+            tmp_path, gui_board_path=board_path, monkeypatch=monkeypatch
+        )
+        assert iface.session_backend == "ipc"
+
+        backend.connected = False  # GUI closed
+        iface._safe_load_board = lambda path: _FakeBoard(path)
+
+        result = iface.handle_command("save_project", {})
+        assert iface.session_backend == "swig"
+        assert result["_backend"] == "swig"
+        assert holder.get("swig_saves") == 1
+
+    def test_reopen_repins(self, tmp_path, monkeypatch):
+        iface, backend, holder, board_path, _ = _loaded_iface(
+            tmp_path, gui_board_path=None, monkeypatch=monkeypatch
+        )
+        assert iface.session_backend == "swig"
+
+        # User opens the project in the GUI, then re-opens via MCP.
+        backend.open_board_path = str(board_path)
+        result = iface.handle_command("open_project", {"path": str(board_path)})
+        assert iface.session_backend == "ipc"
+        assert result["_backend"] == "ipc"
+
+
+@pytest.mark.unit
+class TestBackendStateReporting:
+    def test_backend_status_reports_session_pin(self, tmp_path, monkeypatch):
+        iface, _, _, _, _ = _loaded_iface(tmp_path, gui_board_path=None, monkeypatch=monkeypatch)
+        status = iface._backend_status()
+        # IPC is connected, but the session pin is the truth.
+        assert status["backend"] == "swig"
+        assert status["realtime_sync"] is False
+        assert status["ipc_connected"] is True
+
+    def test_backend_status_without_project_uses_connectivity(self):
+        iface = _make_iface({}, _FakeIPCBackend(connected=True), use_ipc=True)
+        status = iface._backend_status()
+        assert status["backend"] == "ipc"
+
+
+@pytest.mark.unit
+class TestPathNormalization:
+    def test_normalize_handles_none_and_empty(self):
+        assert KiCADInterface._normalize_board_path(None) is None
+        assert KiCADInterface._normalize_board_path("") is None
+
+    def test_match_false_without_backend(self):
+        iface = _make_iface({}, None, use_ipc=False)
+        assert iface._ipc_board_path_matches("C:/x/y.kicad_pcb") is False
+
+    def test_match_false_when_backend_raises(self):
+        class _Raising(_FakeIPCBackend):
+            def get_open_board_path(self):
+                raise RuntimeError("ipc down")
+
+        iface = _make_iface({}, _Raising(), use_ipc=True)
+        assert iface._ipc_board_path_matches("C:/x/y.kicad_pcb") is False


### PR DESCRIPTION
Fixes #223.

## Problem
On a single loaded project, the backend was chosen per call. `create_project`/`open_project` always ran on SWIG (they're not IPC-capable), but any later IPC-capable command — including `save_project` — silently upgraded the session to IPC when KiCad was reachable. The IPC save then wrote the live GUI's board, which never saw the SWIG-side edits: lost work, and the driver behind the #220/#222 symptoms ptr727 reported.

## Fix: session-pinned backend
- **Pin at load**: `open_project` pins the session to `ipc` only when the live GUI provably has the *same* `.kicad_pcb` open (new `IPCBackend.get_open_board_path()` + normalized path comparison). Otherwise — including every `create_project`, since the GUI can't have a brand-new board open — the session pins to `swig`.
- **No silent upgrades**: a swig-pinned session never routes board commands over IPC, even with IPC connected. The GUI's in-memory board may be stale relative to our edits, so an IPC save could clobber them. Responses carry a `_backend_note` explaining the pin and how to adopt the GUI (reopen the project while it's open in KiCad).
- **Graceful downgrade**: an ipc-pinned session falls back to swig if the connection drops (GUI closed), reloading the board from its last on-disk state.
- **Observability**: `get_backend_state` now returns `sessionBackend`/`sessionBoardPath`, and its `backend` field reflects the pin while a project is loaded — previously it reported `ipc` connectivity while every project command actually ran on SWIG, which is exactly the confusion in the issue report.
- Runtime reconnect with **no project loaded** is unchanged.

## Testing
- 14 new tests in `tests/test_backend_session_pinning.py`, including the literal issue repro: open via SWIG, then `save_project` with IPC connected must stay SWIG and never touch `_ipc_save_project`.
- Existing `test_backend_metadata.py` invariants all still pass (17/17).
- Full suite at baseline (8 failed / 1062 passed — the failures are the pre-existing Java-not-installed freerouting set), `npm run build` clean.
- Docs: session-pinning section added to `docs/IPC_BACKEND_STATUS.md`, CHANGELOG entry under Unreleased.

## Verification ask
The live-GUI path can't be fully exercised headless (CI covers SWIG only). @ptr727 — when you get a chance, could you re-run your repro from #223 on this branch (Win11 / KiCad 10 with IPC enabled)? Expected: `get_backend_state` shows `sessionBackend` after open, every project command reports the same `_backend`, and edits survive save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)