### PR TITLE
fix: correct pin positions and outward angles for rotated+mirrored symbols

### DIFF
--- a/python/commands/pin_locator.py
+++ b/python/commands/pin_locator.py
@@ -274,7 +274,7 @@ class PinLocator:
             if transform is None:
                 return None
 
-            _, _, symbol_rotation, mirror_x, mirror_y, lib_id = transform
+            sym_x, sym_y, symbol_rotation, mirror_x, mirror_y, lib_id = transform
             if not lib_id:
                 return None
 
@@ -289,29 +289,45 @@ class PinLocator:
                 else:
                     return None
 
-            pin_def_angle = pins[pin_number].get("angle", 0)
+            pin = pins[pin_number]
+            px = float(pin.get("x", 0.0))
+            py = float(pin.get("y", 0.0))
+            lib_angle = math.radians(pin.get("angle", 0))
 
-            # Mirror this exactly the way WireDragger.pin_world_xy does, in the
-            # same order: Y-flip (lib Y-up → screen Y-down) → mirror → rotate.
+            # Derive the outward bearing straight from WireDragger.pin_world_xy
+            # rather than re-deriving the angle transform by hand.  pin_world_xy
+            # is the netlist-verified position transform (Y-flip → rotate →
+            # mirror); transforming two points along the pin axis and taking
+            # atan2 of their difference is rotation/mirror-correct *by
+            # construction*, for both horizontal and vertical pins.
             #
-            # Y-flip on an angle: negate it (reflects across X axis).
-            pin_def_angle = (-pin_def_angle) % 360
+            # The library pin `angle` points *into* the body, so a point one
+            # unit along it is bodyward; (endpoint − bodyward) is the outward
+            # vector.  Screen Y is down, so negate the Y component to land in the
+            # 0=right / 90=up / 180=left / 270=down convention the wire-stub
+            # consumer (connection_schematic.connect_to_net) expects:
+            #   stub_end = pin + L*(cos θ, −sin θ)
+            #
+            # The hand-rolled version this replaces negated the library angle (a
+            # Y-flip), which only happens to give the outward direction for
+            # *vertical* pins (270↔90); horizontal pins (0→0, 180→180) were left
+            # pointing into the body — 180° wrong.  The old unit test used only a
+            # vertical-pin Device:R, so it never surfaced.
+            from commands.wire_dragger import WireDragger
 
-            # eeschema (symbol.h:43-44):
-            #   (mirror x) = SYM_MIRROR_X = TRANSFORM(1,0,0,-1) → negates Y →
-            #     reflect angle across X axis → -angle.
-            #   (mirror y) = SYM_MIRROR_Y = TRANSFORM(-1,0,0,1) → negates X →
-            #     reflect angle across Y axis → 180 - angle.
-            if mirror_x:
-                pin_def_angle = (-pin_def_angle) % 360
-            if mirror_y:
-                pin_def_angle = (180 - pin_def_angle) % 360
-
-            # eeschema's rotation TRANSFORM is screen-CCW in Y-down, which is
-            # math-CW in standard atan2 convention — so subtract the rotation
-            # to match `pin_world_xy`'s `_rotate(..., -rotation)` call.
-            absolute_angle = (pin_def_angle - symbol_rotation) % 360
-            return absolute_angle
+            ex, ey = WireDragger.pin_world_xy(
+                px, py, sym_x, sym_y, symbol_rotation, mirror_x, mirror_y
+            )
+            bx, by = WireDragger.pin_world_xy(
+                px + math.cos(lib_angle),
+                py + math.sin(lib_angle),
+                sym_x,
+                sym_y,
+                symbol_rotation,
+                mirror_x,
+                mirror_y,
+            )
+            return math.degrees(math.atan2(-(ey - by), ex - bx)) % 360.0
 
         except Exception:
             return None

--- a/python/commands/wire_dragger.py
+++ b/python/commands/wire_dragger.py
@@ -156,7 +156,7 @@ class WireDragger:
         Compute the world coordinate of a pin given the symbol transform.
 
         Library pins are stored Y-up; the schematic is Y-down. Order matches
