### PR TITLE
fix: emit structurally-complete symbol instances (no crash on drag)

### DIFF
--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -529,6 +529,191 @@ class DynamicSymbolLoader:
         ry = -dx * math.sin(rad) + dy * math.cos(rad)
         return round(rx, 3), round(ry, 3)
 
+    # ------------------------------------------------------------------ #
+    # Instance-block helpers (project name, hierarchical path, pin uuids) #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _read_root_uuid(content: str) -> str:
+        """Return a schematic's own top-level (uuid ...) value, or '' if absent."""
+        m = re.search(r'\(uuid\s+"?([0-9a-fA-F-]+)"?\)', content)
+        return m.group(1) if m else ""
+
+    def _resolve_project_name(self, schematic_path: Path) -> str:
+        """Return the KiCad project name recorded in (instances (project "<name>" ...)).
+
+        KiCad uses the project (``.kicad_pro``) stem, not the literal string
+        ``"project"``. Derive it from the nearest ``.kicad_pro`` (searching the
+        schematic's directory then a few parents), falling back to the schematic's
+        own stem when no project file is found.
+        """
+        try:
+            sch = Path(schematic_path).resolve()
+            search_dirs = [sch.parent] + list(sch.parent.parents)[:3]
+            for directory in search_dirs:
+                pros = sorted(directory.glob("*.kicad_pro"))
+                if pros:
+                    return pros[0].stem
+            return sch.stem
+        except Exception:
+            return Path(schematic_path).stem
+
+    def _iter_child_sheets(self, content: str) -> List[Tuple[str, str]]:
+        """Yield (sheet_block_uuid, sheet_file_rel) for each (sheet ...) in a schematic.
+
+        Skips (sheet_instances ...) — its token has no whitespace after ``sheet``.
+        """
+        results: List[Tuple[str, str]] = []
+        for m in re.finditer(r"\(sheet(?=\s)", content):
+            block = self._extract_paren_block(content, m.start())
+            um = re.search(r'\(uuid\s+"?([0-9a-fA-F-]+)"?\)', block)
+            fm = re.search(r'\(property\s+"Sheet file"\s+"([^"]+)"', block)
+            if um and fm:
+                results.append((um.group(1), fm.group(1).replace("\\", "/")))
+        return results
+
+    def _find_root_schematic(self, target: Path) -> Optional[Path]:
+        """Find the project's root .kicad_sch (the one carrying (sheet_instances ...))."""
+        try:
+            directory = target.parent
+            for pro in sorted(directory.glob("*.kicad_pro")):
+                cand = directory / f"{pro.stem}.kicad_sch"
+                if cand.exists():
+                    return cand.resolve()
+            for cand in sorted(directory.glob("*.kicad_sch")):
+                try:
+                    if "(sheet_instances" in cand.read_text(encoding="utf-8"):
+                        return cand.resolve()
+                except Exception:
+                    continue
+        except Exception:
+            pass
+        return None
+
+    def _sheet_chain_to(self, root: Path, target: Path) -> List[str]:
+        """Return the UUID chain [root_uuid, sheet_block_uuid, ...] from root to target.
+
+        Walks the root project's sheet tree breadth-first. Returns [] if target is not
+        reachable from root.
+        """
+        try:
+            root = root.resolve()
+            target = target.resolve()
+            root_content = root.read_text(encoding="utf-8")
+            root_uuid = self._read_root_uuid(root_content)
+            if not root_uuid:
+                return []
+            if root == target:
+                return [root_uuid]
+            visited = {root}
+            queue: List[Tuple[Path, str, List[str]]] = [(root, root_content, [root_uuid])]
+            while queue:
+                fpath, fcontent, chain = queue.pop(0)
+                for block_uuid, rel in self._iter_child_sheets(fcontent):
+                    child = (fpath.parent / rel).resolve()
+                    new_chain = chain + [block_uuid]
+                    if child == target:
+                        return new_chain
+                    if child.exists() and child not in visited:
+                        visited.add(child)
+                        try:
+                            queue.append((child, child.read_text(encoding="utf-8"), new_chain))
+                        except Exception:
+                            continue
+            return []
+        except Exception:
+            return []
+
+    def _build_instance_path(self, schematic_path: Path) -> str:
+        """Return the symbol instance path for symbols placed in ``schematic_path``.
+
+        - Root / flat schematic (carries (sheet_instances ...)): ``/<root-sheet-uuid>``
+          where the UUID is the schematic's own top-level (uuid ...).
+        - Child sheet in a hierarchy: the chain of sheet-instance UUIDs from the root,
+          ``/<root-uuid>/<sheet-block-uuid>[/...]``, reconstructed by walking the root
+          project's sheet tree.
+        - Unlinked child (no chain yet): one level using the sheet's own UUID;
+          add_hierarchical_sheet -> fix_subsheet_instances repairs it once linked.
+        """
+        try:
+            target = Path(schematic_path).resolve()
+            content = target.read_text(encoding="utf-8")
+            this_uuid = self._read_root_uuid(content)
+
+            if "(sheet_instances" in content and this_uuid:
+                return f"/{this_uuid}"
+
+            root = self._find_root_schematic(target)
+            if root is not None:
+                chain = self._sheet_chain_to(root, target)
+                if chain:
+                    return "/" + "/".join(chain)
+
+            return f"/{this_uuid}" if this_uuid else "/"
+        except Exception:
+            return "/"
+
+    def _extract_symbol_pins(
+        self, schematic_path: Path, library_name: str, symbol_name: str, unit: int
+    ) -> List[str]:
+        """Return string-sorted pin numbers for the placed unit (plus shared unit-0 pins).
+
+        KiCad writes a ``(pin "N" (uuid ...))`` entry inside every placed symbol for each
+        pin; omitting them yields a structurally-incomplete instance the editor can crash
+        on when dragged. Pins live inside lib sub-symbols named ``<sym>_<unit>_<style>``;
+        unit-0 sub-symbols are shared by every unit. Numbers are returned in KiCad's
+        ordering (ascending string sort).
+        """
+        try:
+            content = Path(schematic_path).read_text(encoding="utf-8")
+            lib_start = content.find("(lib_symbols")
+            if lib_start == -1:
+                return []
+            sym_start = content.find(f'(symbol "{library_name}:{symbol_name}"', lib_start)
+            if sym_start == -1:
+                return []
+            sym_block = self._extract_paren_block(content, sym_start)
+
+            numbers: List[str] = []
+            for m in re.finditer(r'\(symbol\s+"([^"]+)"', sym_block):
+                name = m.group(1)
+                if ":" in name:
+                    # Top-level lib wrapper (e.g. "Device:R"); units live in sub-symbols.
+                    continue
+                um = re.search(r"_(\d+)_(\d+)$", name)
+                sub_unit = int(um.group(1)) if um else None
+                if sub_unit not in (None, 0, unit):
+                    continue
+                sub_block = self._extract_paren_block(sym_block, m.start())
+                for pm in re.finditer(r'\(pin\b.*?\(number\s+"([^"]+)"', sub_block, re.DOTALL):
+                    numbers.append(pm.group(1))
+
+            return sorted(dict.fromkeys(numbers))
+        except Exception:
+            return []
+
+    def _extract_lib_property_value(
+        self, schematic_path: Path, library_name: str, symbol_name: str, prop_name: str
+    ) -> Optional[str]:
+        """Return a top-level property value from the injected lib symbol, or None.
+
+        Used to copy Datasheet/Description values into the placed instance so it matches
+        KiCad-authored output (KiCad carries these fields on every symbol).
+        """
+        try:
+            content = Path(schematic_path).read_text(encoding="utf-8")
+            lib_start = content.find("(lib_symbols")
+            if lib_start == -1:
+                return None
+            sym_start = content.find(f'(symbol "{library_name}:{symbol_name}"', lib_start)
+            if sym_start == -1:
+                return None
+            sym_block = self._extract_paren_block(content, sym_start)
+            m = re.search(r'\(property\s+"' + re.escape(prop_name) + r'"\s+"([^"]*)"', sym_block)
+            return m.group(1) if m else None
+        except Exception:
+            return None
+
     def create_component_instance(
         self,
         schematic_path: Path,
@@ -576,34 +761,104 @@ class DynamicSymbolLoader:
 
         ref_x, ref_y, ref_a, ref_eff = _prop_at("Reference", 2.032, 0, 0)
         val_x, val_y, val_a, val_eff = _prop_at("Value", 0, 2.54, 0)
-        fp_x, fp_y, _, _ = _prop_at("Footprint", 0, 0, 0)
-        ds_x, ds_y, _, _ = _prop_at("Datasheet", 0, 0, 0)
+        fp_x, fp_y, fp_a, fp_eff = _prop_at("Footprint", 0, 0, 0)
+        ds_x, ds_y, ds_a, ds_eff = _prop_at("Datasheet", 0, 0, 0)
+        desc_x, desc_y, desc_a, desc_eff = _prop_at("Description", 0, 0, 0)
+
+        def _fmt(n: float) -> str:
+            """Format a coordinate the way KiCad does: integral values without a
+            trailing ``.0`` (e.g. 100.0 -> '100', 90.0 -> '90')."""
+            try:
+                f = float(n)
+            except (TypeError, ValueError):
+                return str(n)
+            return str(int(f)) if f.is_integer() else str(n)
+
+        def _clean_effects(eff: str) -> str:
+            """Strip legacy hide markers from a lib (effects ...) string.
+
+            KiCad 10 records field visibility with a top-level (hide yes) on the
+            property, not inside (effects ...). Remove both the parenthesised
+            (hide ...) and the bare ``hide`` token so we don't emit a v9-style
+            effects block beside the v10 top-level (hide yes).
+            """
+            eff = re.sub(r"\s*\(hide\s+[^)]*\)", "", eff)
+            eff = re.sub(r"\s+hide(?=[\s)])", "", eff)
+            return eff.strip() or "(effects (font (size 1.27 1.27)))"
+
+        def _property(
+            name: str, value: str, px: float, py: float, pa: float, eff: str, hide: bool
+        ) -> str:
+            """Build a KiCad-10 (property ...) block.
+
+            Field order: at, [hide yes], show_name no, do_not_autoplace no, effects.
+            """
+            hide_line = "      (hide yes)\n" if hide else ""
+            return (
+                f'    (property "{name}" "{value}"\n'
+                f"      (at {_fmt(px)} {_fmt(py)} {_fmt(pa)})\n"
+                f"{hide_line}"
+                f"      (show_name no)\n"
+                f"      (do_not_autoplace no)\n"
+                f"      {_clean_effects(eff)}\n"
+                f"    )"
+            )
+
+        # Datasheet/Description values come from the injected lib symbol. KiCad normalises
+        # the placeholder "~" datasheet to an empty string, so mirror that to keep the
+        # generated instance byte-stable across a KiCad save (round-trip).
+        ds_val = self._extract_lib_property_value(
+            schematic_path, library_name, symbol_name, "Datasheet"
+        )
+        ds_val = "" if ds_val in (None, "~") else ds_val
+        desc_val = (
+            self._extract_lib_property_value(
+                schematic_path, library_name, symbol_name, "Description"
+            )
+            or ""
+        )
+
+        properties_str = "\n".join(
+            [
+                _property("Reference", reference, ref_x, ref_y, ref_a, ref_eff, False),
+                _property("Value", value or symbol_name, val_x, val_y, val_a, val_eff, False),
+                _property("Footprint", footprint, fp_x, fp_y, fp_a, fp_eff, True),
+                _property("Datasheet", ds_val, ds_x, ds_y, ds_a, ds_eff, True),
+                _property("Description", desc_val, desc_x, desc_y, desc_a, desc_eff, True),
+            ]
+        )
+
+        # Per-pin uuids — KiCad writes a (pin "N" (uuid ...)) for every pin of the placed
+        # unit; their absence is a primary cause of editor crashes when the symbol is dragged.
+        pin_numbers = self._extract_symbol_pins(schematic_path, library_name, symbol_name, unit)
+        pins_str = "\n".join(f'    (pin "{n}" (uuid "{uuid.uuid4()}"))' for n in pin_numbers)
+
+        # Real project name + hierarchical sheet path (not the "project" / "/" placeholders).
+        project_name = self._resolve_project_name(schematic_path)
+        instance_path = self._build_instance_path(schematic_path)
+        instances_str = (
+            "    (instances\n"
+            f'      (project "{project_name}"\n'
+            f'        (path "{instance_path}"\n'
+            f'          (reference "{reference}")\n'
+            f"          (unit {unit})\n"
+            "        )\n"
+            "      )\n"
+            "    )"
+        )
+
+        body = "\n".join(part for part in [properties_str, pins_str, instances_str] if part)
 
         mirror_str = " (mirror y)" if mirror_y else ""
-        instance_block = f"""  (symbol (lib_id "{full_lib_id}") (at {x} {y} {angle}){mirror_str} (unit {unit})
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid "{new_uuid}")
-    (property "Reference" "{reference}" (at {ref_x} {ref_y} {ref_a})
-      {ref_eff}
-    )
-    (property "Value" "{value or symbol_name}" (at {val_x} {val_y} {val_a})
-      {val_eff}
-    )
-    (property "Footprint" "{footprint}" (at {fp_x} {fp_y} 0)
-      (effects (font (size 1.27 1.27)) (hide yes))
-    )
-    (property "Datasheet" "~" (at {ds_x} {ds_y} 0)
-      (effects (font (size 1.27 1.27)) (hide yes))
-    )
-    (instances
-      (project "project"
-        (path "/"
-          (reference "{reference}")
-          (unit {unit})
+        instance_block = (
+            f'  (symbol (lib_id "{full_lib_id}") (at {_fmt(x)} {_fmt(y)} {_fmt(angle)})'
+            f"{mirror_str} (unit {unit})\n"
+            "    (body_style 1) (exclude_from_sim no) (in_bom yes) (on_board yes)"
+            " (in_pos_files yes) (dnp no)\n"
+            f'    (uuid "{new_uuid}")\n'
+            f"{body}\n"
+            "  )"
         )
-      )
-    )
-  )"""
 
         with open(schematic_path, "r", encoding="utf-8") as f:
             content = f.read()

--- a/tests/test_symbol_instance_completeness.py
+++ b/tests/test_symbol_instance_completeness.py
@@ -1,0 +1,347 @@
+"""Tests that placed symbol instances are *structurally complete* — i.e. they match
+KiCad-authored output closely enough that the editor does not crash when the symbol is
+dragged.
+
+Regression target: ``DynamicSymbolLoader.create_component_instance`` used to emit an
+instance block with placeholder values:
+
+    (instances (project "project" (path "/" ...)))   # literal "project", root "/"
+
+and omitted ``body_style``/``exclude_from_sim``/``in_pos_files``, per-pin
+``(pin "N" (uuid ...))`` entries and the v10 ``(show_name no)``/``(do_not_autoplace no)``
+property attributes. KiCad rendered such a symbol but crashed on drag.
+
+Both ``add_schematic_component`` and ``batch_add_components`` route through
+``create_component_instance``, so these tests exercise the single shared writer.
+
+Ground truth was captured from KiCad 10.0.4 (schematic format version 20260306,
+generator "eeschema") by upgrading a bundled demo with ``kicad-cli sch upgrade``.
+"""
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.dynamic_symbol_loader import DynamicSymbolLoader  # noqa: E402
+
+TEMPLATES_DIR = Path(__file__).parent.parent / "python" / "templates"
+EMPTY_SCH = TEMPLATES_DIR / "empty.kicad_sch"
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _project(tmp_path: Path, project_stem: str = "myproj") -> Path:
+    """Create a flat project (one .kicad_sch + matching .kicad_pro) and return the sch."""
+    sch = tmp_path / f"{project_stem}.kicad_sch"
+    shutil.copy(EMPTY_SCH, sch)
+    (tmp_path / f"{project_stem}.kicad_pro").write_text('{"meta":{"version":1}}', encoding="utf-8")
+    return sch
+
+
+def _root_uuid(sch: Path) -> str:
+    m = re.search(r'\(uuid\s+"?([0-9a-fA-F-]+)"?\)', sch.read_text(encoding="utf-8"))
+    assert m, "schematic has no top-level uuid"
+    return m.group(1)
+
+
+def _placed_block(sch: Path, lib_id: str = "Device:R") -> str:
+    """Return the first placed (symbol ... (lib_id "<lib_id>") ... (instances ...)) block.
+
+    Works for both the compact form the generator writes and the multi-line form KiCad
+    rewrites to on save.
+    """
+    s = sch.read_text(encoding="utf-8")
+    for m in re.finditer(r"\(symbol\b", s):
+        start = m.start()
+        depth = 0
+        i = start
+        while i < len(s):
+            if s[i] == "(":
+                depth += 1
+            elif s[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        block = s[start : i + 1]
+        if f'(lib_id "{lib_id}")' in block and "(instances" in block:
+            return block
+    raise AssertionError(f"placed symbol {lib_id} not found")
+
+
+# A synthetic two-unit symbol: unit-0 sub-symbol holds shared power pins (8, 4);
+# unit 1 holds pins 3/2/1; unit 2 holds pins 5/6/7. Used to pin down per-unit pin
+# selection without depending on installed symbol libraries.
+_DUAL_SCH = """(kicad_sch (version 20250114) (generator "x")
+  (uuid "11110000-0000-0000-0000-000000000000")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Test:DUAL" (pin_numbers hide) (pin_names (offset 0)) (in_bom yes) (on_board yes)
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "DUAL" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+      (property "Datasheet" "~" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+      (symbol "DUAL_0_1"
+        (pin power_in line (at 0 10 0) (length 2) (name "V+") (number "8"))
+        (pin power_in line (at 0 -10 0) (length 2) (name "V-") (number "4")))
+      (symbol "DUAL_1_1"
+        (pin input line (at -5 5 0) (length 2) (name "+") (number "3"))
+        (pin input line (at -5 -5 0) (length 2) (name "-") (number "2"))
+        (pin output line (at 5 0 0) (length 2) (name "O") (number "1")))
+      (symbol "DUAL_2_1"
+        (pin input line (at -5 5 0) (length 2) (name "+") (number "5"))
+        (pin input line (at -5 -5 0) (length 2) (name "-") (number "6"))
+        (pin output line (at 5 0 0) (length 2) (name "O") (number "7")))
+    )
+  )
+  (sheet_instances (path "/" (page "1")))
+)
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Header / property field set (KiCad 10 format)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestHeaderFieldSet:
+    def test_header_has_v10_fields_in_order(self, tmp_path: Any) -> None:
+        sch = _project(tmp_path)
+        DynamicSymbolLoader().create_component_instance(
+            sch, "Device", "R", reference="R1", value="10k", x=100, y=100
+        )
+        block = _placed_block(sch)
+        order = [
+            "(lib_id ",
+            "(at ",
+            "(unit ",
+            "(body_style 1)",
+            "(exclude_from_sim no)",
+            "(in_bom yes)",
+            "(on_board yes)",
+            "(in_pos_files yes)",
+            "(dnp no)",
+            "(uuid ",
+        ]
+        positions = [block.find(tok) for tok in order]
+        assert all(p != -1 for p in positions), dict(zip(order, positions))
+        assert positions == sorted(positions), f"header fields out of order: {positions}"
+
+    def test_properties_have_v10_attributes(self, tmp_path: Any) -> None:
+        sch = _project(tmp_path)
+        DynamicSymbolLoader().create_component_instance(
+            sch, "Device", "R", reference="R1", value="10k", x=100, y=100
+        )
+        block = _placed_block(sch)
+        for prop in ("Reference", "Value", "Footprint", "Datasheet"):
+            assert f'(property "{prop}"' in block
+        # Each visible/hidden property carries the v10 attributes.
+        assert block.count("(show_name no)") >= 4
+        assert block.count("(do_not_autoplace no)") >= 4
+        # Hidden fields use a top-level (hide yes), not (hide yes) inside (effects ...).
+        assert "(hide yes)" in block
+        assert not re.search(r"\(effects[^)]*hide", block)
+
+
+# --------------------------------------------------------------------------- #
+# Real project name + real instance path (no placeholders)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestProjectAndPath:
+    def test_no_placeholder_project_or_root_path(self, tmp_path: Any) -> None:
+        sch = _project(tmp_path, "myproj")
+        DynamicSymbolLoader().create_component_instance(
+            sch, "Device", "R", reference="R1", value="10k", x=100, y=100
+        )
+        block = _placed_block(sch)
+        assert '(project "project"' not in block
+        assert '(project "myproj"' in block
+        # The symbol instance path must be the real root sheet UUID, not "/".
+        assert '(path "/"' not in block
+
+    def test_flat_path_is_root_uuid(self, tmp_path: Any) -> None:
+        sch = _project(tmp_path, "myproj")
+        DynamicSymbolLoader().create_component_instance(
+            sch, "Device", "R", reference="R1", value="10k", x=100, y=100
+        )
+        block = _placed_block(sch)
+        assert f'(path "/{_root_uuid(sch)}"' in block
+
+    def test_project_name_falls_back_to_schematic_stem(self, tmp_path: Any) -> None:
+        # No .kicad_pro present -> use the schematic's own stem.
+        sch = tmp_path / "loneboard.kicad_sch"
+        shutil.copy(EMPTY_SCH, sch)
+        assert DynamicSymbolLoader()._resolve_project_name(sch) == "loneboard"
+
+
+# --------------------------------------------------------------------------- #
+# Per-pin uuids + multi-unit pin selection
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestPerPinUuids:
+    def test_pins_emitted_with_uuids(self, tmp_path: Any) -> None:
+        sch = _project(tmp_path)
+        DynamicSymbolLoader().create_component_instance(
+            sch, "Device", "R", reference="R1", value="10k", x=100, y=100
+        )
+        block = _placed_block(sch)
+        # Device:R has two pins; both must be emitted with a uuid.
+        assert re.search(r'\(pin "1" \(uuid "[0-9a-fA-F-]{36}"\)\)', block)
+        assert re.search(r'\(pin "2" \(uuid "[0-9a-fA-F-]{36}"\)\)', block)
+
+    def test_unit_pin_selection(self, tmp_path: Any) -> None:
+        sch = tmp_path / "dual.kicad_sch"
+        sch.write_text(_DUAL_SCH, encoding="utf-8")
+        loader = DynamicSymbolLoader()
+        # Unit 1 -> its own pins (1,2,3) + shared unit-0 pins (4,8); string-sorted.
+        assert loader._extract_symbol_pins(sch, "Test", "DUAL", 1) == ["1", "2", "3", "4", "8"]
+        # Unit 2 -> (5,6,7) + shared (4,8).
+        assert loader._extract_symbol_pins(sch, "Test", "DUAL", 2) == ["4", "5", "6", "7", "8"]
+
+    def test_pins_string_sorted(self, tmp_path: Any) -> None:
+        sch = tmp_path / "dual.kicad_sch"
+        sch.write_text(_DUAL_SCH, encoding="utf-8")
+        pins = DynamicSymbolLoader()._extract_symbol_pins(sch, "Test", "DUAL", 1)
+        assert pins == sorted(pins)
+
+
+# --------------------------------------------------------------------------- #
+# Hierarchical instance path reconstruction
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestHierarchicalPath:
+    def _build(self, tmp_path: Path) -> tuple:
+        root = tmp_path / "design.kicad_sch"
+        child = tmp_path / "child.kicad_sch"
+        (tmp_path / "design.kicad_pro").write_text('{"meta":{"version":1}}', encoding="utf-8")
+        root.write_text(
+            '(kicad_sch (version 20250114) (generator "x")\n'
+            '  (uuid "aaaa0000-0000-0000-0000-000000000001")\n  (paper "A4")\n'
+            "  (lib_symbols)\n"
+            "  (sheet (at 50 50) (size 30 20)\n"
+            '    (uuid "bbbb0000-0000-0000-0000-000000000002")\n'
+            '    (property "Sheet name" "Child" (at 50 48 0) (effects (font (size 1.27 1.27))))\n'
+            '    (property "Sheet file" "child.kicad_sch" (at 50 72 0)'
+            " (effects (font (size 1.27 1.27))))\n"
+            "  )\n"
+            '  (sheet_instances (path "/" (page "1")))\n)\n',
+            encoding="utf-8",
+        )
+        child.write_text(
+            '(kicad_sch (version 20250114) (generator "x")\n'
+            '  (uuid "cccc0000-0000-0000-0000-000000000003")\n  (paper "A4")\n'
+            "  (lib_symbols)\n)\n",
+            encoding="utf-8",
+        )
+        return root, child
+
+    def test_root_path_is_root_uuid(self, tmp_path: Any) -> None:
+        root, _ = self._build(tmp_path)
+        assert (
+            DynamicSymbolLoader()._build_instance_path(root)
+            == "/aaaa0000-0000-0000-0000-000000000001"
+        )
+
+    def test_child_path_is_root_then_sheet_block(self, tmp_path: Any) -> None:
+        _, child = self._build(tmp_path)
+        assert DynamicSymbolLoader()._build_instance_path(child) == (
+            "/aaaa0000-0000-0000-0000-000000000001/bbbb0000-0000-0000-0000-000000000002"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end structural round-trip via kicad-cli (skipped if unavailable)
+# --------------------------------------------------------------------------- #
+
+
+def _kicad_cli() -> str:
+    cli = shutil.which("kicad-cli")
+    if cli:
+        return cli
+    for cand in (
+        r"C:\Program Files\KiCad\10.0\bin\kicad-cli.exe",
+        r"C:\Program Files\KiCad\9.0\bin\kicad-cli.exe",
+    ):
+        if Path(cand).exists():
+            return cand
+    return ""
+
+
+@pytest.mark.integration
+class TestKicadCliRoundTrip:
+    """A placed symbol must survive a KiCad save (``kicad-cli sch upgrade``) with its
+    structural fields unchanged. If KiCad rewrites the instance, the generator did not
+    match KiCad-authored output."""
+
+    def setup_method(self) -> None:
+        self.cli = _kicad_cli()
+        if not self.cli:
+            pytest.skip("kicad-cli not available")
+        try:
+            import sexpdata  # noqa: F401
+        except ImportError:
+            pytest.skip("sexpdata not available")
+
+    def _canon(self, node: Any) -> Any:
+        import sexpdata
+        from sexpdata import Symbol
+
+        if isinstance(node, list):
+            if node and node[0] == Symbol("uuid"):
+                return [Symbol("uuid"), "U"]
+            return [self._canon(x) for x in node]
+        return node
+
+    def test_erc_parses_and_roundtrips(self, tmp_path: Any) -> None:
+        import sexpdata
+
+        sch = _project(tmp_path, "rt")
+        DynamicSymbolLoader().create_component_instance(
+            sch,
+            "Device",
+            "R",
+            reference="R1",
+            value="10k",
+            footprint="Resistor_SMD:R_0402_1005Metric",
+            x=100,
+            y=100,
+        )
+        before = _placed_block(sch)
+
+        # 1) ERC must load/parse the file (non-zero exit just means violations exist).
+        erc = subprocess.run(
+            [self.cli, "sch", "erc", str(sch)],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+        )
+        assert "Failed to load" not in (erc.stdout + erc.stderr)
+
+        # 2) Round-trip: KiCad rewrites to canonical form; structural tree must be equal.
+        up = subprocess.run(
+            [self.cli, "sch", "upgrade", str(sch)],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+        )
+        assert up.returncode == 0, up.stdout + up.stderr
+        after = _placed_block(sch)
+
+        assert self._canon(sexpdata.loads(before)) == self._canon(sexpdata.loads(after))


### PR DESCRIPTION
## Problem
Placing a symbol via `add_schematic_component` (or `batch_add_components`) wrote a
symbol-instance block that KiCad loads and renders fine but **crashes when the placed
symbol is dragged** in the editor. Both tools route through
`DynamicSymbolLoader.create_component_instance`, whose instance block used placeholder
values and omitted fields that real KiCad output includes:

- literal `(project "project")` instead of the real project name
- hardcoded `(path "/")` instead of the real sheet-UUID path
- omitted `body_style` / `exclude_from_sim` / `in_pos_files`
- omitted per-pin `(pin "N" (uuid ...))` entries
- v9-style hide markers inside `(effects ...)` and missing `(show_name no)` /
  `(do_not_autoplace no)`

## Fix
Reproduce KiCad 10 (schematic format `20260306`, generator `eeschema`) authored output:

- **Real project name** derived from the nearest `.kicad_pro` stem
- **Real instance path**:
  - flat / root schematic: `/<root-sheet-uuid>` (the schematic's own top-level uuid)
  - hierarchical child sheet: `/<root-uuid>/<sheet-block-uuid>...`, reconstructed by
    walking the root project's sheet tree
- **Full KiCad-10 header field set** in canonical order
  (lib_id, at, [mirror], unit, body_style, exclude_from_sim, in_bom, on_board,
  in_pos_files, dnp, uuid, properties, pins, instances)
- **Per-pin `(pin "N" (uuid ...))`** for the placed unit (plus shared unit-0 pins),
  string-sorted to match KiCad's ordering
- **v10 property attributes** (`show_name no` / `do_not_autoplace no`) with top-level
  `(hide yes)` instead of `hide` inside `(effects ...)`

Because both `add_schematic_component` and `batch_add_components` use the same writer,
the single change fixes both.

## Verification (KiCad 10.0.4)
Ground truth was captured by upgrading a bundled demo (`interf_u`) with
`kicad-cli sch upgrade`.

1. `kicad-cli sch erc <file>` parses the generated schematic with no structural/parse
   error.
2. Round-trip: `kicad-cli sch upgrade` rewrites the file to canonical form and the
   placed symbol is **structurally identical** (s-expression tree equal modulo fresh
   uuids) — i.e. KiCad does not rewrite the instance.
3. Multi-unit pin selection (placed unit + shared unit-0 pins, string-sorted) and the
   hierarchical-path chain are unit-tested.
4. Both `add_schematic_component` and `batch_add_components` covered (shared writer).

> Note: the drag-crash itself requires the KiCad GUI to confirm interactively; the
> `kicad-cli` round-trip equivalence to KiCad-authored output is the structural proxy.

## Tests
- New `tests/test_symbol_instance_completeness.py` (header field set, v10 properties,
  real project name + path, per-pin uuids, multi-unit selection, hierarchical path, and
  a `kicad-cli` ERC + round-trip integration test that skips when the CLI is absent).
- Full affected suite green: 132 passed. Pre-commit hooks (black, isort, flake8, mypy)
  pass.

## PR Checklist
- [x] Code follows style guidelines
- [x] All tests pass locally
- [x] New tests added for new behavior
- [x] Commit messages follow convention
- [x] No merge conflicts
