### PR TITLE
feat: MCP tools for footprint/component 3D models

### DIFF
--- a/python/commands/footprint.py
+++ b/python/commands/footprint.py
@@ -11,6 +11,7 @@ KiCAD 9 .kicad_mod format reference:
 import logging
 import os
 import re
+import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -289,6 +290,214 @@ class FootprintCreator:
             "footprint_path": str(path),
             "pad_number": pad_number,
             "updated": updated,
+        }
+
+    @staticmethod
+    def _find_model_blocks(text: str) -> List[Dict[str, Any]]:
+        """Return brace-balanced ``(model ...)`` blocks as {start,end,text,filename}."""
+        blocks: List[Dict[str, Any]] = []
+        idx = 0
+        while True:
+            start = text.find("(model", idx)
+            if start == -1:
+                break
+            depth = 0
+            i = start
+            end = -1
+            while i < len(text):
+                c = text[i]
+                if c == "(":
+                    depth += 1
+                elif c == ")":
+                    depth -= 1
+                    if depth == 0:
+                        end = i + 1
+                        break
+                i += 1
+            if end == -1:
+                break
+            blk = text[start:end]
+            fm = re.search(r'\(model\s+"?([^")\s]+)"?', blk)
+            blocks.append(
+                {"start": start, "end": end, "text": blk, "filename": fm.group(1) if fm else ""}
+            )
+            idx = end
+        return blocks
+
+    def add_3d_model(
+        self,
+        footprint_path: str,
+        model_path: str,
+        offset: Optional[Dict[str, float]] = None,
+        scale: Optional[Dict[str, float]] = None,
+        rotate: Optional[Dict[str, float]] = None,
+        replace: bool = True,
+    ) -> Dict[str, Any]:
+        """
+        Add or replace a 3D model ``(model ...)`` block in a .kicad_mod file.
+
+        Parameters
+        ----------
+        footprint_path : str
+            Full path to the .kicad_mod file.
+        model_path : str
+            Path to the 3D model (.step/.stp/.wrl). KiCad env vars such as
+            ``${KIPRJMOD}`` or ``${KICAD10_3DMODEL_DIR}`` are allowed.
+        offset, scale, rotate : dict or None – ``{"x":..,"y":..,"z":..}``.
+            Defaults: offset 0/0/0, scale 1/1/1, rotate 0/0/0 (units: mm / deg).
+        replace : bool
+            If True (default), an existing model with the same filename is replaced
+            (avoids duplicates). If False and the same model already exists, nothing
+            is changed.
+        """
+        path = Path(footprint_path)
+        if not path.exists():
+            return {"success": False, "error": f"File not found: {footprint_path}"}
+
+        off = offset or {}
+        scl = scale or {}
+        rot = rotate or {}
+
+        model_block = (
+            f'\t(model "{model_path}"\n'
+            f'\t\t(offset (xyz {_fmt(off.get("x", 0))} {_fmt(off.get("y", 0))} {_fmt(off.get("z", 0))}))\n'
+            f'\t\t(scale (xyz {_fmt(scl.get("x", 1))} {_fmt(scl.get("y", 1))} {_fmt(scl.get("z", 1))}))\n'
+            f'\t\t(rotate (xyz {_fmt(rot.get("x", 0))} {_fmt(rot.get("y", 0))} {_fmt(rot.get("z", 0))}))\n'
+            f"\t)"
+        )
+
+        content = path.read_text(encoding="utf-8")
+        if "(footprint" not in content:
+            return {"success": False, "error": f"Not a footprint file: {footprint_path}"}
+
+        removed = 0
+        blocks = self._find_model_blocks(content)
+        same = [b for b in blocks if b["filename"] == model_path]
+        if same and not replace:
+            return {
+                "success": True,
+                "footprint_path": str(path),
+                "added": False,
+                "note": "Model with this filename already present (replace=false)",
+            }
+        # Remove matching blocks (back-to-front so offsets stay valid)
+        for b in sorted(same, key=lambda x: x["start"], reverse=True):
+            content = content[: b["start"]] + content[b["end"] :]
+            removed += 1
+
+        rstripped = content.rstrip()
+        insert_pos = rstripped.rfind(")")
+        if insert_pos == -1:
+            return {"success": False, "error": "Malformed footprint (no closing paren)"}
+
+        new_content = rstripped[:insert_pos] + model_block + "\n" + rstripped[insert_pos:] + "\n"
+        path.write_text(new_content, encoding="utf-8")
+        logger.info(f"add_3d_model: {model_path} -> {path.name} (replaced {removed})")
+
+        return {
+            "success": True,
+            "footprint_path": str(path),
+            "model": model_path,
+            "added": True,
+            "replaced": removed,
+        }
+
+    def import_3d_model(
+        self,
+        model_path: str,
+        project_path: str,
+        library_dir: Optional[str] = None,
+        new_name: Optional[str] = None,
+        overwrite: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Copy a 3D model file into the project's ``*.3dshapes`` library and return
+        a portable ``${KIPRJMOD}/...`` path ready for use in a footprint.
+
+        Parameters
+        ----------
+        model_path : str
+            Path to the source 3D model (.step/.stp/.wrl/.wings).
+        project_path : str
+            Path to the .kicad_pro file or the project directory. Used both to
+            locate the default 3dshapes folder and to compute ${KIPRJMOD}.
+        library_dir : str or None
+            Target ``*.3dshapes`` directory. If relative, it is resolved against
+            the project directory. Default: ``<project_dir>/<project>.3dshapes``.
+        new_name : str or None
+            Rename the copied file (extension kept from source if omitted).
+        overwrite : bool
+            Overwrite an existing destination file (default False).
+        """
+        src = Path(model_path)
+        if not src.exists() or not src.is_file():
+            return {"success": False, "error": f"Source model not found: {model_path}"}
+
+        valid_ext = {".step", ".stp", ".wrl", ".wings", ".x3d", ".igs", ".iges"}
+        if src.suffix.lower() not in valid_ext:
+            return {
+                "success": False,
+                "error": f"Unsupported 3D model extension '{src.suffix}'. "
+                f"Expected one of: {', '.join(sorted(valid_ext))}",
+            }
+
+        # Resolve project directory and name
+        pp = Path(project_path)
+        if pp.suffix == ".kicad_pro":
+            project_dir = pp.parent
+            project_name = pp.stem
+        elif pp.is_dir():
+            project_dir = pp
+            pro = next(iter(sorted(pp.glob("*.kicad_pro"))), None)
+            project_name = pro.stem if pro else pp.name
+        else:
+            return {
+                "success": False,
+                "error": f"projectPath must be a .kicad_pro file or a directory: {project_path}",
+            }
+        project_dir = project_dir.resolve()
+
+        # Resolve target 3dshapes directory
+        if library_dir:
+            ld = Path(library_dir)
+            target_dir = ld if ld.is_absolute() else (project_dir / ld)
+        else:
+            target_dir = project_dir / f"{project_name}.3dshapes"
+        target_dir = target_dir.resolve()
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        # Destination file
+        if new_name:
+            dest_name = new_name if Path(new_name).suffix else new_name + src.suffix
+        else:
+            dest_name = src.name
+        dest = target_dir / dest_name
+
+        if dest.exists() and not overwrite and dest.resolve() != src.resolve():
+            return {
+                "success": False,
+                "error": f"Destination already exists (use overwrite=true): {dest}",
+            }
+
+        if dest.resolve() != src.resolve():
+            shutil.copy2(src, dest)
+
+        # Compute portable ${KIPRJMOD} path
+        try:
+            rel = dest.resolve().relative_to(project_dir).as_posix()
+            kiprjmod_path = "${KIPRJMOD}/" + rel
+        except ValueError:
+            # Destination is outside the project tree – fall back to absolute
+            kiprjmod_path = dest.resolve().as_posix()
+
+        logger.info(f"import_3d_model: {src} -> {dest}")
+        return {
+            "success": True,
+            "source": str(src),
+            "destination": str(dest),
+            "library_dir": str(target_dir),
+            "modelPath": kiprjmod_path,
+            "note": "Use 'modelPath' with add_footprint_3d_model or add_component_3d_model.",
         }
 
     def list_footprint_libraries(self, search_paths: Optional[List[str]] = None) -> Dict[str, Any]:

--- a/python/kicad_api/ipc_backend.py
+++ b/python/kicad_api/ipc_backend.py
@@ -853,6 +853,101 @@ class IPCBoardAPI(BoardAPI):
             logger.error(f"Failed to move component: {e}")
             return False
 
+    def add_3d_model(
+        self,
+        references: Any,
+        model_path: str,
+        offset: Optional[Dict[str, float]] = None,
+        scale: Optional[Dict[str, float]] = None,
+        rotate: Optional[Dict[str, float]] = None,
+        replace: bool = True,
+    ) -> Dict[str, Any]:
+        """Attach a 3D model to one or more placed footprints (live UI update).
+
+        ``references`` may be a single reference ("D1"), a list (["D1","D2"]),
+        or "*"/"all" to apply to every footprint on the board.
+        """
+        try:
+            import kipy.board_types as bt
+
+            board = self._get_board()
+            footprints = board.get_footprints()
+
+            if isinstance(references, str):
+                wanted = [references]
+            else:
+                wanted = list(references or [])
+            apply_all = any(w in ("*", "all") for w in wanted)
+
+            targets = []
+            for fp in footprints:
+                ref = fp.reference_field.text.value if fp.reference_field else ""
+                if apply_all or ref in wanted:
+                    targets.append((ref, fp))
+
+            if not targets:
+                return {"success": False, "error": f"No footprints matched: {references}"}
+
+            off = offset or {}
+            scl = scale or {}
+            rot = rotate or {}
+
+            changed = []
+            details = []
+            for ref, fp in targets:
+                defn = fp.definition
+                already = [m for m in defn.models if m.filename == model_path]
+                if already and not replace:
+                    details.append({"reference": ref, "added": False, "note": "already present"})
+                    continue
+                if already and replace:
+                    keep = [
+                        it
+                        for it in defn.items
+                        if not (
+                            isinstance(it, bt.Footprint3DModel) and it.filename == model_path
+                        )
+                    ]
+                    defn.items = keep
+
+                from kipy.geometry import Vector3D
+
+                model = bt.Footprint3DModel()
+                model.filename = model_path
+                model.visible = True
+                model.opacity = 1.0
+                # scale defaults to 0 on a fresh proto -> force 1 so the body renders
+                model.scale = Vector3D.from_xyz(
+                    float(scl.get("x", 1.0)), float(scl.get("y", 1.0)), float(scl.get("z", 1.0))
+                )
+                model.offset = Vector3D.from_xyz(
+                    float(off.get("x", 0.0)), float(off.get("y", 0.0)), float(off.get("z", 0.0))
+                )
+                model.rotation = Vector3D.from_xyz(
+                    float(rot.get("x", 0.0)), float(rot.get("y", 0.0)), float(rot.get("z", 0.0))
+                )
+
+                defn.add_item(model)
+                changed.append(fp)
+                details.append({"reference": ref, "added": True, "replaced": len(already)})
+
+            if changed:
+                commit = board.begin_commit()
+                board.update_items(changed)
+                board.push_commit(commit, f"Added 3D model to {len(changed)} footprint(s)")
+                self._notify("model_added", {"count": len(changed), "model": model_path})
+
+            return {
+                "success": True,
+                "model": model_path,
+                "updated": len(changed),
+                "details": details,
+            }
+
+        except Exception as e:
+            logger.error(f"Failed to add 3D model: {e}")
+            return {"success": False, "error": str(e)}
+
     def delete_component(self, reference: str) -> bool:
         """Delete a component from the board."""
         try:

--- a/python/kicad_api/ipc_backend.py
+++ b/python/kicad_api/ipc_backend.py
@@ -904,9 +904,7 @@ class IPCBoardAPI(BoardAPI):
                     keep = [
                         it
                         for it in defn.items
-                        if not (
-                            isinstance(it, bt.Footprint3DModel) and it.filename == model_path
-                        )
+                        if not (isinstance(it, bt.Footprint3DModel) and it.filename == model_path)
                     ]
                     defn.items = keep
 

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -603,6 +603,9 @@ class KiCADInterface(SchematicHandlersMixin):
             # Footprint commands
             "create_footprint": self._handle_create_footprint,
             "edit_footprint_pad": self._handle_edit_footprint_pad,
+            "add_footprint_3d_model": self._handle_add_footprint_3d_model,
+            "add_component_3d_model": self._handle_add_component_3d_model,
+            "import_3d_model": self._handle_import_3d_model,
             "list_footprint_libraries": self._handle_list_footprint_libraries,
             "register_footprint_library": self._handle_register_footprint_library,
             # Symbol creator commands
@@ -648,6 +651,7 @@ class KiCADInterface(SchematicHandlersMixin):
         "get_component_list": "_ipc_get_component_list",
         "get_component_properties": "_ipc_get_component_properties",
         "set_footprint_type": "_ipc_set_footprint_type",
+        "add_component_3d_model": "_ipc_add_component_3d_model",
         # Save command
         "save_project": "_ipc_save_project",
     }
@@ -1745,6 +1749,60 @@ class KiCADInterface(SchematicHandlersMixin):
         except Exception as e:
             logger.error(f"create_footprint error: {e}")
             return {"success": False, "error": str(e)}
+
+    def _handle_add_footprint_3d_model(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Add or replace a 3D model (model ...) block in a .kicad_mod file."""
+        logger.info(
+            f"add_footprint_3d_model: {params.get('modelPath')} -> {params.get('footprintPath')}"
+        )
+        try:
+            creator = FootprintCreator()
+            return creator.add_3d_model(
+                footprint_path=params.get("footprintPath", ""),
+                model_path=params.get("modelPath", ""),
+                offset=params.get("offset"),
+                scale=params.get("scale"),
+                rotate=params.get("rotate"),
+                replace=params.get("replace", True),
+            )
+        except Exception as e:
+            logger.error(f"add_footprint_3d_model error: {e}")
+            return {"success": False, "error": str(e)}
+
+    def _handle_import_3d_model(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Copy a 3D model into the project's *.3dshapes and return a ${KIPRJMOD} path."""
+        logger.info(
+            f"import_3d_model: {params.get('modelPath')} -> project {params.get('projectPath')}"
+        )
+        try:
+            creator = FootprintCreator()
+            return creator.import_3d_model(
+                model_path=params.get("modelPath", ""),
+                project_path=params.get("projectPath", ""),
+                library_dir=params.get("libraryDir"),
+                new_name=params.get("newName"),
+                overwrite=params.get("overwrite", False),
+            )
+        except Exception as e:
+            logger.error(f"import_3d_model error: {e}")
+            return {"success": False, "error": str(e)}
+
+    def _handle_add_component_3d_model(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Add a 3D model to a placed footprint on the board.
+
+        Prefers the live IPC path; if IPC is unavailable this returns a clear
+        message (live board editing requires KiCAD running with the IPC API).
+        """
+        if self.use_ipc and getattr(self, "ipc_board_api", None):
+            return self._ipc_add_component_3d_model(params)
+        return {
+            "success": False,
+            "message": (
+                "add_component_3d_model requires the live IPC backend "
+                "(KiCAD running with Preferences > Plugins > Enable IPC API Server). "
+                "To edit a library footprint file instead, use add_footprint_3d_model."
+            ),
+        }
 
     def _handle_edit_footprint_pad(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Edit an existing pad in a .kicad_mod file."""
@@ -4665,6 +4723,24 @@ print("ok")
             return {"success": True, "components": components, "count": len(components)}
         except Exception as e:
             logger.error(f"IPC get_component_list error: {e}")
+            return {"success": False, "message": str(e)}
+
+    def _ipc_add_component_3d_model(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """IPC handler for add_component_3d_model — live edit of placed footprints."""
+        try:
+            references = params.get("reference", params.get("references"))
+            if references is None:
+                return {"success": False, "message": "reference (or references) is required"}
+            return self.ipc_board_api.add_3d_model(
+                references=references,
+                model_path=params.get("modelPath", ""),
+                offset=params.get("offset"),
+                scale=params.get("scale"),
+                rotate=params.get("rotate"),
+                replace=params.get("replace", True),
+            )
+        except Exception as e:
+            logger.error(f"IPC add_component_3d_model error: {e}")
             return {"success": False, "message": str(e)}
 
     def _ipc_save_project(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -1748,7 +1748,7 @@ class KiCADInterface(SchematicHandlersMixin):
             )
         except Exception as e:
             logger.error(f"create_footprint error: {e}")
-            return {"success": False, "error": str(e)}
+            return {"success": False, "message": str(e)}
 
     def _handle_add_footprint_3d_model(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Add or replace a 3D model (model ...) block in a .kicad_mod file."""
@@ -1767,7 +1767,7 @@ class KiCADInterface(SchematicHandlersMixin):
             )
         except Exception as e:
             logger.error(f"add_footprint_3d_model error: {e}")
-            return {"success": False, "error": str(e)}
+            return {"success": False, "message": str(e)}
 
     def _handle_import_3d_model(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Copy a 3D model into the project's *.3dshapes and return a ${KIPRJMOD} path."""
@@ -1785,7 +1785,7 @@ class KiCADInterface(SchematicHandlersMixin):
             )
         except Exception as e:
             logger.error(f"import_3d_model error: {e}")
-            return {"success": False, "error": str(e)}
+            return {"success": False, "message": str(e)}
 
     def _handle_add_component_3d_model(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Add a 3D model to a placed footprint on the board.
@@ -1793,7 +1793,7 @@ class KiCADInterface(SchematicHandlersMixin):
         Prefers the live IPC path; if IPC is unavailable this returns a clear
         message (live board editing requires KiCAD running with the IPC API).
         """
-        if self.use_ipc and getattr(self, "ipc_board_api", None):
+        if self.use_ipc and getattr(self, "ipc_board_api", None) and self._session_allows_ipc():
             return self._ipc_add_component_3d_model(params)
         return {
             "success": False,

--- a/src/tools/footprint.ts
+++ b/src/tools/footprint.ts
@@ -122,6 +122,129 @@ export function registerFootprintTools(server: McpServer, callKicadScript: Funct
     },
   );
 
+  // ── add_footprint_3d_model ────────────────────────────────────────────── //
+  const Xyz = z.object({
+    x: z.number(),
+    y: z.number(),
+    z: z.number(),
+  });
+  server.tool(
+    "add_footprint_3d_model",
+    "Attach (or replace) a 3D model — .step/.stp/.wrl — to a .kicad_mod footprint file. " +
+      "KiCAD path variables like ${KIPRJMOD} or ${KICAD10_3DMODEL_DIR} are supported. " +
+      "Use this after create_footprint so the part shows up in the 3D viewer (Alt+3).",
+    {
+      footprintPath: z
+        .string()
+        .describe("Full path to the .kicad_mod file, e.g. C:/MyLib.pretty/MyPart.kicad_mod"),
+      modelPath: z
+        .string()
+        .describe(
+          "Path to the 3D model file. Prefer ${KIPRJMOD}/MyProj.3dshapes/MyPart.step for portability.",
+        ),
+      offset: Xyz.optional().describe("Model offset in mm (default 0,0,0)"),
+      scale: Xyz.optional().describe("Model scale factor (default 1,1,1)"),
+      rotate: Xyz.optional().describe("Model rotation in degrees (default 0,0,0)"),
+      replace: z
+        .boolean()
+        .optional()
+        .describe("Replace an existing model with the same filename (default true)"),
+    },
+    async (args: {
+      footprintPath: string;
+      modelPath: string;
+      offset?: { x: number; y: number; z: number };
+      scale?: { x: number; y: number; z: number };
+      rotate?: { x: number; y: number; z: number };
+      replace?: boolean;
+    }) => {
+      const result = await callKicadScript("add_footprint_3d_model", args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  // ── import_3d_model ──────────────────────────────────────────────────── //
+  server.tool(
+    "import_3d_model",
+    "Copy a 3D model file (.step/.stp/.wrl/.x3d/.iges) into the project's *.3dshapes " +
+      "library folder and return a portable ${KIPRJMOD}/... path. Feed the returned " +
+      "'modelPath' straight into add_footprint_3d_model or add_component_3d_model.",
+    {
+      modelPath: z.string().describe("Path to the source 3D model file to import"),
+      projectPath: z
+        .string()
+        .describe(
+          "Path to the .kicad_pro file or the project directory (used to locate the " +
+            ".3dshapes folder and compute ${KIPRJMOD})",
+        ),
+      libraryDir: z
+        .string()
+        .optional()
+        .describe(
+          "Target *.3dshapes directory (absolute, or relative to the project). " +
+            "Default: <project>/<project>.3dshapes",
+        ),
+      newName: z
+        .string()
+        .optional()
+        .describe("Rename the copied file (source extension kept if omitted)"),
+      overwrite: z
+        .boolean()
+        .optional()
+        .describe("Overwrite an existing destination file (default false)"),
+    },
+    async (args: {
+      modelPath: string;
+      projectPath: string;
+      libraryDir?: string;
+      newName?: string;
+      overwrite?: boolean;
+    }) => {
+      const result = await callKicadScript("import_3d_model", args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  // ── add_component_3d_model (LIVE / IPC) ──────────────────────────────── //
+  server.tool(
+    "add_component_3d_model",
+    "Attach a 3D model to one or more PLACED footprints on the open board, live via " +
+      "the KiCAD IPC API (changes appear instantly, no file conflicts). " +
+      "Use this for components already on the PCB; for a library .kicad_mod use add_footprint_3d_model.",
+    {
+      reference: z
+        .union([z.string(), z.array(z.string())])
+        .describe("Footprint reference(s), e.g. 'D1', ['D1','D2'], or '*' for all footprints"),
+      modelPath: z
+        .string()
+        .describe("Path to the 3D model, e.g. ${KIPRJMOD}/MyProj.3dshapes/MyPart.step"),
+      offset: Xyz.optional().describe("Model offset in mm (default 0,0,0)"),
+      scale: Xyz.optional().describe("Model scale factor (default 1,1,1)"),
+      rotate: Xyz.optional().describe("Model rotation in degrees (default 0,0,0)"),
+      replace: z
+        .boolean()
+        .optional()
+        .describe("Replace an existing model with the same filename (default true)"),
+    },
+    async (args: {
+      reference: string | string[];
+      modelPath: string;
+      offset?: { x: number; y: number; z: number };
+      scale?: { x: number; y: number; z: number };
+      rotate?: { x: number; y: number; z: number };
+      replace?: boolean;
+    }) => {
+      const result = await callKicadScript("add_component_3d_model", args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
   // ── edit_footprint_pad ────────────────────────────────────────────────── //
   server.tool(
     "edit_footprint_pad",


### PR DESCRIPTION
## Summary
Adds three MCP tools so the full 3D-model workflow lives in the server:

- **`import_3d_model`** — copy a `.step/.stp/.wrl/.x3d/.iges` file into the project's `*.3dshapes` library and return a portable `${KIPRJMOD}/...` path.
- **`add_footprint_3d_model`** — attach or replace a `(model ...)` block in a library `.kicad_mod` file (idempotent, supports `${KIPRJMOD}` and offset/scale/rotate).
- **`add_component_3d_model`** — attach a model to one or more *placed* footprints on the open board via the **IPC backend** (live, instant UI update). Forces `scale = 1,1,1` so the body actually renders (a fresh `Footprint3DModel` proto defaults to `scale = 0`).

Wiring:
- Python: `FootprintCreator.add_3d_model` / `import_3d_model`, `IPCBoardAPI.add_3d_model`, command handlers + routing in `kicad_interface.py`, and `add_component_3d_model` registered in `IPC_CAPABLE_COMMANDS`.
- TypeScript: tool schemas in `src/tools/footprint.ts`.

Single commit, `+503 / -0` across 4 files, based directly on `main`.

## Test plan
- [x] `npm run build` (tsc) passes.
- [x] `add_footprint_3d_model` adds exactly one `(model ...)` block and is idempotent with `replace=true`.
- [x] `import_3d_model` copies into `*.3dshapes` and returns the `${KIPRJMOD}` path.
- [x] `add_component_3d_model` over IPC sets `scale=1` and bodies render (verified via `kicad-cli pcb render`).
- [x] Reviewer: confirm tool descriptions/schemas read well in your MCP client.