-        eeschema: Y-flip to screen → mirror → rotate (screen-CCW) → translate.
+        eeschema: Y-flip to screen → rotate (screen-CCW) → mirror → translate.
 
         eeschema's TRANSFORM matrix for rotation 90 is (0, 1, -1, 0) —
         i.e. screen-CCW in Y-down: (x, y) → (y, -x). Our `_rotate` helper is
@@ -167,11 +167,15 @@ class WireDragger:
           (mirror y) = SYM_MIRROR_Y = TRANSFORM(-1, 0, 0, 1) → negates X.
         """
         lx, ly = px, -py  # Y-flip: lib Y-up → screen Y-down
-        if mirror_x:
-            ly = -ly  # SYM_MIRROR_X negates screen-Y
-        if mirror_y:
-            lx = -lx  # SYM_MIRROR_Y negates screen-X
         rx, ry = _rotate(lx, ly, -rotation)  # negate angle: math-CCW → screen-CCW
+        # Mirror reflects the *placed* (already-rotated) symbol — i.e. in screen
+        # space, AFTER the rotation. Applying it before the rotation only agrees
+        # for 0°/180° turns; for 90°/270° it swaps the pins (verified against the
+        # kicad-cli netlist in test_pin_world_xy_eeschema_truth).
+        if mirror_x:
+            ry = -ry  # SYM_MIRROR_X negates screen-Y
+        if mirror_y:
+            rx = -rx  # SYM_MIRROR_Y negates screen-X
         return sym_x + rx, sym_y + ry
 
     @staticmethod

--- a/python/commands/wire_manager.py
+++ b/python/commands/wire_manager.py
@@ -583,9 +583,11 @@ class WireManager:
     def _collect_pin_positions(sch_data: list) -> List[Tuple[float, float]]:
         """Return world (x, y) positions for every placed component pin in sch_data.
 
-        Parses lib_symbols for pin local coordinates (unit-aware), then applies the KiCad
-        transform chain (y-negate → mirror → rotate → translate) to each pin.
+        Parses lib_symbols for pin local coordinates (unit-aware), then applies the
+        shared, eeschema-verified transform (WireDragger.pin_world_xy) to each pin.
         """
+        from commands.wire_dragger import WireDragger
+
         # Build {lib_id: sym_def} from the embedded lib_symbols section.
         # We defer pin extraction until we know which unit each placed instance uses.
         lib_sym_defs: dict = {}
@@ -648,17 +650,13 @@ class WireManager:
             local_pins = WireManager._parse_lib_pins(sym_def, unit=unit_num)
 
             for lx, ly in local_pins:
-                # KiCad lib uses y-up; schematic uses y-down — negate before transform
-                ly = -ly
-                if mirror_x:
-                    ly = -ly
-                if mirror_y:
-                    lx = -lx
-                if rotation != 0.0:
-                    rad = math.radians(rotation)
-                    c, s = math.cos(rad), math.sin(rad)
-                    lx, ly = lx * c - ly * s, lx * s + ly * c
-                world_positions.append((sym_x + lx, sym_y + ly))
+                # Use the shared transform. Previously this loop duplicated it
+                # with the mirror applied *before* the rotation and an inverted
+                # rotation sign, which mislocated pins of rotated+mirrored symbols
+                # (e.g. a diode at rotation 90 + mirror x).
+                world_positions.append(
+                    WireDragger.pin_world_xy(lx, ly, sym_x, sym_y, rotation, mirror_x, mirror_y)
+                )
 
         return world_positions
 

--- a/tests/test_get_pin_angle.py
+++ b/tests/test_get_pin_angle.py
@@ -1,16 +1,31 @@
-"""
-Matrix tests for PinLocator.get_pin_angle on a Device:R symbol.
+"""Matrix tests for PinLocator.get_pin_angle across rotation x mirror.
 
-For each combination of (symbol_rotation, mirror, pin), we construct a real
-.kicad_sch fixture, then compare:
-  - actual:   PinLocator().get_pin_angle(...)
-  - expected: derived geometrically from WireDragger.pin_world_xy by extending
-              the pin one length unit along its library angle and measuring the
-              world-frame displacement direction.
+get_pin_angle returns the *outward* bearing of a pin endpoint — the direction a
+wire stub leaves the pin, away from the symbol body — in the convention the sole
+consumer (connection_schematic.connect_to_net) uses:
 
-This characterizes the post-PR-#88 angle reflection logic. Cases that disagree
-with the geometric expectation are marked xfail with a "PR #88 regression
-candidate" annotation.
+    stub_end = pin + L * (cos θ, −sin θ)        # screen Y is down
+
+so 0=right, 90=up, 180=left, 270=down.
+
+Two symbols are exercised:
+  * Device:R — vertical pins (library angles 90/270)
+  * Device:D — horizontal pins (library angles 0/180)
+
+Horizontal pins are the regression guard: the previous implementation negated
+the library angle (a Y-flip), which only yields the outward direction for
+vertical pins (270↔90).  Horizontal pins (0→0, 180→180) came out pointing *into*
+the body — 180° wrong — and the old test, which used only Device:R, never saw
+it.
+
+Oracles, strongest first:
+  * test_wire_stub_extends_outward — behavioural and implementation-independent:
+    the 2.54 mm stub the consumer would place must land farther from the symbol
+    origin than the pin itself.  The old code fails this for every Device:D case.
+  * test_get_pin_angle_known_values — hand-computed bearings for canonical
+    placements, including the real-world D10 freewheel diode (rot 90 + mirror x).
+  * test_get_pin_angle_matches_pin_world_xy — exhaustive agreement with the
+    netlist-verified WireDragger.pin_world_xy transform.
 """
 
 import importlib.util
