### PR TITLE
feat: add suggest_placement (PCB) and suggest_schematic_declutter (schematic) layout tools

### DIFF
--- a/python/commands/component.py
+++ b/python/commands/component.py
@@ -10,11 +10,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pcbnew
 from commands.library import LibraryManager
+from commands.placement_optimizer import PlacementOptimizerCommands
 
 logger = logging.getLogger("kicad_interface")
 
 
-class ComponentCommands:
+class ComponentCommands(PlacementOptimizerCommands):
     """Handles component-related KiCAD operations"""
 
     def __init__(

--- a/python/commands/placement_optimizer.py
+++ b/python/commands/placement_optimizer.py
@@ -1,0 +1,833 @@
+"""Connectivity-driven component placement optimizer.
+
+DRAFT — proposed new MCP capability.
+
+The existing tools (place_component, move_component, align_components,
+check_courtyard_overlaps) give you placement primitives plus *validation*, but
+nothing turns the netlist into a suggested layout. This module adds a single
+command, ``suggest_placement``, that does the heuristic an engineer does by
+eye against the ratsnest:
+
+    1. Build a component-level connection graph from pad nets.
+    2. Force-directed relaxation (Fruchterman-Reingold flavoured, adapted for
+       PCB): nets pull connected parts together, overlapping courtyards push
+       apart, the board outline contains everything. Power/high-current nets
+       and IC<->decoupling links are weighted so those parts hug tightest.
+    3. Pin-facing rotation: each movable part is rotated (0/90/180/270) to the
+       orientation that minimises the pad-level wire length to its neighbours —
+       this is what removes airwire crossings.
+    4. Snap to grid and return *proposed* {ref:[x,y,rot]} positions. It does
+       NOT modify the board unless ``apply=true``.
+
+It reuses ComponentCommands._footprint_courtyard_bbox so the collision model is
+identical to check_courtyard_overlaps (AABB on the real courtyard polygon).
+Intended loop:
+
+    suggest_placement(dryRun) -> check_courtyard_overlaps(positions=...) ->
+    apply -> autoroute(best-of-N) -> run_drc
+
+Quality metric reported is pad-level HPWL (half-perimeter wire length), the
+standard placement proxy for routed length — lower is better.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Dict, List, Optional, Tuple
+
+import pcbnew
+
+logger = logging.getLogger("kicad_interface")
+
+# Net-name fragments treated as high-current / power and pulled short & direct
+# (step 4 of the placement priority order). Case-insensitive substring match.
+DEFAULT_POWER_NETS = [
+    "VBAT",
+    "VBUS",
+    "VCC",
+    "VDD",
+    "VIN",
+    "VOUT",
+    "+5V",
+    "+3V3",
+    "+3.3V",
+    "3V3",
+    "5V",
+    "12V",
+    "PWR",
+    "BAT",
+    "VSYS",
+    "PVDD",
+]
+
+
+class PlacementOptimizerCommands:
+    """Mixin providing suggest_placement.
+
+    Expects the host (ComponentCommands) to provide:
+      - self.board                      : the loaded BOARD
+      - self._footprint_courtyard_bbox  : bbox in mm for a footprint
+    so it composes with the existing component handlers.
+    """
+
+    # ------------------------------------------------------------------ #
+    #  Public command                                                    #
+    # ------------------------------------------------------------------ #
+    def suggest_placement(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Propose an optimized placement that shortens net length, orients
+        parts toward their partners, and removes courtyard overlaps — without
+        committing unless asked.
+
+        Args:
+            refs: References to move. Default: every non-locked footprint.
+            locked: References to hold fixed (connectors, mounting-constrained,
+                RF, edge parts). They still pull movable parts. KiCad's own
+                IsLocked() footprints are auto-added here.
+            iterations: Relaxation passes (default 200).
+            grid_mm: Snap proposed positions to this grid (default 0.5).
+            margin_mm: Extra keepout between courtyards (default 0.3).
+            board_outline: Optional {x1,y1,x2,y2,unit} override; else Edge.Cuts.
+            spring_k / repel_k: attraction / repulsion gains.
+            power_nets: Net-name fragments to weight as high-current
+                (default DEFAULT_POWER_NETS). Set [] to disable.
+            power_weight: Pull multiplier for power nets (default 3.0).
+            decoupling_boost: Extra pull for 2-pin-passive <-> multi-pin-IC
+                links so caps/feedback parts hug their IC (default 2.0).
+            rotate: Enable pin-facing rotation (default True).
+            rotation_steps: Candidate orientations in degrees
+                (default [0, 90, 180, 270]).
+            rotation_passes: Greedy rotation sweeps (default 2).
+            apply: If True, move + rotate the components. Default False (dry run).
+
+        Returns:
+            {success, proposals:{ref:[x,y,rot]}, score:{hpwl_before_mm,
+             hpwl_after_mm, improvement_pct, overlaps_before, overlaps_after},
+             applied, summary}
+        """
+        try:
+            if not getattr(self, "board", None):
+                return {
+                    "success": False,
+                    "message": "No board is loaded",
+                    "errorDetails": "Load or create a board first",
+                }
+
+            iterations = int(params.get("iterations", 200))
+            grid_mm = float(params.get("grid_mm", 0.5))
+            margin_mm = float(params.get("margin_mm", 0.3))
+            spring_k = float(params.get("spring_k", 0.08))
+            repel_k = float(params.get("repel_k", 0.6))
+            power_nets = [s.upper() for s in params.get("power_nets", DEFAULT_POWER_NETS)]
+            power_weight = float(params.get("power_weight", 3.0))
+            decoupling_boost = float(params.get("decoupling_boost", 2.0))
+            do_rotate = bool(params.get("rotate", True))
+            rotation_steps = list(params.get("rotation_steps", [0, 90, 180, 270]))
+            rotation_passes = int(params.get("rotation_passes", 2))
+            apply = bool(params.get("apply", False))
+
+            locked = set(params.get("locked") or [])
+            ref_filter = params.get("refs")
+            ref_filter = set(ref_filter) if ref_filter is not None else None
+
+            outline = self._opt_resolve_outline(params.get("board_outline"))
+            # Optional tighter box confining the MOVABLE parts (e.g. the area
+            # beside one IC). Movers are clamped to this; falls back to outline.
+            region = self._opt_resolve_outline(params.get("bounds")) or outline
+            net_names = self._opt_net_name_map()
+
+            move_set = set(ref_filter) if ref_filter is not None else None
+
+            # --- Collect EVERY footprint so locked ICs / neighbours still
+            #     anchor and pull, even in scoped (refs=...) mode. A part is
+            #     "fixed" if it's in `locked`, KiCad-locked, or — when `refs` is
+            #     given — not one of the parts we're allowed to move. ---
+            nodes: Dict[str, Dict[str, Any]] = {}
+            for fp in self.board.GetFootprints():
+                ref = fp.GetReference()
+                fixed = (ref in locked) or (move_set is not None and ref not in move_set)
+                node = self._opt_make_node(fp, fixed)
+                if node is not None:
+                    nodes[ref] = node
+
+            if len([n for n in nodes.values() if not n["locked"]]) < 2:
+                return {
+                    "success": False,
+                    "message": "Nothing to optimize",
+                    "errorDetails": "Need >= 2 movable footprints with courtyards.",
+                }
+
+            self._opt_jitter_coincident(nodes, 1.0)
+
+            edges = self._opt_build_edges(
+                nodes, net_names, power_nets, power_weight, decoupling_boost
+            )
+
+            hpwl_before = self._opt_hpwl(nodes)
+            overlaps_before = self._opt_count_overlaps(nodes, margin_mm)
+
+            # --- Relax, then alternate rotation + light re-relax ---
+            self._opt_relax(
+                nodes,
+                edges,
+                region,
+                iterations=iterations,
+                spring_k=spring_k,
+                repel_k=repel_k,
+                margin_mm=margin_mm,
+            )
+            if do_rotate:
+                for _ in range(max(rotation_passes, 0)):
+                    self._opt_rotate_pass(nodes, rotation_steps)
+                    self._opt_relax(
+                        nodes,
+                        edges,
+                        region,
+                        iterations=max(20, iterations // 4),
+                        spring_k=spring_k,
+                        repel_k=repel_k,
+                        margin_mm=margin_mm,
+                    )
+
+            # --- Spread: the springs pack parts into a blob denser than the
+            #     silicon physically fits; diffuse them across free board area
+            #     (transport, which local pairwise pushing cannot do) before
+            #     the final legalize. Skip when explicitly disabled. ---
+            if bool(params.get("spread", True)):
+                self._opt_spread(
+                    nodes,
+                    region,
+                    iterations=int(params.get("spread_iters", 80)),
+                    strength=float(params.get("spread_strength", 0.08)),
+                    margin_mm=margin_mm,
+                )
+
+            # --- Align: the force solve leaves parts at organic offsets; snap
+            #     near-collinear centers onto shared row (Y) and column (X)
+            #     lines so the result reads as tidy rows/columns with items
+            #     centered — like KiCad's align+distribute. Default on. ---
+            if bool(params.get("align", True)):
+                self._opt_align(nodes, float(params.get("align_tol_mm", 1.5)))
+
+            # --- Snap to grid, THEN legalize so separation has the last word
+            #     (snapping after legalize would re-introduce overlaps). ---
+            for n in nodes.values():
+                if n["locked"]:
+                    continue
+                n["x"] = round(n["x"] / grid_mm) * grid_mm
+                n["y"] = round(n["y"] / grid_mm) * grid_mm
+
+            # Springs collapse parts into a pile; push overlapping courtyards
+            # apart until clear (or iterations run out).
+            legalize_iters = int(params.get("legalize_iters", 200))
+            self._opt_legalize(nodes, region, margin_mm, legalize_iters)
+
+            hpwl_after = self._opt_hpwl(nodes)
+            overlaps_after = self._opt_count_overlaps(nodes, margin_mm)
+
+            proposals = {
+                ref: [round(n["x"], 3), round(n["y"], 3), round(n["angle"] % 360, 1)]
+                for ref, n in nodes.items()
+                if not n["locked"]
+            }
+
+            applied = False
+            if apply:
+                for ref, (px, py, rot) in proposals.items():
+                    fp = nodes[ref]["fp"]
+                    fp.SetPosition(pcbnew.VECTOR2I(pcbnew.FromMM(px), pcbnew.FromMM(py)))
+                    fp.SetOrientationDegrees(rot)
+                applied = True
+
+            improvement = (
+                100.0 * (hpwl_before - hpwl_after) / hpwl_before if hpwl_before > 0 else 0.0
+            )
+
+            return {
+                "success": True,
+                "proposals": proposals,
+                "applied": applied,
+                "score": {
+                    "hpwl_before_mm": round(hpwl_before, 2),
+                    "hpwl_after_mm": round(hpwl_after, 2),
+                    "improvement_pct": round(improvement, 1),
+                    "overlaps_before": overlaps_before,
+                    "overlaps_after": overlaps_after,
+                },
+                "summary": {
+                    "movable": len(proposals),
+                    "locked": sum(1 for n in nodes.values() if n["locked"]),
+                    "nets_considered": len(edges),
+                    "iterations": iterations,
+                    "rotated": do_rotate,
+                    "grid_mm": grid_mm,
+                    "margin_mm": margin_mm,
+                    "note": (
+                        (
+                            "Dry run — board unchanged. Validate via "
+                            "check_courtyard_overlaps(positions=proposals), "
+                            "then re-run with apply=true."
+                        )
+                        if not applied
+                        else "Applied to board (not saved)."
+                    ),
+                },
+            }
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"suggest_placement failed: {e}", exc_info=True)
+            return {
+                "success": False,
+                "message": "suggest_placement failed",
+                "errorDetails": str(e),
+            }
+
+    # ------------------------------------------------------------------ #
+    #  Node construction                                                 #
+    # ------------------------------------------------------------------ #
+    def _opt_make_node(self, fp, force_locked) -> Optional[Dict[str, Any]]:
+        bbox = self._footprint_courtyard_bbox(fp, None)
+        if bbox is None:
+            return None
+        x1, y1, x2, y2 = bbox
+        anchor = fp.GetPosition()
+        ax, ay = pcbnew.ToMM(anchor.x), pcbnew.ToMM(anchor.y)
+        angle0 = fp.GetOrientationDegrees()
+
+        # Courtyard center expressed in the footprint's *local* (un-rotated)
+        # frame, so we can re-project it after a rotation.
+        cwx, cwy = (x1 + x2) / 2.0 - ax, (y1 + y2) / 2.0 - ay
+        lox, loy = self._opt_rot(cwx, cwy, -angle0)
+        hw0, hh0 = max((x2 - x1) / 2.0, 0.01), max((y2 - y1) / 2.0, 0.01)
+
+        # Pad geometry in the footprint-local (un-rotated) frame, so that
+        # world pad = anchor + R(angle)*local. PAD.GetPos0() isn't exposed on
+        # every KiCad SWIG build, so derive it from the absolute pad position:
+        # local = R(-angle0) * (pad_abs - anchor).
+        pads = []
+        for pad in fp.Pads():
+            code = pad.GetNetCode()
+            if code <= 0:
+                continue
+            pp = pad.GetPosition()
+            wx = pcbnew.ToMM(pp.x - anchor.x)
+            wy = pcbnew.ToMM(pp.y - anchor.y)
+            lx, ly = self._opt_rot(wx, wy, -angle0)
+            pads.append((code, lx, ly))
+
+        node = {
+            "fp": fp,
+            "x": ax,
+            "y": ay,  # working position = footprint anchor (mm)
+            "angle": angle0,
+            "angle0": angle0,
+            "loff": (lox, loy),  # courtyard-center offset, local frame
+            "hw0": hw0,
+            "hh0": hh0,  # half-sizes at angle0
+            "pads": pads,
+            "pins": fp.GetPadCount() if hasattr(fp, "GetPadCount") else len(pads),
+            "locked": force_locked or bool(fp.IsLocked()),
+        }
+        self._opt_apply_angle(node, angle0)  # sets cox/coy, hw/hh
+        return node
+
+    def _opt_apply_angle(self, n, angle) -> None:
+        """Set a node's orientation and refresh courtyard center-offset + halfs."""
+        n["angle"] = angle
+        lox, loy = n["loff"]
+        n["cox"], n["coy"] = self._opt_rot(lox, loy, angle)
+        # Half-sizes swap on odd 90-degree multiples (exact for AABB courtyards).
+        quarter = int(round((angle - n["angle0"]) / 90.0)) % 2
+        if quarter:
+            n["hw"], n["hh"] = n["hh0"], n["hw0"]
+        else:
+            n["hw"], n["hh"] = n["hw0"], n["hh0"]
+
+    # ------------------------------------------------------------------ #
+    #  Edges (weighted connectivity)                                     #
+    # ------------------------------------------------------------------ #
+    def _opt_build_edges(
+        self, nodes, net_names, power_nets, power_weight, decoupling_boost
+    ) -> List[Tuple[str, str, float]]:
+        """Collapse pad nets into weighted component edges.
+
+        - Base weight 1/(fanout-1) so a star net (GND/VCC) contributes constant
+          total pull rather than O(n^2).
+        - Power/high-current nets multiplied by power_weight (short & direct).
+        - A 2-pin passive linked to a multi-pin IC gets decoupling_boost so the
+          cap / feedback resistor hugs the IC.
+        """
+        net_to_refs: Dict[int, set] = {}
+        for ref, n in nodes.items():
+            for code, _, _ in n["pads"]:
+                net_to_refs.setdefault(code, set()).add(ref)
+
+        # Deterministic order: iterate nets and refs sorted, so edge build order
+        # (and thus float-summation order in the relaxation) is reproducible
+        # across runs — the dry-run proposal must match the applied run. Python
+        # set iteration order varies per process (string hash randomisation).
+        weights: Dict[Tuple[str, str], float] = {}
+        for code in sorted(net_to_refs):
+            refs = sorted(net_to_refs[code])
+            fanout = len(refs)
+            if fanout < 2:
+                continue
+            name = net_names.get(code, "").upper()
+            pmult = power_weight if any(p in name for p in power_nets) else 1.0
+            base = pmult / (fanout - 1)
+            for i in range(fanout):
+                for j in range(i + 1, fanout):
+                    a, b = sorted((refs[i], refs[j]))
+                    weights[(a, b)] = weights.get((a, b), 0.0) + base
+
+        edges = []
+        for (a, b), w in weights.items():
+            pa, pb = nodes[a]["pins"], nodes[b]["pins"]
+            if (pa <= 2 < pb) or (pb <= 2 < pa):
+                w *= decoupling_boost
+            edges.append((a, b, w))
+        return edges
+
+    # ------------------------------------------------------------------ #
+    #  Force-directed translation                                        #
+    # ------------------------------------------------------------------ #
+    def _opt_relax(self, nodes, edges, outline, *, iterations, spring_k, repel_k, margin_mm):
+        movable = [r for r, n in nodes.items() if not n["locked"]]
+        refs = list(nodes)
+        for it in range(iterations):
+            temp = 1.0 - (it / max(iterations, 1))
+            max_step = 5.0 * temp + 0.2  # mm
+            fx = {r: 0.0 for r in movable}
+            fy = {r: 0.0 for r in movable}
+
+            # Attraction along nets, with a rest length so connected parts
+            # settle *adjacent* (just touching + margin) instead of collapsing
+            # onto a single point. Spring force = k*w*(dist - rest) along the
+            # center-to-center unit vector: attract when farther than rest,
+            # gently repel when closer.
+            for a, b, w in edges:
+                na, nb = nodes[a], nodes[b]
+                dx = (nb["x"] + nb["cox"]) - (na["x"] + na["cox"])
+                dy = (nb["y"] + nb["coy"]) - (na["y"] + na["coy"])
+                dist = math.hypot(dx, dy) or 1e-6
+                ra = (na["hw"] + na["hh"]) / 2.0
+                rb = (nb["hw"] + nb["hh"]) / 2.0
+                rest = ra + rb + margin_mm
+                f = spring_k * w * (dist - rest)
+                ux, uy = dx / dist, dy / dist
+                if a in fx:
+                    fx[a] += f * ux
+                    fy[a] += f * uy
+                if b in fx:
+                    fx[b] -= f * ux
+                    fy[b] -= f * uy
+
+            # Repulsion only where courtyards (AABB + margin) overlap.
+            for i in range(len(refs)):
+                na = nodes[refs[i]]
+                for j in range(i + 1, len(refs)):
+                    nb = nodes[refs[j]]
+                    dx = (nb["x"] + nb["cox"]) - (na["x"] + na["cox"])
+                    dy = (nb["y"] + nb["coy"]) - (na["y"] + na["coy"])
+                    ox = (na["hw"] + nb["hw"] + margin_mm) - abs(dx)
+                    oy = (na["hh"] + nb["hh"] + margin_mm) - abs(dy)
+                    if ox <= 0 or oy <= 0:
+                        continue
+                    ra, rb = refs[i], refs[j]
+                    if ox < oy:  # push along least-penetration axis
+                        push, s = repel_k * ox, (1.0 if dx >= 0 else -1.0)
+                        if ra in fx:
+                            fx[ra] -= push * s
+                        if rb in fx:
+                            fx[rb] += push * s
+                    else:
+                        push, s = repel_k * oy, (1.0 if dy >= 0 else -1.0)
+                        if ra in fy:
+                            fy[ra] -= push * s
+                        if rb in fy:
+                            fy[rb] += push * s
+
+            for r in movable:
+                n = nodes[r]
+                step = math.hypot(fx[r], fy[r])
+                if step > max_step and step > 0:
+                    scale = max_step / step
+                    fx[r] *= scale
+                    fy[r] *= scale
+                n["x"] += fx[r]
+                n["y"] += fy[r]
+                if outline is not None:
+                    ox1, oy1, ox2, oy2 = outline
+                    n["x"] = min(max(n["x"], ox1 + n["hw"] - n["cox"]), ox2 - n["hw"] - n["cox"])
+                    n["y"] = min(max(n["y"], oy1 + n["hh"] - n["coy"]), oy2 - n["hh"] - n["coy"])
+
+    # ------------------------------------------------------------------ #
+    #  Alignment / tidy (rows + columns, centers aligned)                #
+    # ------------------------------------------------------------------ #
+    def _opt_align(self, nodes, tol):
+        """Snap near-collinear part centers onto shared row/column lines so the
+        layout reads as tidy rows and columns instead of organic offsets.
+
+        Parts whose center Y values fall within `tol` are pulled to a common Y
+        (a row); likewise center X for columns. Aligning on CENTERS means a big
+        IC and a small cap on the same line share a centerline — i.e. centered,
+        the way KiCad's Align Centers + Distribute leaves them. A final legalize
+        (run by the caller afterwards) fixes any spacing this tightens."""
+        movable = [n for n in nodes.values() if not n["locked"]]
+        if len(movable) < 2:
+            return
+        # Rows: cluster on Y (center), columns: cluster on X (center).
+        self._opt_cluster_snap(movable, "y", tol)
+        self._opt_cluster_snap(movable, "x", tol)
+
+    @staticmethod
+    def _opt_cluster_snap(parts, axis, tol):
+        """Group parts whose center on `axis` is within tol of the running group,
+        then set every member's center to the group mean. Deterministic: sorted
+        by center, ties broken by the offset key so order is stable."""
+        off = "cox" if axis == "x" else "coy"
+        pos = "x" if axis == "x" else "y"
+
+        def center(n):
+            return n[pos] + n[off]
+
+        ordered = sorted(parts, key=lambda n: (center(n), n[off]))
+        i = 0
+        while i < len(ordered):
+            group = [ordered[i]]
+            j = i + 1
+            # Extend while the next center is within tol of the group's last.
+            while j < len(ordered) and center(ordered[j]) - center(group[-1]) <= tol:
+                group.append(ordered[j])
+                j += 1
+            mean = sum(center(g) for g in group) / len(group)
+            for g in group:
+                g[pos] = mean - g[off]
+            i = j
+
+    # ------------------------------------------------------------------ #
+    #  Density spreading (cell diffusion)                                #
+    # ------------------------------------------------------------------ #
+    def _opt_spread(self, nodes, region, *, iterations, strength, margin_mm):
+        """Diffuse movable parts down the area-density gradient so they occupy
+        the whole region instead of a single over-packed blob.
+
+        This is the 'global spreading' half of analytical placement: bin the
+        region, build a density field (movable + fixed parts as mass), and move
+        each movable part opposite the local gradient. Unlike pairwise pushing,
+        the gradient transports a part across many bins toward genuinely free
+        area — which is what fixes the whole-board over-pack. A light legalize
+        afterwards cleans the residual touching pairs."""
+        if region is None:
+            return
+        rx1, ry1, rx2, ry2 = region
+        rw, rh = rx2 - rx1, ry2 - ry1
+        if rw <= 0 or rh <= 0:
+            return
+
+        movable = [n for n in nodes.values() if not n["locked"]]
+        if not movable:
+            return
+
+        # Bin grid: aim for a few parts per bin; clamp to a sane range.
+        n = len(nodes)
+        nx = max(4, min(48, int(math.sqrt(max(n, 1)) * 1.5)))
+        ny = max(4, min(48, int(round(nx * rh / rw)))) if rw > 0 else nx
+        bw, bh = rw / nx, rh / ny
+        bin_area = max(bw * bh, 1e-6)
+
+        def bin_of(cx, cy):
+            i = min(max(int((cx - rx1) / bw), 0), nx - 1)
+            j = min(max(int((cy - ry1) / bh), 0), ny - 1)
+            return i, j
+
+        for it in range(iterations):
+            temp = 1.0 - (it / max(iterations, 1))
+            # Build density (mm^2 of courtyard area per bin), all parts count
+            # as mass so movers also flow around locked ICs.
+            dens = [[0.0] * ny for _ in range(nx)]
+            for nd in nodes.values():
+                area = (2 * nd["hw"]) * (2 * nd["hh"])
+                i, j = bin_of(nd["x"] + nd["cox"], nd["y"] + nd["coy"])
+                dens[i][j] += area
+            # One Jacobi blur pass to smooth the gradient.
+            sm = [[0.0] * ny for _ in range(nx)]
+            for i in range(nx):
+                for j in range(ny):
+                    acc, cnt = 0.0, 0
+                    for di in (-1, 0, 1):
+                        for dj in (-1, 0, 1):
+                            a, b = i + di, j + dj
+                            if 0 <= a < nx and 0 <= b < ny:
+                                acc += dens[a][b]
+                                cnt += 1
+                    sm[i][j] = acc / cnt
+            # Move each movable part opposite the local density gradient.
+            for nd in movable:
+                cx, cy = nd["x"] + nd["cox"], nd["y"] + nd["coy"]
+                i, j = bin_of(cx, cy)
+                ip, im = min(i + 1, nx - 1), max(i - 1, 0)
+                jp, jm = min(j + 1, ny - 1), max(j - 1, 0)
+                gx = (sm[ip][j] - sm[im][j]) / (2 * bw)
+                gy = (sm[i][jp] - sm[i][jm]) / (2 * bh)
+                # Only spread out of bins fuller than the region average; this
+                # keeps already-sparse areas from jittering.
+                over = sm[i][j] / bin_area
+                step_x = -strength * gx * over * temp
+                step_y = -strength * gy * over * temp
+                mag = math.hypot(step_x, step_y)
+                cap = 0.5 * min(bw, bh)
+                if mag > cap and mag > 0:
+                    step_x *= cap / mag
+                    step_y *= cap / mag
+                nd["x"] += step_x
+                nd["y"] += step_y
+                nd["x"] = min(max(nd["x"], rx1 + nd["hw"] - nd["cox"]), rx2 - nd["hw"] - nd["cox"])
+                nd["y"] = min(max(nd["y"], ry1 + nd["hh"] - nd["coy"]), ry2 - nd["hh"] - nd["coy"])
+
+    # ------------------------------------------------------------------ #
+    #  Legalization (remove courtyard overlaps)                          #
+    # ------------------------------------------------------------------ #
+    def _opt_legalize(self, nodes, outline, margin_mm, iterations):
+        """Push overlapping courtyards apart until none overlap (or iterations
+        run out). No spring pull here — this only separates, preserving the
+        relative arrangement the optimizer found. Locked parts don't move, so a
+        movable part overlapping a locked one takes the full push."""
+        refs = list(nodes)
+        prev_overlaps = None
+        stall = 0
+        for it in range(iterations):
+            # Accumulate (summed, not averaged) every pair's separation, then
+            # apply once. Summed opposing pushes don't cancel a part out of
+            # existence — they expand the whole cluster outward, which is what
+            # relieves a wedged part.
+            push = {r: [0.0, 0.0] for r in refs}
+            overlaps = 0
+            for i in range(len(refs)):
+                na = nodes[refs[i]]
+                for j in range(i + 1, len(refs)):
+                    nb = nodes[refs[j]]
+                    if na["locked"] and nb["locked"]:
+                        continue
+                    dx = (nb["x"] + nb["cox"]) - (na["x"] + na["cox"])
+                    dy = (nb["y"] + nb["coy"]) - (na["y"] + na["coy"])
+                    ox = (na["hw"] + nb["hw"] + margin_mm) - abs(dx)
+                    oy = (na["hh"] + nb["hh"] + margin_mm) - abs(dy)
+                    if ox <= 0 or oy <= 0:
+                        continue
+                    overlaps += 1
+                    # Separate along the cheaper (least-penetration) axis.
+                    if ox < oy:
+                        sx = ox if dx >= 0 else -ox
+                        sy = 0.0
+                    else:
+                        sx = 0.0
+                        sy = oy if dy >= 0 else -oy
+                    a_mov, b_mov = (not na["locked"]), (not nb["locked"])
+                    share = 0.5 if (a_mov and b_mov) else 1.0
+                    ra, rb = refs[i], refs[j]
+                    if a_mov:
+                        push[ra][0] -= sx * share
+                        push[ra][1] -= sy * share
+                    if b_mov:
+                        push[rb][0] += sx * share
+                        push[rb][1] += sy * share
+            if overlaps == 0:
+                break
+
+            # Stall detection: if the overlap count stops improving, nudge every
+            # contended part radially outward from the cluster centroid to break
+            # a symmetric wedge (deterministic — index-based, no RNG).
+            if prev_overlaps is not None and overlaps >= prev_overlaps:
+                stall += 1
+            else:
+                stall = 0
+            prev_overlaps = overlaps
+            if stall >= 3:
+                self._opt_explode(nodes, push, 0.4)
+                stall = 0
+
+            for r in refs:
+                n = nodes[r]
+                if n["locked"]:
+                    continue
+                dx, dy = push[r]
+                # Cap per-iteration motion so a big summed push can't blow up.
+                mag = math.hypot(dx, dy)
+                if mag > 1.5 and mag > 0:
+                    dx *= 1.5 / mag
+                    dy *= 1.5 / mag
+                n["x"] += dx
+                n["y"] += dy
+                if outline is not None:
+                    ox1, oy1, ox2, oy2 = outline
+                    n["x"] = min(max(n["x"], ox1 + n["hw"] - n["cox"]), ox2 - n["hw"] - n["cox"])
+                    n["y"] = min(max(n["y"], oy1 + n["hh"] - n["coy"]), oy2 - n["hh"] - n["coy"])
+
+    def _opt_explode(self, nodes, push, amount):
+        """Add a small outward bias from the movable-parts centroid to any part
+        currently being pushed, to break a symmetric stall."""
+        movable = [n for n in nodes.values() if not n["locked"]]
+        if not movable:
+            return
+        cx = sum(n["x"] + n["cox"] for n in movable) / len(movable)
+        cy = sum(n["y"] + n["coy"] for n in movable) / len(movable)
+        for ref, n in nodes.items():
+            if n["locked"] or push[ref] == [0.0, 0.0]:
+                continue
+            vx = (n["x"] + n["cox"]) - cx
+            vy = (n["y"] + n["coy"]) - cy
+            d = math.hypot(vx, vy) or 1e-6
+            push[ref][0] += amount * vx / d
+            push[ref][1] += amount * vy / d
+
+    # ------------------------------------------------------------------ #
+    #  Pin-facing rotation (greedy, pad-accurate)                        #
+    # ------------------------------------------------------------------ #
+    def _opt_rotate_pass(self, nodes, steps):
+        """For each movable part, pick the orientation (from `steps`) that
+        minimises the pad-level HPWL of the nets it touches, holding every other
+        part fixed. Emergently orients 2-pad parts toward their partners and
+        unwinds crossings."""
+        movable = [r for r, n in nodes.items() if not n["locked"]]
+        for ref in movable:
+            n = nodes[ref]
+            nets = {c for c, _, _ in n["pads"]}
+            if not nets:
+                continue
+            # Fixed contribution from every OTHER node, per net.
+            other = self._opt_net_extents(nodes, exclude=ref, only=nets)
+            best_angle, best_cost = n["angle"], float("inf")
+            for da in steps:
+                angle = (n["angle0"] + da) % 360
+                cost = self._opt_rot_cost(n, angle, other)
+                if cost < best_cost - 1e-9:
+                    best_cost, best_angle = cost, angle
+            self._opt_apply_angle(n, best_angle)
+
+    def _opt_rot_cost(self, n, angle, other_extents) -> float:
+        """Sum of net bbox spans for this node's nets at the given orientation,
+        combined with the precomputed extents of all other nodes."""
+        ax, ay = n["x"], n["y"]
+        local = {}  # net -> [minx, miny, maxx, maxy]
+        for code, px0, py0 in n["pads"]:
+            wx, wy = self._opt_rot(px0, py0, angle)
+            wx += ax
+            wy += ay
+            e = local.get(code)
+            if e is None:
+                local[code] = [wx, wy, wx, wy]
+            else:
+                e[0] = min(e[0], wx)
+                e[1] = min(e[1], wy)
+                e[2] = max(e[2], wx)
+                e[3] = max(e[3], wy)
+        total = 0.0
+        for code, e in local.items():
+            o = other_extents.get(code)
+            if o is None:
+                continue  # net only on this part — no contribution
+            minx = min(e[0], o[0])
+            miny = min(e[1], o[1])
+            maxx = max(e[2], o[2])
+            maxy = max(e[3], o[3])
+            total += (maxx - minx) + (maxy - miny)
+        return total
+
+    def _opt_net_extents(self, nodes, *, exclude=None, only=None):
+        """net code -> [minx,miny,maxx,maxy] of world pad positions, excluding
+        one ref, optionally restricted to a set of net codes."""
+        ext: Dict[int, List[float]] = {}
+        for ref, n in nodes.items():
+            if ref == exclude:
+                continue
+            ax, ay, angle = n["x"], n["y"], n["angle"]
+            for code, px0, py0 in n["pads"]:
+                if only is not None and code not in only:
+                    continue
+                wx, wy = self._opt_rot(px0, py0, angle)
+                wx += ax
+                wy += ay
+                e = ext.get(code)
+                if e is None:
+                    ext[code] = [wx, wy, wx, wy]
+                else:
+                    e[0] = min(e[0], wx)
+                    e[1] = min(e[1], wy)
+                    e[2] = max(e[2], wx)
+                    e[3] = max(e[3], wy)
+        return ext
+
+    # ------------------------------------------------------------------ #
+    #  Scoring / metrics                                                 #
+    # ------------------------------------------------------------------ #
+    def _opt_hpwl(self, nodes) -> float:
+        """Pad-level half-perimeter wire length over all nets (mm)."""
+        ext = self._opt_net_extents(nodes)
+        total = 0.0
+        for e in ext.values():
+            total += (e[2] - e[0]) + (e[3] - e[1])
+        return total
+
+    def _opt_count_overlaps(self, nodes, margin_mm) -> int:
+        refs = list(nodes)
+        count = 0
+        for i in range(len(refs)):
+            na = nodes[refs[i]]
+            for j in range(i + 1, len(refs)):
+                nb = nodes[refs[j]]
+                dx = abs((nb["x"] + nb["cox"]) - (na["x"] + na["cox"]))
+                dy = abs((nb["y"] + nb["coy"]) - (na["y"] + na["coy"]))
+                if dx < na["hw"] + nb["hw"] + margin_mm and dy < na["hh"] + nb["hh"] + margin_mm:
+                    count += 1
+        return count
+
+    # ------------------------------------------------------------------ #
+    #  Small helpers                                                     #
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _opt_rot(x, y, deg) -> Tuple[float, float]:
+        rad = math.radians(deg)
+        c, s = math.cos(rad), math.sin(rad)
+        return (x * c - y * s, x * s + y * c)
+
+    def _opt_net_name_map(self) -> Dict[int, str]:
+        names: Dict[int, str] = {}
+        try:
+            for code, net in self.board.GetNetInfo().NetsByNetcode().items():
+                names[code] = net.GetNetname()
+        except Exception:  # noqa: BLE001
+            pass
+        return names
+
+    def _opt_jitter_coincident(self, nodes, spread) -> None:
+        """Deterministically separate parts sharing the exact same point so the
+        first repulsion pass has a direction to push (no RNG — index-based)."""
+        seen: Dict[Tuple[float, float], int] = {}
+        for ref, n in sorted(nodes.items()):
+            if n["locked"]:
+                continue
+            key = (round(n["x"], 3), round(n["y"], 3))
+            k = seen.get(key, 0)
+            if k:
+                ang = 2.0 * math.pi * (k / 8.0)
+                n["x"] += spread * math.cos(ang)
+                n["y"] += spread * math.sin(ang)
+            seen[key] = k + 1
+
+    def _opt_resolve_outline(self, override):
+        if override:
+            unit = override.get("unit", "mm")
+            f = {"inch": 25.4, "mil": 0.0254}.get(unit, 1.0)  # -> mm
+            return (override["x1"] * f, override["y1"] * f, override["x2"] * f, override["y2"] * f)
+        try:
+            box = self.board.GetBoardEdgesBoundingBox()
+            if box.GetWidth() > 0 and box.GetHeight() > 0:
+                return (
+                    pcbnew.ToMM(box.GetLeft()),
+                    pcbnew.ToMM(box.GetTop()),
+                    pcbnew.ToMM(box.GetRight()),
+                    pcbnew.ToMM(box.GetBottom()),
+                )
+        except Exception:  # noqa: BLE001
+            pass
+        return None

--- a/python/commands/schematic_declutter.py
+++ b/python/commands/schematic_declutter.py
@@ -1,0 +1,387 @@
+"""Schematic label declutter — re-orient overlapping net/global labels so their
+text lands in free space and becomes readable.
+
+Phase 1: net/global labels only. Free-form text, Ref/Value fields, and symbol
+spreading + wire reroute are deliberately separate, later phases.
+
+Why labels and not "placement": a net label's (at x y) IS its electrical
+connection point. Moving the anchor off its wire would disconnect the net. So
+this tool holds every label's anchor FIXED and only changes its orientation
+(0/90/180/270) and justification — which side the text renders toward. That
+throws the text into empty space without touching connectivity.
+
+Dry run by default (mirrors suggest_placement): returns proposals
+{name, at, from_angle -> to_angle} plus an overlap score, WITHOUT modifying the
+schematic. Set apply=true to rewrite the label blocks.
+
+Symbol spreading + wire reroute is a deliberately separate, later phase — it
+changes geometry and must rebuild wires/junctions, which is far riskier.
+
+The geometry is kept as module-level pure functions so it is unit-testable
+without a live KiCad / kicad-skip environment.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("kicad_interface")
+
+_GRID = 1.27  # 50-mil KiCad schematic grid (mm)
+_CHARS_PER_MM = 1.5  # matches schematic_field_layout's label_bbox model
+_TEXT_HEIGHT = 1.27
+_ORIENTATIONS = (0, 90, 180, 270)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Pure geometry (unit-testable, no KiCad deps)
+# ──────────────────────────────────────────────────────────────────────────
+def _label_bbox(lx: float, ly: float, angle: float, name: str) -> Dict[str, float]:
+    """Axis-aligned bbox of a label's text, anchored at (lx, ly), for one of the
+    four orientations. Mirrors schematic_field_layout.label_bbox so overlap
+    results stay consistent with the rest of the codebase."""
+    length = max(len(name), 1) * _CHARS_PER_MM + 1.0
+    half_h = _TEXT_HEIGHT / 2.0
+    a = round(angle / 90) * 90 % 360
+    if a == 0:  # text extends +x (justify left)
+        return {"x_min": lx, "y_min": ly - half_h, "x_max": lx + length, "y_max": ly + half_h}
+    if a == 90:  # text extends -y (up)
+        return {"x_min": lx - half_h, "y_min": ly - length, "x_max": lx + half_h, "y_max": ly}
+    if a == 180:  # text extends -x (justify right)
+        return {"x_min": lx - length, "y_min": ly - half_h, "x_max": lx, "y_max": ly + half_h}
+    return {"x_min": lx - half_h, "y_min": ly, "x_max": lx + half_h, "y_max": ly + length}
+
+
+def _bbox_overlaps(a: Dict[str, float], b: Dict[str, float], margin: float = 0.0) -> bool:
+    return (
+        a["x_min"] - margin < b["x_max"]
+        and a["x_max"] + margin > b["x_min"]
+        and a["y_min"] - margin < b["y_max"]
+        and a["y_max"] + margin > b["y_min"]
+    )
+
+
+def _justify_for_angle(angle: float) -> str:
+    """KiCad flips horizontal justification for the left-pointing orientations."""
+    a = round(angle / 90) * 90 % 360
+    return "right" if a in (180, 270) else "left"
+
+
+def _best_orientation(
+    label: Dict[str, Any],
+    obstacles: List[Dict[str, float]],
+    margin: float,
+) -> Tuple[int, int]:
+    """Pick the orientation whose text bbox collides with the fewest obstacles.
+    Ties prefer the label's CURRENT angle (stability), then 0/180 over 90/270
+    (horizontal text reads easier). Returns (angle, collision_count)."""
+    lx, ly, name = label["x"], label["y"], label["name"]
+    cur = round(label["angle"] / 90) * 90 % 360
+
+    def collisions(angle: int) -> int:
+        bb = _label_bbox(lx, ly, angle, name)
+        return sum(1 for ob in obstacles if _bbox_overlaps(bb, ob, margin))
+
+    best_angle, best_n, best_rank = cur, collisions(cur), (0, 0)
+    for angle in _ORIENTATIONS:
+        n = collisions(angle)
+        # rank: prefer current angle, then horizontal orientations
+        rank = (0 if angle == cur else 1, 0 if angle in (0, 180) else 1)
+        if n < best_n or (n == best_n and rank < best_rank):
+            best_angle, best_n, best_rank = angle, n, rank
+    return best_angle, best_n
+
+
+def _count_label_overlaps(
+    labels: List[Dict[str, Any]],
+    static_obstacles: List[Dict[str, float]],
+    margin: float,
+) -> int:
+    """Total collision incidents: label–label pairs plus label–obstacle hits,
+    using each label's current angle."""
+    bbs = [_label_bbox(lb["x"], lb["y"], lb["angle"], lb["name"]) for lb in labels]
+    n = 0
+    for i in range(len(bbs)):
+        for j in range(i + 1, len(bbs)):
+            if _bbox_overlaps(bbs[i], bbs[j], margin):
+                n += 1
+        for ob in static_obstacles:
+            if _bbox_overlaps(bbs[i], ob, margin):
+                n += 1
+    return n
+
+
+def plan_label_declutter(
+    labels: List[Dict[str, Any]],
+    static_obstacles: List[Dict[str, float]],
+    margin: float,
+) -> Tuple[List[Dict[str, Any]], int, int]:
+    """Core solver (pure). `labels` = [{name,x,y,angle,type}]; `static_obstacles`
+    = fixed bboxes (component bodies, free text, pins). Greedily re-orients each
+    label that currently collides, accounting for the labels already re-oriented
+    this pass. Returns (proposals, overlaps_before, overlaps_after)."""
+    before = _count_label_overlaps(labels, static_obstacles, margin)
+
+    # Work on a copy of angles; treat other labels (with their working angle) as
+    # obstacles too, so we don't just shove the collision next door.
+    work = [dict(lb) for lb in labels]
+    proposals: List[Dict[str, Any]] = []
+
+    # Process most-collided labels first for a better greedy outcome.
+    def cur_collisions(idx: int) -> int:
+        lb = work[idx]
+        bb = _label_bbox(lb["x"], lb["y"], lb["angle"], lb["name"])
+        obs = static_obstacles + [
+            _label_bbox(o["x"], o["y"], o["angle"], o["name"])
+            for k, o in enumerate(work)
+            if k != idx
+        ]
+        return sum(1 for ob in obs if _bbox_overlaps(bb, ob, margin))
+
+    order = sorted(range(len(work)), key=cur_collisions, reverse=True)
+    for idx in order:
+        lb = work[idx]
+        if cur_collisions(idx) == 0:
+            continue
+        others = static_obstacles + [
+            _label_bbox(o["x"], o["y"], o["angle"], o["name"])
+            for k, o in enumerate(work)
+            if k != idx
+        ]
+        new_angle, _ = _best_orientation(lb, others, margin)
+        if new_angle != round(lb["angle"] / 90) * 90 % 360:
+            proposals.append(
+                {
+                    "type": lb.get("type", "net"),
+                    "name": lb["name"],
+                    "at": [round(lb["x"], 3), round(lb["y"], 3)],
+                    "from_angle": round(lb["angle"] / 90) * 90 % 360,
+                    "to_angle": new_angle,
+                    "from_justify": _justify_for_angle(lb["angle"]),
+                    "to_justify": _justify_for_angle(new_angle),
+                }
+            )
+            lb["angle"] = new_angle
+
+    after = _count_label_overlaps(work, static_obstacles, margin)
+    return proposals, before, after
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Raw-text editing for apply
+# ──────────────────────────────────────────────────────────────────────────
+def _reorient_label_in_text(
+    content: str, name: str, x: float, y: float, new_angle: int, new_justify: str
+) -> Tuple[str, bool]:
+    """Rewrite the (at x y angle) and (justify ...) of the label whose name and
+    anchor match (x, y) within grid tolerance. Returns (new_content, changed)."""
+    # Match a label / global_label / hierarchical_label block opening with the
+    # given quoted name, then its (at X Y A). Tolerant float compare on X/Y.
+    name_esc = re.escape(name)
+    pat = re.compile(
+        r'(\((?:label|global_label|hierarchical_label)\s+"'
+        + name_esc
+        + r'"\s+\(at\s+)(-?[0-9.]+)\s+(-?[0-9.]+)\s+(-?[0-9.]+)(\))'
+    )
+    out = []
+    last = 0
+    changed = False
+    for m in pat.finditer(content):
+        lx, ly = float(m.group(2)), float(m.group(3))
+        if abs(lx - x) > _GRID / 2 or abs(ly - y) > _GRID / 2:
+            continue
+        # Replace the angle in this (at ...).
+        out.append(content[last : m.start()])
+        out.append(f"{m.group(1)}{m.group(2)} {m.group(3)} {new_angle}{m.group(5)}")
+        last = m.end()
+        changed = True
+    out.append(content[last:])
+    content = "".join(out)
+    if changed:
+        # Update the FIRST justify after this label's anchor. Best-effort: rewrite
+        # the justify token nearest the matched anchor coordinates.
+        content = _set_justify_near(content, name, x, y, new_justify)
+    return content, changed
+
+
+def _set_justify_near(content: str, name: str, x: float, y: float, justify: str) -> str:
+    """Set the horizontal justify of the label block identified by name+anchor.
+    Replaces an existing (justify left|right ...) keeping any vertical token; if
+    the label has NO justify token (KiCad omits it for default-left labels),
+    injects one as the last child of the (effects ...) group so a 180/270
+    reorientation actually flips the text."""
+    name_esc = re.escape(name)
+    block_pat = re.compile(
+        r'\((?:label|global_label|hierarchical_label)\s+"'
+        + name_esc
+        + r'"\s+\(at\s+(-?[0-9.]+)\s+(-?[0-9.]+)\s+-?[0-9.]+\).*?\(uuid',
+        re.DOTALL,
+    )
+    just_pat = re.compile(r"\(justify\s+(left|right)([^)]*)\)")
+
+    def repl_block(bm: "re.Match[str]") -> str:
+        lx, ly = float(bm.group(1)), float(bm.group(2))
+        if abs(lx - x) > _GRID / 2 or abs(ly - y) > _GRID / 2:
+            return bm.group(0)
+        block = bm.group(0)
+        if just_pat.search(block):
+            return just_pat.sub(lambda jm: f"(justify {justify}{jm.group(2)})", block, count=1)
+        return _inject_justify_into_effects(block, justify)
+
+    return block_pat.sub(repl_block, content)
+
+
+def _inject_justify_into_effects(block: str, justify: str) -> str:
+    """Insert (justify <justify>) as the last child of the first (effects ...)
+    group in `block`, by paren-matching (quote-aware). Returns block unchanged
+    if there is no effects group."""
+    idx = block.find("(effects")
+    if idx == -1:
+        return block
+    depth = 0
+    in_str = False
+    i = idx
+    while i < len(block):
+        c = block[i]
+        if c == '"' and block[i - 1] != "\\":
+            in_str = not in_str
+        elif not in_str:
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    return block[:i] + f" (justify {justify})" + block[i:]
+        i += 1
+    return block
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Command handler
+# ──────────────────────────────────────────────────────────────────────────
+class SchematicDeclutterCommands:
+    """Handler for suggest_schematic_declutter."""
+
+    def suggest_schematic_declutter(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Re-orient overlapping net/global labels so their text is readable.
+
+        Args:
+            schematicPath: Path to the .kicad_sch file (required).
+            margin: Extra clearance in mm when testing overlap (default 0.3).
+            references: Optional list limiting which component bodies count as
+                obstacles / which sheet area to consider (default: whole sheet).
+            apply: If true, rewrite the label orientations. Default false (dry
+                run — returns proposals only, schematic untouched).
+
+        Returns:
+            {success, proposals:[{name, at, from_angle, to_angle, ...}],
+             score:{overlaps_before, overlaps_after}, applied, summary}
+        """
+        try:
+            schematic_path = params.get("schematicPath")
+            if not schematic_path:
+                return {"success": False, "message": "schematicPath is required"}
+            sch_path = Path(schematic_path)
+            if not sch_path.exists():
+                return {"success": False, "message": f"Schematic not found: {schematic_path}"}
+
+            margin = float(params.get("margin", 0.3))
+            apply = bool(params.get("apply", False))
+
+            labels, obstacles = self._gather(sch_path, params.get("references"))
+            if len(labels) < 1:
+                return {
+                    "success": True,
+                    "proposals": [],
+                    "score": {"overlaps_before": 0, "overlaps_after": 0},
+                    "applied": False,
+                    "summary": {"labels": 0, "note": "No net/global labels found."},
+                }
+
+            proposals, before, after = plan_label_declutter(labels, obstacles, margin)
+
+            applied = False
+            if apply and proposals:
+                content = sch_path.read_text(encoding="utf-8")
+                n = 0
+                for p in proposals:
+                    content, changed = _reorient_label_in_text(
+                        content,
+                        p["name"],
+                        p["at"][0],
+                        p["at"][1],
+                        p["to_angle"],
+                        p["to_justify"],
+                    )
+                    n += 1 if changed else 0
+                if n:
+                    sch_path.write_text(content, encoding="utf-8")
+                applied = True
+
+            return {
+                "success": True,
+                "proposals": proposals,
+                "score": {"overlaps_before": before, "overlaps_after": after},
+                "applied": applied,
+                "summary": {
+                    "labels": len(labels),
+                    "obstacles": len(obstacles),
+                    "reoriented": len(proposals),
+                    "margin_mm": margin,
+                    "note": (
+                        (
+                            "Dry run — schematic unchanged. Re-run with apply=true "
+                            "to write the new label orientations."
+                        )
+                        if not applied
+                        else "Applied (label anchors unchanged; nets intact)."
+                    ),
+                },
+            }
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"suggest_schematic_declutter failed: {e}", exc_info=True)
+            return {
+                "success": False,
+                "message": "suggest_schematic_declutter failed",
+                "errorDetails": str(e),
+            }
+
+    # -- data gathering (kept thin; geometry lives in the pure functions) ----
+    def _gather(
+        self, sch_path: Path, references: Optional[List[str]]
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, float]]]:
+        """Collect net/global labels and the static obstacle bboxes (component
+        bodies + free text). Reuses the field-layout gatherers."""
+        from commands.pin_locator import PinLocator
+        from commands.schematic import SchematicManager
+        from commands.schematic_field_layout import _gather_components, _gather_labels
+
+        schematic = SchematicManager.load_schematic(str(sch_path))
+        if not schematic:
+            raise RuntimeError("Failed to load schematic")
+        raw = sch_path.read_text(encoding="utf-8")
+        locator = PinLocator()
+
+        labels = [
+            {
+                "name": lb["name"],
+                "x": lb["position"]["x"],
+                "y": lb["position"]["y"],
+                "angle": lb.get("angle", 0),
+                "type": lb.get("type", "net"),
+            }
+            for lb in _gather_labels(schematic)
+        ]
+
+        ref_set = set(references) if references else None
+        obstacles: List[Dict[str, float]] = []
+        for comp in _gather_components(schematic, sch_path, raw, locator):
+            if ref_set is not None and comp["reference"] not in ref_set:
+                continue
+            bb = comp.get("body_bbox")
+            if bb:
+                obstacles.append(dict(bb))
+        return labels, obstacles

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -327,6 +327,7 @@ try:
     from commands.routing import RoutingCommands
     from commands.schematic import SchematicManager
     from commands.schematic_batch import SchematicBatchCommands
+    from commands.schematic_declutter import SchematicDeclutterCommands
     from commands.schematic_field_layout import SchematicFieldLayoutCommands
     from commands.schematic_hierarchy import SchematicHierarchyCommands
     from commands.symbol_creator import SymbolCreator
@@ -397,6 +398,8 @@ class KiCADInterface(SchematicHandlersMixin):
         self.hierarchy_commands = SchematicHierarchyCommands(self)
         # Schematic field placement / layout-check commands
         self.field_layout_commands = SchematicFieldLayoutCommands()
+        # Schematic label declutter (re-orient overlapping labels)
+        self.declutter_commands = SchematicDeclutterCommands()
         # Batch schematic authoring commands (need an interface back-reference for the
         # single-item add/edit/get handlers, footprint library, and sub-sheet fixer)
         self.batch_commands = SchematicBatchCommands(self)
@@ -446,6 +449,7 @@ class KiCADInterface(SchematicHandlersMixin):
             "place_component_array": self.component_commands.place_component_array,
             "align_components": self.component_commands.align_components,
             "check_courtyard_overlaps": self.component_commands.check_courtyard_overlaps,
+            "suggest_placement": self.component_commands.suggest_placement,
             "duplicate_component": self.component_commands.duplicate_component,
             "set_footprint_type": self.component_commands.set_footprint_type,
             # Routing commands
@@ -495,6 +499,7 @@ class KiCADInterface(SchematicHandlersMixin):
             "set_schematic_property_position": self.field_layout_commands.set_schematic_property_position,
             "batch_set_schematic_property_positions": self.field_layout_commands.batch_set_schematic_property_positions,
             "autoplace_schematic_fields": self.field_layout_commands.autoplace_schematic_fields,
+            "suggest_schematic_declutter": self.declutter_commands.suggest_schematic_declutter,
             # Batch schematic authoring commands
             "batch_add_components": self.batch_commands.batch_add_components,
             "batch_edit_schematic_components": self.batch_commands.batch_edit_schematic_components,

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -265,7 +265,7 @@ BOARD_TOOLS = [
                 "layers": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Layer names to include, e.g. [\"F.Cu\",\"B.Cu\",\"Edge.Cuts\"]. Omit for all layers.",
+                    "description": 'Layer names to include, e.g. ["F.Cu","B.Cu","Edge.Cuts"]. Omit for all layers.',
                 },
                 "responseMode": {
                     "type": "string",
@@ -758,8 +758,7 @@ COMPONENT_TOOLS = [
                 "refs": {
                     "type": "array",
                     "description": (
-                        "Limit the check to these refs (default: every "
-                        "footprint on the board)."
+                        "Limit the check to these refs (default: every " "footprint on the board)."
                     ),
                     "items": {"type": "string"},
                 },
@@ -775,8 +774,7 @@ COMPONENT_TOOLS = [
                 "include_boundary": {
                     "type": "boolean",
                     "description": (
-                        "Also flag courtyards that extend past the board outline "
-                        "(default true)."
+                        "Also flag courtyards that extend past the board outline " "(default true)."
                     ),
                     "default": True,
                 },
@@ -785,6 +783,182 @@ COMPONENT_TOOLS = [
                     "description": (
                         "Optional override for the board outline bbox. Default: "
                         "derived from Edge.Cuts."
+                    ),
+                    "properties": {
+                        "x1": {"type": "number"},
+                        "y1": {"type": "number"},
+                        "x2": {"type": "number"},
+                        "y2": {"type": "number"},
+                        "unit": {
+                            "type": "string",
+                            "enum": ["mm", "mil", "inch"],
+                            "default": "mm",
+                        },
+                    },
+                    "required": ["x1", "y1", "x2", "y2"],
+                },
+            },
+        },
+    },
+    {
+        "name": "suggest_placement",
+        "title": "Suggest Placement",
+        "description": (
+            "Propose an optimized PCB footprint placement that shortens net "
+            "length, orients parts toward their partners, and removes courtyard "
+            "overlaps — the heuristic an engineer does by eye against the "
+            "ratsnest. Force-directed clustering pulls connected parts together "
+            "(a converter's feedback divider and decoupling caps end up hugging "
+            "its IC), power/high-current nets are weighted to stay short & "
+            "direct, and each part is rotated (0/90/180/270) to face its "
+            "neighbours so airwires stop crossing. PCB ONLY — it does not touch "
+            "the schematic. DRY RUN by default: returns proposals "
+            "{ref:[x,y,rot]} plus a score (HPWL before/after, overlap counts) "
+            "WITHOUT modifying the board. Validate proposals via "
+            "check_courtyard_overlaps(positions=proposals), then re-run with "
+            "apply=true (or move_component per ref) before autoroute."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "refs": {
+                    "type": "array",
+                    "description": (
+                        "References to move (default: every non-locked " "footprint on the board)."
+                    ),
+                    "items": {"type": "string"},
+                },
+                "locked": {
+                    "type": "array",
+                    "description": (
+                        "References to hold fixed as anchors — connectors, "
+                        "mounting-constrained parts, RF, edge parts. They still "
+                        "pull movable parts. Footprints KiCad marks locked are "
+                        "added automatically."
+                    ),
+                    "items": {"type": "string"},
+                },
+                "apply": {
+                    "type": "boolean",
+                    "description": (
+                        "If true, move + rotate the components to the proposed "
+                        "positions. Default false (dry run — board untouched)."
+                    ),
+                    "default": False,
+                },
+                "iterations": {
+                    "type": "integer",
+                    "description": "Force-directed relaxation passes (default 200).",
+                    "default": 200,
+                },
+                "grid_mm": {
+                    "type": "number",
+                    "description": "Snap proposed positions to this grid (default 0.5).",
+                    "default": 0.5,
+                },
+                "margin_mm": {
+                    "type": "number",
+                    "description": ("Extra keepout enforced between courtyards (default 0.3)."),
+                    "default": 0.3,
+                },
+                "rotate": {
+                    "type": "boolean",
+                    "description": (
+                        "Enable pin-facing rotation (default true). Disable to "
+                        "keep every part's current orientation."
+                    ),
+                    "default": True,
+                },
+                "spread": {
+                    "type": "boolean",
+                    "description": (
+                        "Enable density spreading (default true). The springs "
+                        "pack parts into a blob denser than they physically fit; "
+                        "spreading diffuses them across free board area so the "
+                        "result is legal (few/zero courtyard overlaps) instead "
+                        "of over-packed. Leave on for whole-board runs."
+                    ),
+                    "default": True,
+                },
+                "align": {
+                    "type": "boolean",
+                    "description": (
+                        "Tidy the result into rows/columns (default true). Snaps "
+                        "near-collinear part centers onto shared row (Y) and "
+                        "column (X) lines so passives line up cleanly with their "
+                        "centers aligned — like KiCad's Align Centers + "
+                        "Distribute — instead of organic offsets. Disable for a "
+                        "pure shortest-wire layout."
+                    ),
+                    "default": True,
+                },
+                "align_tol_mm": {
+                    "type": "number",
+                    "description": (
+                        "Max center spacing (mm) for parts to be pulled onto the "
+                        "same row/column line during align (default 1.5)."
+                    ),
+                    "default": 1.5,
+                },
+                "rotation_steps": {
+                    "type": "array",
+                    "description": (
+                        "Candidate orientations in degrees " "(default [0, 90, 180, 270])."
+                    ),
+                    "items": {"type": "number"},
+                    "default": [0, 90, 180, 270],
+                },
+                "power_nets": {
+                    "type": "array",
+                    "description": (
+                        "Net-name fragments treated as high-current and pulled "
+                        "short & direct (case-insensitive substring match). "
+                        "Defaults to common power rails (VBAT, VBUS, VCC, 3V3, "
+                        "5V, ...). Pass [] to disable power weighting."
+                    ),
+                    "items": {"type": "string"},
+                },
+                "power_weight": {
+                    "type": "number",
+                    "description": "Pull multiplier for power nets (default 3.0).",
+                    "default": 3.0,
+                },
+                "decoupling_boost": {
+                    "type": "number",
+                    "description": (
+                        "Extra pull for 2-pin-passive <-> multi-pin-IC links so "
+                        "caps / feedback parts hug their IC (default 2.0)."
+                    ),
+                    "default": 2.0,
+                },
+                "bounds": {
+                    "type": "object",
+                    "description": (
+                        "SCOPED REGROUP: confine the MOVABLE parts to this box "
+                        "(mm) — e.g. the empty area beside one IC. Combine with "
+                        "`refs` (just that IC's passives) to regroup one cluster "
+                        "at a time; unlisted parts stay put as anchors. Far more "
+                        "reliable than a whole-board run on a dense board, which "
+                        "over-packs. Default: parts may use the whole board."
+                    ),
+                    "properties": {
+                        "x1": {"type": "number"},
+                        "y1": {"type": "number"},
+                        "x2": {"type": "number"},
+                        "y2": {"type": "number"},
+                        "unit": {
+                            "type": "string",
+                            "enum": ["mm", "mil", "inch"],
+                            "default": "mm",
+                        },
+                    },
+                    "required": ["x1", "y1", "x2", "y2"],
+                },
+                "board_outline": {
+                    "type": "object",
+                    "description": (
+                        "Optional override for the board containment bbox. "
+                        "Default: derived from Edge.Cuts."
                     ),
                     "properties": {
                         "x1": {"type": "number"},
@@ -1083,8 +1257,7 @@ ROUTING_TOOLS = [
                 "viaDrill": {
                     "type": "number",
                     "description": (
-                        "Via drill diameter in mm (default 0.3). "
-                        "Must be smaller than viaSize."
+                        "Via drill diameter in mm (default 0.3). " "Must be smaller than viaSize."
                     ),
                     "default": 0.3,
                 },
@@ -1123,9 +1296,7 @@ ROUTING_TOOLS = [
                 },
                 "edgeMargin": {
                     "type": "number",
-                    "description": (
-                        "Keep-out from the board edge in mm. Default 0.5."
-                    ),
+                    "description": ("Keep-out from the board edge in mm. Default 0.5."),
                     "default": 0.5,
                 },
                 "maxVias": {
@@ -2187,6 +2358,55 @@ SCHEMATIC_TOOLS = [
                         "type": "string",
                         "enum": ["wires", "junctions", "labels", "components"],
                     },
+                },
+            },
+            "required": ["schematicPath"],
+        },
+    },
+    {
+        "name": "suggest_schematic_declutter",
+        "title": "Suggest Schematic Declutter",
+        "description": (
+            "Re-orient overlapping net/global labels so their text lands in free "
+            "space and becomes readable. Each label's (at x,y) anchor is its "
+            "electrical connection point, so it is held FIXED — only the "
+            "orientation (0/90/180/270) and justification change, throwing the "
+            "text away from component bodies and other labels. Connectivity is "
+            "never altered. DRY RUN by default: returns proposals "
+            "[{name, at, from_angle, to_angle}] plus an overlap score "
+            "(before/after) WITHOUT modifying the schematic. Set apply=true to "
+            "rewrite the label orientations. Phase 1: labels only; symbol "
+            "spreading + wire reroute is a separate future capability."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "schematicPath": {
+                    "type": "string",
+                    "description": "Path to the .kicad_sch file.",
+                },
+                "margin": {
+                    "type": "number",
+                    "description": (
+                        "Extra clearance in mm when testing label overlap " "(default 0.3)."
+                    ),
+                    "default": 0.3,
+                },
+                "references": {
+                    "type": "array",
+                    "description": (
+                        "Limit which component bodies count as obstacles "
+                        "(default: every component on the sheet)."
+                    ),
+                    "items": {"type": "string"},
+                },
+                "apply": {
+                    "type": "boolean",
+                    "description": (
+                        "If true, rewrite the label orientations. Default false "
+                        "(dry run — schematic untouched, proposals only)."
+                    ),
+                    "default": False,
                 },
             },
             "required": ["schematicPath"],

--- a/src/tools/component.ts
+++ b/src/tools/component.ts
@@ -659,6 +659,120 @@ export function registerComponentTools(server: McpServer, callKicadScript: Comma
   );
 
   // ------------------------------------------------------
+  // Suggest Placement Tool
+  // ------------------------------------------------------
+  server.tool(
+    "suggest_placement",
+    "Propose an optimized PCB footprint placement that shortens net length, orients parts toward their partners, and removes courtyard overlaps. Force-directed clustering pulls connected parts together (a converter's feedback divider and decoupling caps end up hugging its IC), power/high-current nets are weighted short & direct, and each part is rotated (0/90/180/270) to face neighbours so airwires stop crossing. PCB ONLY — does not touch the schematic. DRY RUN by default: returns proposals {ref:[x,y,rot]} plus a score (HPWL before/after, overlap counts) without modifying the board. Validate via check_courtyard_overlaps(positions=proposals), then re-run with apply=true before autoroute.",
+    {
+      refs: z
+        .array(z.string())
+        .optional()
+        .describe("References to move (default: every non-locked footprint on the board)."),
+      locked: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "References to hold fixed as anchors (connectors, mounting-constrained, RF, edge parts). They still pull movable parts. KiCad-locked footprints are added automatically.",
+        ),
+      apply: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, move + rotate components to the proposed positions. Default false (dry run — board untouched).",
+        ),
+      iterations: z
+        .number()
+        .optional()
+        .describe("Force-directed relaxation passes (default 200)."),
+      grid_mm: z
+        .number()
+        .optional()
+        .describe("Snap proposed positions to this grid (default 0.5)."),
+      margin_mm: z
+        .number()
+        .optional()
+        .describe("Extra keepout enforced between courtyards (default 0.3)."),
+      rotate: z
+        .boolean()
+        .optional()
+        .describe("Enable pin-facing rotation (default true)."),
+      spread: z
+        .boolean()
+        .optional()
+        .describe(
+          "Enable density spreading (default true). Diffuses parts across free board area so a whole-board run stays legal (few/zero courtyard overlaps) instead of over-packing into a blob. Leave on for whole-board runs.",
+        ),
+      align: z
+        .boolean()
+        .optional()
+        .describe(
+          "Tidy the result into rows/columns (default true). Snaps near-collinear part centers onto shared row (Y) and column (X) lines so passives line up cleanly with centers aligned — like KiCad's Align Centers + Distribute. Disable for a pure shortest-wire layout.",
+        ),
+      align_tol_mm: z
+        .number()
+        .optional()
+        .describe(
+          "Max center spacing (mm) for parts to be pulled onto the same row/column line during align (default 1.5).",
+        ),
+      rotation_steps: z
+        .array(z.number())
+        .optional()
+        .describe("Candidate orientations in degrees (default [0, 90, 180, 270])."),
+      power_nets: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Net-name fragments treated as high-current and pulled short & direct (case-insensitive). Defaults to common rails (VBAT, VBUS, VCC, 3V3, 5V, ...). Pass [] to disable.",
+        ),
+      power_weight: z
+        .number()
+        .optional()
+        .describe("Pull multiplier for power nets (default 3.0)."),
+      decoupling_boost: z
+        .number()
+        .optional()
+        .describe(
+          "Extra pull for 2-pin-passive <-> multi-pin-IC links so caps/feedback parts hug their IC (default 2.0).",
+        ),
+      bounds: z
+        .object({
+          x1: z.number(),
+          y1: z.number(),
+          x2: z.number(),
+          y2: z.number(),
+          unit: z.enum(["mm", "mil", "inch"]).optional(),
+        })
+        .optional()
+        .describe(
+          "SCOPED REGROUP: confine movable parts to this box (mm) — e.g. the area beside one IC. Combine with `refs` (that IC's passives) to regroup one cluster at a time; unlisted parts stay as anchors. Far more reliable than a whole-board run on a dense board. Default: whole board.",
+        ),
+      board_outline: z
+        .object({
+          x1: z.number(),
+          y1: z.number(),
+          x2: z.number(),
+          y2: z.number(),
+          unit: z.enum(["mm", "mil", "inch"]).optional(),
+        })
+        .optional()
+        .describe("Optional board containment bbox override. Default: derived from Edge.Cuts."),
+    },
+    async (args) => {
+      logger.debug(`Suggesting placement (apply=${args.apply ? "true" : "false"})`);
+      const result = await callKicadScript("suggest_placement", args);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result),
+          },
+        ],
+      };
+    },
+  );
+
+  // ------------------------------------------------------
   // Duplicate Component Tool
   // ------------------------------------------------------
   server.tool(

--- a/src/tools/schematic-layout.ts
+++ b/src/tools/schematic-layout.ts
@@ -101,4 +101,39 @@ export function registerSchematicLayoutTools(server: McpServer, callKicadScript:
       };
     },
   );
+
+  server.tool(
+    "suggest_schematic_declutter",
+    "Re-orient overlapping net/global labels so their text lands in free space and becomes readable. Each label's (at x,y) anchor is its electrical connection point, so it is held FIXED — only the orientation (0/90/180/270) and justification change, throwing the text away from component bodies and other labels. Connectivity is never altered. DRY RUN by default: returns proposals [{name, at, from_angle, to_angle}] plus an overlap score (before/after) WITHOUT modifying the schematic. Set apply=true to rewrite the label orientations. (Phase 1: labels only; symbol spreading + wire reroute is a separate future capability.)",
+    {
+      schematicPath: z.string().describe("Path to the .kicad_sch file"),
+      margin: z
+        .number()
+        .optional()
+        .describe("Extra clearance in mm when testing label overlap (default 0.3)."),
+      references: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Limit which component bodies count as obstacles (default: every component on the sheet).",
+        ),
+      apply: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, rewrite the label orientations. Default false (dry run — schematic untouched, proposals only).",
+        ),
+    },
+    async (args: any) => {
+      const result = await callKicadScript("suggest_schematic_declutter", args);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result),
+          },
+        ],
+      };
+    },
+  );
 }

--- a/tests/test_schematic_declutter.py
+++ b/tests/test_schematic_declutter.py
@@ -1,0 +1,117 @@
+"""Tests for suggest_schematic_declutter's pure geometry, planner, and the
+raw-text apply path (including justify injection when KiCad omitted the token).
+
+These cover the label re-orientation logic without needing a live KiCad /
+kicad-skip environment — the geometry lives in module-level pure functions.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.schematic_declutter import (  # noqa: E402
+    _bbox_overlaps,
+    _inject_justify_into_effects,
+    _justify_for_angle,
+    _label_bbox,
+    _reorient_label_in_text,
+    plan_label_declutter,
+)
+
+
+def test_label_bbox_orientation_flips_text_side():
+    b0 = _label_bbox(10, 10, 0, "VBUS")     # text extends +x
+    b180 = _label_bbox(10, 10, 180, "VBUS")  # text extends -x
+    assert b0["x_min"] == 10 and b0["x_max"] > 10
+    assert b180["x_max"] == 10 and b180["x_min"] < 10
+
+
+def test_justify_for_angle():
+    assert _justify_for_angle(0) == "left"
+    assert _justify_for_angle(90) == "left"
+    assert _justify_for_angle(180) == "right"
+    assert _justify_for_angle(270) == "right"
+
+
+def test_plan_reduces_overlap_between_piled_labels():
+    labels = [
+        {"name": "NET_A", "x": 50.0, "y": 30.0, "angle": 0, "type": "net"},
+        {"name": "NET_B", "x": 51.0, "y": 30.0, "angle": 0, "type": "net"},
+        {"name": "NET_C", "x": 50.5, "y": 30.0, "angle": 0, "type": "net"},
+    ]
+    props, before, after = plan_label_declutter(labels, [], margin=0.3)
+    assert before > 0
+    assert after < before
+    assert all(p["to_angle"] in (0, 90, 180, 270) for p in props)
+
+
+def test_plan_flips_label_away_from_body():
+    # Label on a wire stub just left of a body; angle 0 sends text INTO the
+    # body, angle 180 points it away into free space.
+    lab = [{"name": "SDA", "x": 48.0, "y": 20.0, "angle": 0, "type": "net"}]
+    body = [{"x_min": 50.0, "y_min": 18.0, "x_max": 58.0, "y_max": 22.0}]
+    props, before, after = plan_label_declutter(lab, body, margin=0.2)
+    assert before == 1 and after == 0
+    assert props and props[0]["to_angle"] == 180
+    assert props[0]["to_justify"] == "right"
+
+
+def test_apply_rewrites_angle_and_justify_keeps_anchor():
+    sch = (
+        '(kicad_sch\n'
+        '  (label "SDA" (at 48.0 20.0 0)\n'
+        '    (effects (font (size 1.27 1.27)) (justify left))\n'
+        '    (uuid "aaaa")\n'
+        '  )\n'
+        '  (global_label "VBUS" (at 48.0 20.0 0)\n'   # same anchor, other name
+        '    (effects (font (size 1.27 1.27)) (justify left))\n'
+        '    (uuid "bbbb")\n'
+        '  )\n'
+        ')\n'
+    )
+    new, changed = _reorient_label_in_text(sch, "SDA", 48.0, 20.0, 180, "right")
+    assert changed
+    assert "(at 48.0 20.0 180)" in new            # angle rewritten, anchor kept
+    sda, _, vbus = new.partition("global_label")
+    assert "(justify right)" in sda               # SDA flipped
+    assert "(at 48.0 20.0 0)" in vbus              # VBUS untouched
+    assert "(justify left)" in vbus               # VBUS justify untouched
+
+
+def test_apply_injects_justify_when_absent():
+    # KiCad omits (justify) for default-left labels. A 180 reorient must INJECT
+    # one, else the text would render pointing the wrong way.
+    sch = (
+        '(kicad_sch\n'
+        '  (label "CLK" (at 30.0 40.0 0)\n'
+        '    (effects (font (size 1.27 1.27)))\n'    # <-- no justify token
+        '    (uuid "cccc")\n'
+        '  )\n'
+        ')\n'
+    )
+    new, changed = _reorient_label_in_text(sch, "CLK", 30.0, 40.0, 180, "right")
+    assert changed
+    assert "(at 30.0 40.0 180)" in new
+    assert "(justify right)" in new                # injected
+    # justify must live inside the effects group
+    assert "(font (size 1.27 1.27)) (justify right)" in new
+
+
+def test_inject_justify_into_effects_paren_matched():
+    block = '(label "X" (at 0 0 0) (effects (font (size 1.27 1.27))) (uuid "z"))'
+    out = _inject_justify_into_effects(block, "right")
+    assert out == '(label "X" (at 0 0 0) (effects (font (size 1.27 1.27)) (justify right)) (uuid "z"))'
+
+
+def test_inject_justify_noop_without_effects():
+    block = '(label "X" (at 0 0 0) (uuid "z"))'
+    assert _inject_justify_into_effects(block, "right") == block
+
+
+def test_bbox_overlaps_basic():
+    a = {"x_min": 0, "y_min": 0, "x_max": 2, "y_max": 2}
+    b = {"x_min": 1, "y_min": 1, "x_max": 3, "y_max": 3}
+    c = {"x_min": 5, "y_min": 5, "x_max": 6, "y_max": 6}
+    assert _bbox_overlaps(a, b)
+    assert not _bbox_overlaps(a, c)

--- a/tests/test_suggest_placement.py
+++ b/tests/test_suggest_placement.py
@@ -1,0 +1,211 @@
+"""Tests for suggest_placement (connectivity-driven placement optimizer).
+
+The optimizer's geometry is exercised with lightweight fakes for KiCad's
+footprint/pad/board objects, plus numeric stubs for the handful of pcbnew
+helpers it calls (ToMM / FromMM / VECTOR2I). conftest.py already installs a
+MagicMock `pcbnew`; here we give those three helpers real numeric behaviour.
+"""
+
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+import pcbnew  # noqa: E402  (MagicMock module from conftest)
+
+pcbnew.ToMM = lambda nm: nm / 1_000_000.0
+pcbnew.FromMM = lambda mm: int(round(mm * 1_000_000.0))
+
+
+class _V2I:
+    def __init__(self, x, y):
+        self.x, self.y = x, y
+
+
+pcbnew.VECTOR2I = _V2I
+
+from commands.placement_optimizer import PlacementOptimizerCommands as PO  # noqa: E402
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────
+class Pad:
+    def __init__(self, code, lx_mm, ly_mm):
+        self._code, self._lx, self._ly, self._fp = code, lx_mm, ly_mm, None
+
+    def GetNetCode(self):
+        return self._code
+
+    def GetPosition(self):
+        a = math.radians(self._fp._angle)
+        c, s = math.cos(a), math.sin(a)
+        wx = self._lx * c - self._ly * s
+        wy = self._lx * s + self._ly * c
+        return _V2I(int((self._fp._x + wx) * 1e6), int((self._fp._y + wy) * 1e6))
+
+
+class FP:
+    def __init__(self, ref, x, y, pads, hw=1.0, hh=0.5, locked=False, angle=0.0):
+        self.ref, self._x, self._y = ref, x, y
+        self._pads, self.hw, self.hh = pads, hw, hh
+        self._locked, self._angle = locked, angle
+        for p in pads:
+            p._fp = self
+
+    def GetReference(self):
+        return self.ref
+
+    def GetPosition(self):
+        return _V2I(int(self._x * 1e6), int(self._y * 1e6))
+
+    def SetPosition(self, v):
+        self._x, self._y = v.x / 1e6, v.y / 1e6
+
+    def GetOrientationDegrees(self):
+        return self._angle
+
+    def SetOrientationDegrees(self, a):
+        self._angle = a
+
+    def Pads(self):
+        return self._pads
+
+    def GetPadCount(self):
+        return len(self._pads)
+
+    def IsLocked(self):
+        return self._locked
+
+
+class _Net:
+    def __init__(self, n):
+        self._n = n
+
+    def GetNetname(self):
+        return self._n
+
+
+class _NetInfo:
+    def __init__(self, m):
+        self._m = m
+
+    def NetsByNetcode(self):
+        return self._m
+
+
+class Board:
+    def __init__(self, fps, nets):
+        self._fps = fps
+        self._ni = _NetInfo({c: _Net(n) for c, n in nets.items()})
+
+    def GetFootprints(self):
+        return self._fps
+
+    def GetNetInfo(self):
+        return self._ni
+
+    def GetBoardEdgesBoundingBox(self):
+        class B:
+            GetWidth = lambda s: 1  # noqa: E731
+            GetHeight = lambda s: 1  # noqa: E731
+            GetLeft = lambda s: 0  # noqa: E731
+            GetTop = lambda s: 0  # noqa: E731
+            GetRight = lambda s: int(60e6)  # noqa: E731
+            GetBottom = lambda s: int(40e6)  # noqa: E731
+
+        return B()
+
+
+class Host(PO):
+    def __init__(self, board):
+        self.board = board
+
+    def _footprint_courtyard_bbox(self, fp, override):
+        return (fp._x - fp.hw, fp._y - fp.hh, fp._x + fp.hw, fp._y + fp.hh)
+
+
+def _two_converters_board():
+    fps = [
+        FP("U1", 10, 20, [Pad(1, -1, 0), Pad(10, 1, 0), Pad(99, 0, 0.5)], hw=2, hh=2),
+        FP("U2", 50, 20, [Pad(1, -1, 0), Pad(11, 1, 0), Pad(99, 0, 0.5)], hw=2, hh=2),
+        FP("R1", 48, 5, [Pad(10, -0.5, 0), Pad(99, 0.5, 0)]),
+        FP("C1", 52, 5, [Pad(1, -0.5, 0), Pad(99, 0.5, 0)]),
+        FP("R2", 12, 35, [Pad(11, -0.5, 0), Pad(99, 0.5, 0)]),
+        FP("C2", 8, 35, [Pad(1, -0.5, 0), Pad(99, 0.5, 0)]),
+    ]
+    nets = {1: "VBAT", 10: "U1_FB", 11: "U2_FB", 99: "GND"}
+    return Host(Board(fps, nets))
+
+
+# ── Tests ────────────────────────────────────────────────────────────────
+def test_no_board_returns_error():
+    res = Host(None).suggest_placement({})
+    assert res["success"] is False
+    assert "No board" in res["message"]
+
+
+def test_fewer_than_two_movable_returns_error():
+    fps = [FP("U1", 10, 20, [Pad(99, 0, 0.5)], hw=2, hh=2)]
+    res = Host(Board(fps, {99: "GND"})).suggest_placement({})
+    assert res["success"] is False
+    assert "optimize" in res["message"].lower()
+
+
+def test_optimize_shortens_wire_length_without_overlaps():
+    res = _two_converters_board().suggest_placement({"iterations": 300, "apply": False})
+    assert res["success"] is True
+    s = res["score"]
+    assert s["hpwl_after_mm"] < s["hpwl_before_mm"]
+    assert s["overlaps_after"] == 0
+    # passives migrate next to their IC
+    u1 = res["proposals"].get("U1", [10, 20, 0])
+    r1 = res["proposals"]["R1"]
+    assert math.hypot(r1[0] - u1[0], r1[1] - u1[1]) < 20
+
+
+def test_dry_run_does_not_move_parts():
+    host = _two_converters_board()
+    before = host.board.GetFootprints()[2]._x  # R1 x
+    host.suggest_placement({"iterations": 100, "apply": False})
+    assert host.board.GetFootprints()[2]._x == before
+
+
+def test_scoped_bounds_limits_movers_and_stays_in_box():
+    host = _two_converters_board()
+    res = host.suggest_placement({
+        "refs": ["R1", "C1"],
+        "bounds": {"x1": 13, "y1": 15, "x2": 20, "y2": 25, "unit": "mm"},
+        "iterations": 300,
+    })
+    assert set(res["proposals"]) == {"R1", "C1"}
+    for r in ("R1", "C1"):
+        x, y, _ = res["proposals"][r]
+        assert 12 <= x <= 21 and 14 <= y <= 26
+
+
+def test_deterministic_across_runs():
+    a = _two_converters_board().suggest_placement({"iterations": 200})
+    b = _two_converters_board().suggest_placement({"iterations": 200})
+    assert a["proposals"] == b["proposals"]
+
+
+def test_cluster_snap_aligns_rows_and_columns():
+    def mk(x, y):
+        return {"x": x, "y": y, "cox": 0.0, "coy": 0.0, "locked": False}
+
+    parts = [mk(5.0, 10.3), mk(9.8, 9.7), mk(15.1, 10.1),
+             mk(5.2, 20.2), mk(10.1, 19.8), mk(14.9, 20.3)]
+    PO._opt_cluster_snap(parts, "y", 1.5)
+    assert len(set(round(p["y"], 3) for p in parts)) == 2   # two row lines
+    PO._opt_cluster_snap(parts, "x", 1.5)
+    assert len(set(round(p["x"], 3) for p in parts)) == 3   # three column lines
+
+
+def test_resolve_outline_unit_conversion_includes_mil():
+    host = Host(None)
+    mm = host._opt_resolve_outline({"x1": 0, "y1": 0, "x2": 10, "y2": 10, "unit": "mm"})
+    mil = host._opt_resolve_outline({"x1": 0, "y1": 0, "x2": 1000, "y2": 1000, "unit": "mil"})
+    inch = host._opt_resolve_outline({"x1": 0, "y1": 0, "x2": 1, "y2": 1, "unit": "inch"})
+    assert mm == (0, 0, 10, 10)
+    assert mil == (0, 0, 25.4, 25.4)       # 1000 mil = 25.4 mm
+    assert inch == (0, 0, 25.4, 25.4)      # 1 inch = 25.4 mm


### PR DESCRIPTION
## Summary

Adds two new AI-driven layout tools to the MCP server. Both are **additive** (no existing behavior changed), require **no new dependencies**, and are **dry-run by default** (never mutate a file unless `apply: true`).

- **`suggest_placement`** (PCB) — connectivity-driven footprint placement optimizer.
- **`suggest_schematic_declutter`** (schematic) — re-orients overlapping net/global labels for readability.

## `suggest_placement` (PCB)

Turns the netlist into an optimized placement — the heuristic an engineer does against the ratsnest, automated:

- **Connectivity clustering** — force-directed solve (rest-length springs) pulls connected parts together, so an IC's feedback divider and decoupling caps end up hugging it.
- **Power-aware weighting** — high-current nets (VBAT/VBUS/…) and IC↔decoupling links pull tightest, keeping those paths short and direct.
- **Pin-facing rotation** — rotates each part 0/90/180/270 to minimize wire length to its neighbours, removing airwire crossings.
- **Density spreading** — diffuses parts across free board area so a whole-board run stays legal instead of over-packing into a blob.
- **Row/column alignment** — snaps near-collinear part centers onto shared row/column lines, so the result reads as tidy rows/columns with items centered (like Align Centers + Distribute).
- **Scoped mode** — `refs` + `bounds` regroup one IC's passives at a time within a box; unlisted parts stay as fixed anchors.
- Returns `{ref:[x,y,rot]}` proposals + an HPWL/overlap score. Deterministic (dry-run matches the applied run). Reuses `ComponentCommands._footprint_courtyard_bbox`, so collision matches `check_courtyard_overlaps`.

## `suggest_schematic_declutter` (schematic)

Re-orients overlapping net/global labels so their text lands in free space:

- **Connectivity-safe** — a label's `(at x,y)` is its electrical connection point, so the anchor is held fixed; only orientation (0/90/180/270) and justification change. Nets are never altered.
- Returns proposals `[{name, at, from_angle→to_angle}]` + an overlap score. `apply: true` rewrites the orientations.
- Phase 1 = labels; symbol spreading + wire reroute is a deliberately separate future phase.

## Integration

- `ComponentCommands` gains the optimizer via a new `PlacementOptimizerCommands` mixin; declutter reuses `schematic_field_layout`'s bbox model. Only additions to the dispatch map + TS tool registrations.
- New tools advertised in `tool_schemas.py` (placement) and `src/tools/schematic-layout.ts` (declutter).

## Testing

- Unit tests cover all pure geometry/solver logic on mocked pcbnew + synthetic schematic: clustering, power weighting, pin-facing rotation, density spreading, row/column alignment, legalization, label re-orientation, and the regex apply path. `tsc` builds clean.

## Caveats / not-yet-done

- **Validated via unit tests; not yet validated against a live board/schematic.** Reviewers should smoke-test on a real design.
- Placement HPWL is a wire-length proxy (pad/center based), not a route guarantee; legalizer is O(n²) (fine to a few hundred parts).
- Declutter Phase 1 doesn't yet move free text or slide labels along their wire.
