### PR TITLE
fix: project/schematic scaffolding path & format hygiene (#242, #224, partial #221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **Fallback schematic writer emits the KiCad 10 header** (#221, partial): the
+  template-missing fallback in `create_schematic` and `create_project` wrote the
+  stale KiCad 9 header `(version 20250114) (generator "KiCAD-MCP-Server")`. It
+  now writes `(version 20260306) (generator "eeschema") (generator_version
+  "10.0")`, matching what eeschema writes for a new file. This covers only the
+  fallback path; the main templates (which still carry the KiCad 9 version and
+  the `_TEMPLATE_*` clone-source instances used by `add_schematic_component`)
+  are tracked separately because rewriting them touches the component-cloning
+  system.
+
 - **`create_project` returns paths with a single separator** (#224): the
   returned `path`/`boardPath`/`schematicPath` were built with `os.path.join`,
   which on Windows mixed separators when the caller passed a forward-slash path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`create_project` returns paths with a single separator** (#224): the
+  returned `path`/`boardPath`/`schematicPath` were built with `os.path.join`,
+  which on Windows mixed separators when the caller passed a forward-slash path
+  (e.g. `C:/.../EspDinIoT\EspDinIoT.kicad_pro`). The reported paths are now
+  normalized to forward slashes; the on-disk writes still use OS-native paths.
+
 - **`create_schematic` accepts a full `.kicad_sch` path in `path`** (#242):
   passing a complete file path (e.g. `path="/foo/bar/V4.kicad_sch"`) previously
   treated it as a directory and appended the name again, producing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`create_schematic` accepts a full `.kicad_sch` path in `path`** (#242):
+  passing a complete file path (e.g. `path="/foo/bar/V4.kicad_sch"`) previously
+  treated it as a directory and appended the name again, producing
+  `/foo/bar/V4.kicad_sch/V4.kicad_sch` and failing with "No such file or
+  directory". The path is now used as-is when it already ends in `.kicad_sch`,
+  in both `SchematicManager.create_schematic` and the `_handle_create_schematic`
+  save step; passing a directory still works as before.
+
 - **Backend is now pinned per loaded project (SWIG vs IPC)** (#223): commands
   on a single loaded project previously ran on whichever backend happened to
   be reachable per call — `create_project`/`open_project`/`add_layer` on SWIG

--- a/python/commands/project.py
+++ b/python/commands/project.py
@@ -5,6 +5,7 @@ Project-related command implementations for KiCAD interface
 import logging
 import os
 import shutil
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 import pcbnew  # type: ignore
@@ -120,14 +121,20 @@ class ProjectCommands:
 
             self.board = board
 
+            # Normalize returned paths to a single separator (forward slashes).
+            # os.path.join mixes separators on Windows when the caller passes a
+            # path with forward slashes (issue #224): the joined filename used a
+            # backslash while the rest used forward slashes. The on-disk writes
+            # above keep the OS-native paths; only the reported paths are
+            # normalized so callers get consistent, predictable values.
             return {
                 "success": True,
                 "message": f"Created project: {project_name}",
                 "project": {
                     "name": project_name,
-                    "path": project_path,
-                    "boardPath": board_path,
-                    "schematicPath": schematic_path,
+                    "path": Path(project_path).as_posix(),
+                    "boardPath": Path(board_path).as_posix(),
+                    "schematicPath": Path(schematic_path).as_posix(),
                 },
             }
 

--- a/python/commands/project.py
+++ b/python/commands/project.py
@@ -101,7 +101,13 @@ class ProjectCommands:
 
                 schematic_uuid = str(uuid_module.uuid4())
                 with open(schematic_path, "w", encoding="utf-8", newline="\n") as f:
-                    f.write('(kicad_sch (version 20250114) (generator "KiCAD-MCP-Server")\n\n')
+                    # KiCad 10 schematic header (matches what eeschema writes for a
+                    # new file). The older 20250114 token is the KiCad 9 format and
+                    # is stale under KiCad 10 (issue #221).
+                    f.write(
+                        '(kicad_sch (version 20260306) (generator "eeschema")'
+                        ' (generator_version "10.0")\n\n'
+                    )
                     f.write(f"  (uuid {schematic_uuid})\n\n")
                     f.write('  (paper "A4")\n\n')
                     f.write("  (lib_symbols\n  )\n\n")

--- a/python/commands/schematic.py
+++ b/python/commands/schematic.py
@@ -26,9 +26,17 @@ class SchematicManager:
                 "template_with_symbols.kicad_sch",
             )
 
-            # Determine output path
-            base_name = name if name.endswith(".kicad_sch") else f"{name}.kicad_sch"
-            output_path = os.path.join(path, base_name) if path else base_name
+            # Determine output path. A caller may pass `path` as either a
+            # directory or a full ".kicad_sch" file path. When it is already a
+            # full file path, use it directly; otherwise treat it as a directory
+            # and append the schematic file name. Without this, a full path like
+            # "/foo/bar/V4.kicad_sch" was joined again into
+            # "/foo/bar/V4.kicad_sch/V4.kicad_sch" (issue #242).
+            if path and path.endswith(".kicad_sch"):
+                output_path = path
+            else:
+                base_name = name if name.endswith(".kicad_sch") else f"{name}.kicad_sch"
+                output_path = os.path.join(path, base_name) if path else base_name
 
             if os.path.exists(template_path):
                 # Copy template to target location

--- a/python/commands/schematic.py
+++ b/python/commands/schematic.py
@@ -65,7 +65,13 @@ class SchematicManager:
                 schematic_uuid = str(uuid.uuid4())
                 # Write with explicit UTF-8 encoding and Unix line endings for cross-platform compatibility
                 with open(output_path, "w", encoding="utf-8", newline="\n") as f:
-                    f.write('(kicad_sch (version 20250114) (generator "KiCAD-MCP-Server")\n\n')
+                    # KiCad 10 schematic header (matches what eeschema writes for a
+                    # new file). The older 20250114 token is the KiCad 9 format and
+                    # is stale under KiCad 10 (issue #221).
+                    f.write(
+                        '(kicad_sch (version 20260306) (generator "eeschema")'
+                        ' (generator_version "10.0")\n\n'
+                    )
                     f.write(f"  (uuid {schematic_uuid})\n\n")
                     f.write('  (paper "A4")\n\n')
                     f.write("  (lib_symbols\n  )\n\n")

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -123,11 +123,21 @@ class SchematicHandlersMixin:
             schematic = SchematicManager.create_schematic(
                 project_name, path=sch_path, metadata=metadata
             )
-            base_name = (
-                project_name if project_name.endswith(".kicad_sch") else f"{project_name}.kicad_sch"
-            )
-            normalized_path = path or "."
-            file_path = os.path.join(normalized_path, base_name)
+            # Resolve the saved file path the same way create_schematic does: when
+            # `path` is already a full ".kicad_sch" file path, use it directly;
+            # otherwise treat it as a directory and append the file name. This keeps
+            # the save target in step with the created file and avoids doubling the
+            # name into ".../V4.kicad_sch/V4.kicad_sch" (issue #242).
+            if sch_path and sch_path.endswith(".kicad_sch"):
+                file_path = sch_path
+            else:
+                base_name = (
+                    project_name
+                    if project_name.endswith(".kicad_sch")
+                    else f"{project_name}.kicad_sch"
+                )
+                normalized_path = path or "."
+                file_path = os.path.join(normalized_path, base_name)
             success = SchematicManager.save_schematic(schematic, file_path)
 
             return {"success": success, "file_path": file_path}

--- a/tests/test_create_project_paths.py
+++ b/tests/test_create_project_paths.py
@@ -54,3 +54,26 @@ def test_create_project_returns_paths_without_mixed_separators():
     assert project["path"].endswith("EspDinIoT.kicad_pro")
     assert project["boardPath"].endswith("EspDinIoT.kicad_pcb")
     assert project["schematicPath"].endswith("EspDinIoT.kicad_sch")
+
+
+def test_create_project_fallback_schematic_uses_kicad10_header():
+    """
+    Issue #221: when the schematic template is missing, the fallback writer in
+    create_project must emit the KiCad 10 header rather than the stale KiCad 9
+    (20250114) token.
+    """
+    cmds = ProjectCommands()
+    m = mock_open()
+    with patch.object(_mod, "pcbnew", MagicMock()), \
+         patch("os.makedirs"), \
+         patch("os.path.exists", return_value=False), \
+         patch("builtins.open", m):
+        result = cmds.create_project(
+            {"name": "EspDinIoT", "path": "C:/tmp/EspDinIoT"}
+        )
+
+    assert result["success"] is True, result
+    written = "".join(call.args[0] for call in m().write.call_args_list)
+    assert "(version 20260306)" in written, written
+    assert 'generator "eeschema"' in written
+    assert "20250114" not in written

--- a/tests/test_create_project_paths.py
+++ b/tests/test_create_project_paths.py
@@ -1,0 +1,56 @@
+"""
+Unit tests for create_project returned-path normalization (issue #224).
+
+create_project builds its returned paths with os.path.join, which on Windows
+mixes separators when the caller passes a path using forward slashes (the
+joined filename gets a backslash while the rest keep forward slashes). The
+returned path fields should use a single, consistent separator.
+"""
+
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock, mock_open, patch
+
+# pcbnew is only available inside KiCAD — stub it so the project module can be
+# imported in a plain Python environment.
+sys.modules.setdefault("pcbnew", MagicMock())
+
+# Import the module directly (bypasses python/commands/__init__.py which would
+# otherwise pull in board/component commands that also need pcbnew/skip).
+_spec = importlib.util.spec_from_file_location(
+    "project_module",
+    os.path.join(os.path.dirname(__file__), "..", "python", "commands", "project.py"),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+ProjectCommands = _mod.ProjectCommands
+
+
+def test_create_project_returns_paths_without_mixed_separators():
+    """
+    Returned project/board/schematic paths must not contain backslashes
+    (issue #224 reported "C:/.../EspDinIoT\\EspDinIoT.kicad_pro").
+    """
+    cmds = ProjectCommands()
+    with patch.object(_mod, "pcbnew", MagicMock()), \
+         patch("os.makedirs"), \
+         patch("os.path.exists", return_value=False), \
+         patch("builtins.open", mock_open()):
+        result = cmds.create_project(
+            {
+                "name": "EspDinIoT",
+                "path": "C:/Users/piete/Source/Repos/ptr727/EspDinIoT",
+            }
+        )
+
+    assert result["success"] is True, result
+    project = result["project"]
+    for key in ("path", "boardPath", "schematicPath"):
+        value = project[key]
+        assert "\\" not in value, f"{key} still has a backslash: {value!r}"
+
+    # Sanity: the normalized paths keep their expected extensions.
+    assert project["path"].endswith("EspDinIoT.kicad_pro")
+    assert project["boardPath"].endswith("EspDinIoT.kicad_pcb")
+    assert project["schematicPath"].endswith("EspDinIoT.kicad_sch")

--- a/tests/test_create_schematic_path.py
+++ b/tests/test_create_schematic_path.py
@@ -9,7 +9,7 @@ import os
 import sys
 import importlib.util
 import tempfile
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, mock_open
 
 # pcbnew and skip are only available inside KiCAD — stub them so the
 # schematic module can be imported in a plain Python environment.
@@ -110,3 +110,21 @@ def test_create_schematic_accepts_full_sch_path_in_path_arg():
                 f"Expected the full path {full_path!r} used as-is, got {used_path!r}"
             )
             assert "V4.kicad_sch/V4.kicad_sch" not in used_path.replace(os.sep, "/")
+
+
+def test_create_schematic_fallback_writes_kicad10_header():
+    """
+    Issue #221: when the template file is missing, the fallback writer must emit
+    the KiCad 10 schematic header, not the stale KiCad 9 (20250114) token.
+    """
+    m = mock_open()
+    with patch.object(_mod, "Schematic"), \
+         patch("shutil.copy"), \
+         patch("os.path.exists", return_value=False), \
+         patch("builtins.open", m):
+        SchematicManager.create_schematic("myschematic")
+
+    written = "".join(call.args[0] for call in m().write.call_args_list)
+    assert "(version 20260306)" in written, written
+    assert 'generator "eeschema"' in written
+    assert "20250114" not in written

--- a/tests/test_create_schematic_path.py
+++ b/tests/test_create_schematic_path.py
@@ -87,3 +87,26 @@ def test_create_schematic_accepts_full_sch_filename():
             used_path = mock_sch_cls.call_args[0][0]
             assert used_path.endswith("myschematic.kicad_sch")
             assert "myschematic.kicad_sch.kicad_sch" not in used_path
+
+
+def test_create_schematic_accepts_full_sch_path_in_path_arg():
+    """
+    Issue #242: when `path` is itself a full ".kicad_sch" file path, it must be
+    used as-is and not treated as a directory (which doubled the file name into
+    ".../V4.kicad_sch/V4.kicad_sch" and then failed with "No such file").
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        full_path = os.path.join(tmpdir, "V4.kicad_sch")
+        with patch.object(_mod, "Schematic") as mock_sch_cls, \
+             patch("shutil.copy"), \
+             patch("os.path.exists", return_value=True), \
+             patch("builtins.open", _OPEN_MOCK):
+            mock_sch_cls.return_value = MagicMock()
+
+            SchematicManager.create_schematic("V4", path=full_path)
+
+            used_path = mock_sch_cls.call_args[0][0]
+            assert used_path == full_path, (
+                f"Expected the full path {full_path!r} used as-is, got {used_path!r}"
+            )
+            assert "V4.kicad_sch/V4.kicad_sch" not in used_path.replace(os.sep, "/")


### PR DESCRIPTION
## Summary

Three small, isolated correctness fixes for project/schematic scaffolding, each
with a regression test and a CHANGELOG entry. All run without KiCAD installed
(they stub `pcbnew`/`skip`), and none touch the component-cloning system.

Verified locally: full Python suite 1067 passed, 12 skipped. The only failures
(8, in `test_autoroute_best_of_n.py` and `test_freerouting.py`) are pre-existing
and identical on `main` — they require a Java runtime for Freerouting that is not
installed in this environment, and are unrelated to these changes. `npm run build`
and `npm run test:ts` (24 tests) pass. `black`/`mypy` are clean on the changed
`python/` files.

## Changes

### `create_schematic` accepts a full `.kicad_sch` path in `path` (Fixes #242)
When `path` was already a full file path (e.g. `/foo/bar/V4.kicad_sch`), it was
treated as a directory and the name was appended again, producing
`/foo/bar/V4.kicad_sch/V4.kicad_sch` and failing with "No such file or directory".
The path is now used as-is when it ends in `.kicad_sch`. This is fixed in two
places that both compute the output path: `SchematicManager.create_schematic`
(the core) and `_handle_create_schematic` (the handler's separate save step) —
fixing only one would have left the save target doubled.

### `create_project` returns paths with one separator (Fixes #224)
The returned `path`/`boardPath`/`schematicPath` were built with `os.path.join`,
which on Windows mixes separators when the caller passes a forward-slash path
(reported as `C:/.../EspDinIoT\EspDinIoT.kicad_pro`). The reported paths are now
normalized with `Path(...).as_posix()`. The on-disk writes still use the
OS-native paths, so only the values handed back to the caller change.

### Fallback schematic writer emits the KiCad 10 header (partial #221)
The template-missing fallback in `create_schematic` and `create_project` wrote
the stale KiCad 9 header `(version 20250114) (generator "KiCAD-MCP-Server")`. It
now writes `(version 20260306) (generator "eeschema") (generator_version "10.0")`,
matching what eeschema writes for a new file.

This intentionally covers only the **fallback** path, so I have referenced #221
rather than closing it. The main issue in #221 — the primary templates
(`template_with_symbols*.kicad_sch`) carrying the KiCad 9 version and a seeded
`Device:R` — is left open because those templates are not safe to rewrite in
isolation. The off-screen `_TEMPLATE_R/C/D...` instances in those files are the
clone source used by `add_schematic_component` (`component_schematic.py` maps
component types to them via `TEMPLATE_MAP`), and roughly eight modules filter
`_TEMPLATE`-prefixed references out of ERC/analysis/layout on purpose. Deleting
the instances or emptying `lib_symbols` would break component creation, so that
rewrite needs its own design pass (strip-on-save, re-source cloning from
`lib_symbols`, or drive `kicad-cli`/IPC) and is tracked separately.

## Testing
- `tests/test_create_schematic_path.py` — added cases for the full-path `path`
  argument and the KiCad 10 fallback header.
- `tests/test_create_project_paths.py` — new file: returned-path normalization
  and the KiCad 10 fallback header.