@@ -22,7 +37,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-import sexpdata
 
 # ---------------------------------------------------------------------------
 # Module loading — bypass pcbnew, mirror the test_rotate_schematic_mirror style
@@ -31,7 +45,6 @@ _PYTHON_DIR = os.path.join(os.path.dirname(__file__), "..", "python")
 if _PYTHON_DIR not in sys.path:
     sys.path.insert(0, _PYTHON_DIR)
 
-# Stub pcbnew before importing pin_locator (skip is real and works fine)
 sys.modules.setdefault("pcbnew", MagicMock())
 
 _pl_spec = importlib.util.spec_from_file_location(
@@ -52,112 +65,171 @@ WireDragger = _wd_mod.WireDragger
 
 
 # ---------------------------------------------------------------------------
-# Device:R pin definitions (per python/templates/empty.kicad_sch)
-#   pin 1: (0, 3.81), library angle 270, length 1.27
-#   pin 2: (0, -3.81), library angle 90, length 1.27
+# Fixtures: a vertical-pin (Device:R) and a horizontal-pin (Device:D) symbol
 # ---------------------------------------------------------------------------
-PIN_DEFS = {
-    "1": {"x": 0.0, "y": 3.81, "angle": 270.0, "length": 1.27},
-    "2": {"x": 0.0, "y": -3.81, "angle": 90.0, "length": 1.27},
-}
-
 SYMBOL_X = 100.0
 SYMBOL_Y = 100.0
+STUB_LEN = 2.54  # matches connection_schematic.connect_to_net
 
-
-def _make_sch_text(rotation: float, mirror: str | None) -> str:
-    mirror_line = ""
-    if mirror == "x":
-        mirror_line = "(mirror x)"
-    elif mirror == "y":
-        mirror_line = "(mirror y)"
-
-    return textwrap.dedent(f"""\
-        (kicad_sch (version 20250114) (generator "test")
-          (lib_symbols
-            (symbol "Device:R" (pin_numbers hide) (pin_names (offset 0))
-              (symbol "R_1_1"
+SYMS = {
+    "R": {  # vertical pins
+        "lib_id": "Device:R",
+        # pin: (x, y, library angle)
+        "pins": {"1": (0.0, 3.81, 270.0), "2": (0.0, -3.81, 90.0)},
+        "body": textwrap.dedent(
+            """\
+            (symbol "R_1_1"
                 (pin passive line (at 0 3.81 270) (length 1.27)
                   (name "~" (effects (font (size 1.27 1.27))))
-                  (number "1" (effects (font (size 1.27 1.27))))
-                )
+                  (number "1" (effects (font (size 1.27 1.27)))))
                 (pin passive line (at 0 -3.81 90) (length 1.27)
                   (name "~" (effects (font (size 1.27 1.27))))
-                  (number "2" (effects (font (size 1.27 1.27))))
-                )
-              )
-            )
-          )
-          (symbol (lib_id "Device:R") (at {SYMBOL_X} {SYMBOL_Y} {rotation})
-            {mirror_line}
-            (property "Reference" "R1" (at {SYMBOL_X} {SYMBOL_Y} 0))
-            (property "Value" "10k" (at {SYMBOL_X} {SYMBOL_Y} 0))
-          )
-        )
-    """)
+                  (number "2" (effects (font (size 1.27 1.27)))))
+              )"""
+        ),
+    },
+    "D": {  # horizontal pins
+        "lib_id": "Device:D",
+        "pins": {"1": (-3.81, 0.0, 0.0), "2": (3.81, 0.0, 180.0)},
+        "body": textwrap.dedent(
+            """\
+            (symbol "D_1_1"
+                (pin passive line (at -3.81 0 0) (length 2.54)
+                  (name "K" (effects (font (size 1.27 1.27))))
+                  (number "1" (effects (font (size 1.27 1.27)))))
+                (pin passive line (at 3.81 0 180) (length 2.54)
+                  (name "A" (effects (font (size 1.27 1.27))))
+                  (number "2" (effects (font (size 1.27 1.27)))))
+              )"""
+        ),
+    },
+}
 
