### PR TITLE
fix(kicad10): match renamed 'Sheet name' property and NC template phantom pins

### DIFF
--- a/python/commands/wire_manager.py
+++ b/python/commands/wire_manager.py
@@ -1125,10 +1125,14 @@ class WireManager:
         Returns (modified_content, success).
         """
         lines = content.split("\n")
+        # KiCad 7-9 stores the property as "Sheetname"; KiCad 10 renamed it
+        # to "Sheet name" (with space). Match either to stay compatible.
         sheetname_pattern = re.compile(
-            r'\(property\s+"Sheetname"\s+"' + re.escape(sheet_name) + r'"'
+            r'\(property\s+"Sheet\s?name"\s+"' + re.escape(sheet_name) + r'"'
         )
-        sheet_block_pattern = re.compile(r"^\t\(sheet\b")
+        # KiCad 7-9 indents top-level blocks with a single tab; KiCad 10
+        # writes 2- or 4-space indentation. Accept any leading whitespace.
+        sheet_block_pattern = re.compile(r"^\s*\(sheet\b")
 
         # Find the sheet block that contains the target Sheetname property
         i = 0

--- a/python/templates/template_with_symbols.kicad_sch
+++ b/python/templates/template_with_symbols.kicad_sch
@@ -188,6 +188,17 @@
     (pin "2" (uuid 00000000-0000-0000-0000-000000000031))
   )
 
+  ;; No-connect flags on the _TEMPLATE_R/_C/_LED phantom-instance pins.
+  ;; KiCad 10's ERC ignores (dnp yes) for pin-not-connected checks, so the
+  ;; phantoms (placed off-page at -100,-100 etc. solely to seed the cloning
+  ;; flow) generate noise unless their pins are explicitly NC'd here.
+  (no_connect (at -100 -96.19) (uuid 00000000-0000-0000-0000-0000000000c1))
+  (no_connect (at -100 -103.81) (uuid 00000000-0000-0000-0000-0000000000c2))
+  (no_connect (at -100 -106.19) (uuid 00000000-0000-0000-0000-0000000000c3))
+  (no_connect (at -100 -113.81) (uuid 00000000-0000-0000-0000-0000000000c4))
+  (no_connect (at -96.19 -120) (uuid 00000000-0000-0000-0000-0000000000c5))
+  (no_connect (at -103.81 -120) (uuid 00000000-0000-0000-0000-0000000000c6))
+
   (sheet_instances
     (path "/" (page "1"))
   )


### PR DESCRIPTION
## Summary

Two small KiCad 10 compatibility fixes.

### Sheet-rename matcher (`wire_manager.py`)

The sheet-rename path only matched the KiCad 7–9 file format, so it's a silent no-op on KiCad 10 schematics:

- KiCad 10 renamed the sheet's `"Sheetname"` property to `"Sheet name"` (with a space). The property regex now matches either (`"Sheet\s?name"`).
- KiCad 10 writes top-level blocks with 2/4-space indentation instead of KiCad 7–9's single leading tab. The sheet-block pattern now accepts any leading whitespace (`^\s*\(sheet\b`) rather than `^\t\(sheet\b`.

### Template no-connects (`template_with_symbols.kicad_sch`)

The template seeds the symbol-cloning flow with off-page phantom `_TEMPLATE_R/_C/_LED` instances. KiCad 10's ERC ignores `(dnp yes)` for pin-not-connected checks, so those phantom pins generate ERC noise. Added explicit `(no_connect …)` flags on their pins to keep ERC clean.

Both are backward compatible — the widened regexes still match the KiCad 7–9 forms, and the no-connect flags are inert on older versions.