-
-def _write_sch(tmp_path: Path, rotation: float, mirror: str | None) -> Path:
-    p = tmp_path / f"r_rot{int(rotation)}_mirror{mirror or 'none'}.kicad_sch"
-    p.write_text(_make_sch_text(rotation, mirror))
-    return p
-
-
-def _expected_stub_angle(pin_num: str, rotation: float, mirror: str | None) -> float:
-    """Geometrically expected outward angle: extend in library coords by +length
-    along library angle, transform to world, take atan2 of displacement."""
-    pin = PIN_DEFS[pin_num]
-    px, py = pin["x"], pin["y"]
-    lib_angle_rad = math.radians(pin["angle"])
-    ox = px + pin["length"] * math.cos(lib_angle_rad)
-    oy = py + pin["length"] * math.sin(lib_angle_rad)
-
-    mirror_x = mirror == "x"
-    mirror_y = mirror == "y"
-
-    wx_pin, wy_pin = WireDragger.pin_world_xy(
-        px, py, SYMBOL_X, SYMBOL_Y, rotation, mirror_x, mirror_y
-    )
-    wx_out, wy_out = WireDragger.pin_world_xy(
-        ox, oy, SYMBOL_X, SYMBOL_Y, rotation, mirror_x, mirror_y
-    )
-
-    deg = math.degrees(math.atan2(wy_out - wy_pin, wx_out - wx_pin)) % 360.0
-    # Snap to 0/90/180/270 (axis-aligned pins; FP noise tolerance)
-    snapped = round(deg / 90.0) * 90.0 % 360.0
-    if abs(((deg - snapped) + 540) % 360 - 180) < 1e-6:
-        # within tolerance
-        return snapped
-    return snapped
-
-
-# ---------------------------------------------------------------------------
-# Parametrized matrix
-# ---------------------------------------------------------------------------
 ROTATIONS = [0, 90, 180, 270]
 MIRRORS = [None, "x", "y"]
 PINS = ["1", "2"]
 
 
+def _make_sch_text(sym: str, rotation: float, mirror) -> str:
+    spec = SYMS[sym]
+    mirror_line = {"x": "(mirror x)", "y": "(mirror y)"}.get(mirror, "")
+    return textwrap.dedent(
+        f"""\
+        (kicad_sch (version 20250114) (generator "test")
+          (lib_symbols
+            (symbol "{spec['lib_id']}" (pin_numbers hide) (pin_names (offset 0))
+              {spec['body']}
+            )
+          )
+          (symbol (lib_id "{spec['lib_id']}") (at {SYMBOL_X} {SYMBOL_Y} {rotation})
+            {mirror_line}
+            (property "Reference" "U1" (at {SYMBOL_X} {SYMBOL_Y} 0))
+            (property "Value" "v" (at {SYMBOL_X} {SYMBOL_Y} 0))
+          )
+        )
+    """
+    )
+
+
+def _write_sch(tmp_path: Path, sym: str, rotation: float, mirror) -> Path:
+    p = tmp_path / f"{sym}_rot{int(rotation)}_mir{mirror or 'none'}.kicad_sch"
+    p.write_text(_make_sch_text(sym, rotation, mirror))
+    return p
+
+
+def _pin_world(sym, pin_num, rotation, mirror):
+    px, py, _ = SYMS[sym]["pins"][pin_num]
+    return WireDragger.pin_world_xy(
+        px, py, SYMBOL_X, SYMBOL_Y, rotation, mirror == "x", mirror == "y"
+    )
+
+
+def _outward_from_pin_world_xy(sym, pin_num, rotation, mirror):
+    """Ground-truth outward bearing derived from the netlist-verified position
+    transform: the library pin angle points *into* the body, so endpoint minus a
+    bodyward point is the outward vector (screen Y down → negate the Y term)."""
+    px, py, lib_angle = SYMS[sym]["pins"][pin_num]
+    a = math.radians(lib_angle)
+    ex, ey = _pin_world(sym, pin_num, rotation, mirror)
+    bx, by = WireDragger.pin_world_xy(
+        px + math.cos(a),
+        py + math.sin(a),
+        SYMBOL_X,
+        SYMBOL_Y,
+        rotation,
+        mirror == "x",
+        mirror == "y",
+    )
+    deg = math.degrees(math.atan2(-(ey - by), ex - bx)) % 360.0
+    return round(deg / 90.0) * 90.0 % 360.0
+
+
+# ---------------------------------------------------------------------------
+# 1. Behavioural oracle (implementation-independent): the stub goes OUTWARD
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("sym", ["R", "D"])
 @pytest.mark.parametrize("rotation", ROTATIONS)
 @pytest.mark.parametrize("mirror", MIRRORS)
 @pytest.mark.parametrize("pin_num", PINS)
-def test_get_pin_angle_matches_geometric_expectation(tmp_path, rotation, mirror, pin_num):
-    sch_path = _write_sch(tmp_path, rotation, mirror)
-    expected = _expected_stub_angle(pin_num, rotation, mirror)
+def test_wire_stub_extends_outward(tmp_path, sym, rotation, mirror, pin_num):
+    """Replays what connect_to_net does and asserts the stub lands away from the
+    symbol body.  For R/D the pins are radial, so 'outward' == 'farther from the
+    placement origin'.  This is the assertion the old code violated for every
+    horizontal-pin (Device:D) case."""
+    sch = _write_sch(tmp_path, sym, rotation, mirror)
+    angle = PinLocator().get_pin_angle(sch, "U1", pin_num)
+    assert angle is not None
 
-    locator = PinLocator()
-    actual = locator.get_pin_angle(sch_path, "R1", pin_num)
+    pin_x, pin_y = _pin_world(sym, pin_num, rotation, mirror)
+    rad = math.radians(angle)
+    stub_x = pin_x + STUB_LEN * math.cos(rad)
+    stub_y = pin_y - STUB_LEN * math.sin(rad)  # connect_to_net's Y-down convention
 
+    def d2(x, y):
+        return (x - SYMBOL_X) ** 2 + (y - SYMBOL_Y) ** 2
+
+    assert d2(stub_x, stub_y) > d2(pin_x, pin_y) + 1e-6, (
+        f"{sym} pin{pin_num} rot={rotation} mir={mirror}: stub heads INTO the body "
+        f"(pin=({pin_x:.2f},{pin_y:.2f}) stub=({stub_x:.2f},{stub_y:.2f}) angle={angle})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Hand-computed canonical bearings (non-circular spot checks)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "sym, pin_num, rotation, mirror, expected",
+    [
+        ("R", "1", 0, None, 90.0),  # top pin, points up
+        ("R", "2", 0, None, 270.0),  # bottom pin, points down
+        ("D", "1", 0, None, 180.0),  # left pin (cathode), points left
+        ("D", "2", 0, None, 0.0),  # right pin (anode), points right
+        ("D", "1", 90, "x", 90.0),  # real-world: D10 freewheel diode → HS_HOT (up)
+    ],
+)
+def test_get_pin_angle_known_values(tmp_path, sym, pin_num, rotation, mirror, expected):
+    sch = _write_sch(tmp_path, sym, rotation, mirror)
+    angle = PinLocator().get_pin_angle(sch, "U1", pin_num)
+    assert angle is not None
     assert (
-        actual is not None
-    ), f"get_pin_angle returned None for rot={rotation} mirror={mirror} pin={pin_num}"
+        abs(((angle - expected) + 540) % 360 - 180) < 1e-3
+    ), f"{sym} pin{pin_num} rot={rotation} mir={mirror}: got {angle}, expected {expected}"
 
-    # Normalize both to [0, 360)
-    actual_n = actual % 360.0
-    expected_n = expected % 360.0
 
-    assert abs(((actual_n - expected_n) + 540) % 360 - 180) < 1e-3, (
-        f"actual={actual_n}, expected={expected_n} "
-        f"(rotation={rotation}, mirror={mirror}, pin={pin_num})"
+# ---------------------------------------------------------------------------
+# 3. Exhaustive agreement with the netlist-verified pin_world_xy transform
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("sym", ["R", "D"])
+@pytest.mark.parametrize("rotation", ROTATIONS)
+@pytest.mark.parametrize("mirror", MIRRORS)
+@pytest.mark.parametrize("pin_num", PINS)
+def test_get_pin_angle_matches_pin_world_xy(tmp_path, sym, rotation, mirror, pin_num):
+    sch = _write_sch(tmp_path, sym, rotation, mirror)
+    actual = PinLocator().get_pin_angle(sch, "U1", pin_num)
+    assert actual is not None
+
+    expected = _outward_from_pin_world_xy(sym, pin_num, rotation, mirror)
+    assert abs(((actual - expected) + 540) % 360 - 180) < 1e-3, (
+        f"{sym} pin{pin_num} rot={rotation} mir={mirror}: "
+        f"actual={actual % 360.0}, expected={expected}"
     )

--- a/tests/test_get_pin_angle.py
+++ b/tests/test_get_pin_angle.py
@@ -76,8 +76,7 @@ SYMS = {
         "lib_id": "Device:R",
         # pin: (x, y, library angle)
         "pins": {"1": (0.0, 3.81, 270.0), "2": (0.0, -3.81, 90.0)},
-        "body": textwrap.dedent(
-            """\
+        "body": textwrap.dedent("""\
             (symbol "R_1_1"
                 (pin passive line (at 0 3.81 270) (length 1.27)
                   (name "~" (effects (font (size 1.27 1.27))))
@@ -85,14 +84,12 @@ SYMS = {
                 (pin passive line (at 0 -3.81 90) (length 1.27)
                   (name "~" (effects (font (size 1.27 1.27))))
                   (number "2" (effects (font (size 1.27 1.27)))))
-              )"""
-        ),
+              )"""),
     },
     "D": {  # horizontal pins
         "lib_id": "Device:D",
         "pins": {"1": (-3.81, 0.0, 0.0), "2": (3.81, 0.0, 180.0)},
-        "body": textwrap.dedent(
-            """\
+        "body": textwrap.dedent("""\
             (symbol "D_1_1"
                 (pin passive line (at -3.81 0 0) (length 2.54)
                   (name "K" (effects (font (size 1.27 1.27))))
@@ -100,8 +97,7 @@ SYMS = {
                 (pin passive line (at 3.81 0 180) (length 2.54)
                   (name "A" (effects (font (size 1.27 1.27))))
                   (number "2" (effects (font (size 1.27 1.27)))))
-              )"""
-        ),
+              )"""),
     },
 }
 
@@ -113,8 +109,7 @@ PINS = ["1", "2"]
 def _make_sch_text(sym: str, rotation: float, mirror) -> str:
     spec = SYMS[sym]
     mirror_line = {"x": "(mirror x)", "y": "(mirror y)"}.get(mirror, "")
-    return textwrap.dedent(
-        f"""\
+    return textwrap.dedent(f"""\
         (kicad_sch (version 20250114) (generator "test")
           (lib_symbols
             (symbol "{spec['lib_id']}" (pin_numbers hide) (pin_names (offset 0))
@@ -127,8 +122,7 @@ def _make_sch_text(sym: str, rotation: float, mirror) -> str:
             (property "Value" "v" (at {SYMBOL_X} {SYMBOL_Y} 0))
           )
         )
-    """
-    )
+    """)
 
 
 def _write_sch(tmp_path: Path, sym: str, rotation: float, mirror) -> Path:

--- a/tests/test_pin_world_xy_eeschema_truth.py
+++ b/tests/test_pin_world_xy_eeschema_truth.py
@@ -187,6 +187,65 @@ def test_diode_label_polarity_through_eeschema(rotation):
             )
 
 
+def _build_diode_rot_mirror_case(tmp: Path, rotation: int, mirror: str) -> tuple[Path, dict]:
+    """Place a Device:D, apply BOTH rotation and mirror, snap labels by PinLocator coords."""
+    import sexpdata
+
+    sch_path = tmp / f"diode_rot{rotation}_mir{mirror}.kicad_sch"
+    template = PYTHON_DIR / "templates" / "template_with_symbols.kicad_sch"
+    shutil.copy(template, sch_path)
+
+    sch = SchematicManager.load_schematic(str(sch_path))
+    ComponentManager.add_component(
+        sch,
+        {"type": "D", "reference": "D1", "value": "1N4148",
+         "x": 100.0, "y": 100.0, "rotation": 0},
+        sch_path,
+    )
+    SchematicManager.save_schematic(sch, str(sch_path))
+
+    # add_component drops a 'mirror' kwarg, so set rotation + mirror via the same
+    # low-level helper the rotate handler uses.
+    sch_data = sexpdata.loads(sch_path.read_text())
+    if not WireDragger.update_symbol_rotation_mirror(sch_data, "D1", rotation, mirror):
+        raise RuntimeError(f"Failed to set rotation={rotation} mirror={mirror} on D1")
+    sch_path.write_text(sexpdata.dumps(sch_data))
+    if f"(mirror {mirror})" not in sch_path.read_text():
+        raise RuntimeError(
+            f"Fixture failed to write (mirror {mirror}) — the oracle would "
+            f"silently match our coords for an unmirrored symbol."
+        )
+
+    locator = PinLocator()
+    p_k = locator.get_pin_location(sch_path, "D1", "1")
+    p_a = locator.get_pin_location(sch_path, "D1", "2")
+    assert p_k is not None and p_a is not None
+    _add_labels_to_file(sch_path, [("D1_K", p_k[0], p_k[1]), ("D1_A", p_a[0], p_a[1])])
+    return sch_path, {("D1", "1"): "D1_K", ("D1", "2"): "D1_A"}
+
+
+@pytest.mark.parametrize("rotation", [0, 90, 180, 270])
+@pytest.mark.parametrize("mirror", ["x", "y"])
+def test_diode_polarity_rotation_and_mirror_through_eeschema(rotation, mirror):
+    """Polarized symbol with rotation AND mirror together.
+
+    Regression for the pin_world_xy mirror/rotation ORDER bug: the mirror was
+    applied before the rotation, so rotation 90/270 combined with any mirror
+    swapped the pins. The snapped "_K" label must still bind to pin 1 (K) in
+    eeschema's own netlist. (rotation-only and mirror-only are covered above; the
+    combination is the case the previous tests missed.)
+    """
+    with tempfile.TemporaryDirectory() as td:
+        sch_path, expected = _build_diode_rot_mirror_case(Path(td), rotation, mirror)
+        actual = _run_netlist(sch_path)
+        for (ref, pin), net in expected.items():
+            assert actual.get((ref, pin)) == net, (
+                f"rotation={rotation}, mirror={mirror}: D1.{pin} label landed on "
+                f"the wrong pin. Expected net={net}, got {actual.get((ref, pin))}. "
+                f"Full mapping: {actual}"
+            )
+
+
 @pytest.mark.parametrize("axis", ["x", "y"])
 def test_mirrored_resistor_label_through_eeschema(axis):
     """Snap-labelled pin 1 must show up on pin 1 after (mirror x) / (mirror y)."""

--- a/tests/test_pin_world_xy_eeschema_truth.py
+++ b/tests/test_pin_world_xy_eeschema_truth.py
@@ -198,8 +198,7 @@ def _build_diode_rot_mirror_case(tmp: Path, rotation: int, mirror: str) -> tuple
     sch = SchematicManager.load_schematic(str(sch_path))
     ComponentManager.add_component(
         sch,
-        {"type": "D", "reference": "D1", "value": "1N4148",
-         "x": 100.0, "y": 100.0, "rotation": 0},
+        {"type": "D", "reference": "D1", "value": "1N4148", "x": 100.0, "y": 100.0, "rotation": 0},
         sch_path,
     )
     SchematicManager.save_schematic(sch, str(sch_path))


### PR DESCRIPTION
## Summary

Two related fixes for symbol→world pin geometry on symbols that are **both rotated and mirrored**, where the schematic tools reported pins — and the wire-stub direction used to attach net labels — on the wrong side. Both bugs were masked by the same gap: the tests exercised only single-axis placements and a vertical-pin `Device:R`, so neither the rotated+mirrored case nor horizontal pins were ever covered.

The two commits are ordered — the angle fix builds directly on the position fix.

---

## 1. `pin_world_xy` — mirror applied before rotation

`WireDragger.pin_world_xy` — the symbol→world pin transform behind `get_schematic_pin_locations`, `get_net_at_point`, and net-label pin snapping — applied the `(mirror x|y)` reflection in **library space, before the rotation**. eeschema reflects the *placed* (already-rotated) symbol, i.e. **after** the rotation.

The two orders agree for rotations of 0° and 180°, but **diverge for 90°/270° combined with any mirror**: the pins come out swapped. Polarized parts are where it bites — a diode at `rotation 90 + mirror x` reports its cathode (pin 1) and anode (pin 2) at each other's positions. Downstream that:

- snaps polarity-bearing net labels onto the wrong pins, and
- makes `get_schematic_pin_locations` / `get_net_at_point` report the wrong pin→net for any symbol that is **both rotated and mirrored**.

### Fix
- **`WireDragger.pin_world_xy`** — reorder to `Y-flip → rotate → mirror` (mirror in screen space, after the rotation). Single-axis behavior is byte-identical; only the rotated-*and*-mirrored case changes.
- **`WireManager._collect_pin_positions`** — was a second, divergent copy of the transform (mirror-before-rotate *and* an inverted rotation sign). Now routes through `pin_world_xy`, so there's one source of truth.
- **New test** `test_diode_polarity_rotation_and_mirror_through_eeschema`, parametrized over rotation × mirror, using `kicad-cli sch export netlist` as the oracle (a snapped `_K` label must bind to pin 1). The existing tests covered rotation-only and mirror-only but never the combination — which is exactly why this slipped through.

### Verification
Against `kicad-cli sch export netlist` for all 12 (rotation × mirror) combinations, the snapped K/A labels bind to the correct pins. Before the fix the four `{90,270} × {x,y}` cases failed (pins swapped); after, all pass. Existing single-axis pure-math assertions and the resistor set-membership junction tests are unaffected.

---

## 2. `get_pin_angle` — outward bearing wrong for horizontal pins

`pin_locator.get_pin_angle` returns the *outward* bearing of a pin endpoint — the direction a wire stub leaves the pin, away from the body — consumed by `connection_schematic.connect_to_net` to place a stub + net label (`stub_end = pin + L·(cos θ, −sin θ)`, screen Y down).

It derived that bearing by **negating the library pin angle** (a Y-flip). That only yields the outward direction for **vertical** pins (270↔90); **horizontal** pins (0→0, 180→180) came out pointing *into* the body — 180° wrong. So `connect_to_net` placed the stub/label on the wrong side of any horizontal-pin part, and the `angle` field of `get_schematic_pin_locations` was likewise inverted.

The old `test_get_pin_angle.py` used only a vertical-pin `Device:R` **and** an oracle that re-derived the same flawed math, so it was blind to this — the same fixture gap that hid the position bug.

### Fix
- **`get_pin_angle`** now derives the bearing from the (commit-1-fixed) `pin_world_xy`: transform the pin endpoint and a bodyward point, take `atan2` of the difference. Correct by construction for both pin orientations and every rotation/mirror — no hand-rolled angle transform.
- **Rewrote `test_get_pin_angle.py`** to add horizontal pins (`Device:D`) and three independent oracles: a behavioural check (the placed stub must extend *away* from the body), hand-computed bearings for canonical placements incl. the real-world D10 freewheel diode (`rot 90 + mirror x` → up), and exhaustive agreement with `pin_world_xy`.

### Verification
101/101 in the rewritten matrix with the fix; reverting only `get_pin_angle` fails 51, all of them `Device:D` (horizontal) cases. The `connect_to_net` stub+label+netlist integration tests (`test_label_at_pin_net_connections`, `test_net_connectivity`) pass unchanged — the corrected angles don't alter connectivity.
