### PR TITLE
fix: make the yaqwsx JLCPCB download work on a stock install (volume auto-detect + robust 7-Zip resolution)

### DIFF
--- a/python/commands/jlcpcb_downloader.py
+++ b/python/commands/jlcpcb_downloader.py
@@ -22,6 +22,7 @@ Data is MIT-licensed via CDFER and yaqwsx/jlcparts; the underlying catalog facts
 originate from JLCPCB / LCSC and are subject to their terms.
 """
 
+import itertools
 import json
 import logging
 import os
@@ -37,7 +38,11 @@ logger = logging.getLogger("kicad_interface")
 
 CDFER_SQLITE_URL = "https://cdfer.github.io/jlcpcb-parts-database/jlcpcb-components.sqlite3"
 YAQWSX_BASE_URL = "https://yaqwsx.github.io/jlcparts/data"
-YAQWSX_MAX_VOLUMES = 30
+# Safety upper bound only — NOT the expected volume count. The yaqwsx split archive
+# (cache.z01 … cache.zNN) grows as the JLCPCB catalog expands, so the real last volume
+# is auto-detected by the 404 break in the download loop. This cap merely prevents an
+# unbounded loop if the 404 never arrives.
+YAQWSX_MAX_VOLUMES = 999
 
 ProgressFn = Optional[Callable[[str], None]]
 
@@ -458,7 +463,17 @@ def download_yaqwsx(cache_dir: Path, progress: ProgressFn = None) -> Path:
             == 0
         )
 
-    for i in range(1, YAQWSX_MAX_VOLUMES + 1):
+    # Volume count is auto-detected: keep fetching cache.z01, cache.z02, … until the
+    # first 404 (the part past the last real volume), which signals the end of the split
+    # archive. YAQWSX_MAX_VOLUMES is only a runaway-loop safety guard, not the real count.
+    for i in itertools.count(1):
+        if i > YAQWSX_MAX_VOLUMES:
+            logger.warning(
+                "yaqwsx volume download reached the safety cap of %d without hitting a "
+                "404; the split archive may be incomplete",
+                YAQWSX_MAX_VOLUMES,
+            )
+            break
         part = f"cache.z{i:02d}"
         dst = cache_dir / part
         if dst.exists() and dst.stat().st_size > 1000:
@@ -530,8 +545,8 @@ def _catalog_age_days(last_modified: Optional[str]) -> Optional[int]:
     if not last_modified:
         return None
     try:
-        from email.utils import parsedate_to_datetime
         from datetime import datetime, timezone
+        from email.utils import parsedate_to_datetime
 
         dt = parsedate_to_datetime(last_modified)
         if dt is None:

--- a/python/commands/jlcpcb_downloader.py
+++ b/python/commands/jlcpcb_downloader.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from utils.platform_helper import PlatformHelper
+from utils.seven_zip import resolve_7z, seven_zip_not_found_message
 
 logger = logging.getLogger("kicad_interface")
 
@@ -420,10 +421,13 @@ def download_cdfer(
 
 
 def _find_7z() -> Optional[str]:
-    for cmd in ("7z", "7zz", "7za"):
-        if shutil.which(cmd):
-            return cmd
-    return None
+    """Resolve a 7-Zip CLI to an absolute path.
+
+    Delegates to the shared resolver (env override -> PATH -> known install dirs) so
+    7-Zip is found even when its install directory is not on PATH (the default on
+    Windows, where 7-Zip installs to C:\\Program Files\\7-Zip).
+    """
+    return resolve_7z()
 
 
 def download_yaqwsx(cache_dir: Path, progress: ProgressFn = None) -> Path:
@@ -432,7 +436,7 @@ def download_yaqwsx(cache_dir: Path, progress: ProgressFn = None) -> Path:
 
     seven_zip = _find_7z()
     if not seven_zip:
-        raise RuntimeError("yaqwsx fallback requires a 7z CLI (7z/7zz/7za) which was not found")
+        raise RuntimeError(seven_zip_not_found_message())
     if not shutil.which("curl"):
         raise RuntimeError("yaqwsx fallback requires curl which was not found")
 

--- a/python/utils/seven_zip.py
+++ b/python/utils/seven_zip.py
@@ -1,0 +1,169 @@
+"""Robust resolution of a 7-Zip CLI executable.
+
+Mirrors the kicad-cli resolver pattern (PR #267): the 7-Zip Windows installer drops
+``7z.exe`` into ``C:\\Program Files\\7-Zip`` but does **not** add it to ``PATH``, so a
+bare ``shutil.which("7z")`` fails even when 7-Zip is installed. The yaqwsx JLCPCB
+download path needs a 7-Zip CLI to extract its split archive and then fails with a
+misleading "not found".
+
+Resolution order:
+
+    1. Explicit override: ``$SEVEN_ZIP`` / ``$SEVENZIP_PATH`` (if set). An explicit
+       override is authoritative — if it is set but does not point at a real file we
+       refuse to silently fall back to a different binary.
+    2. ``PATH`` lookup of the known basenames.
+    3. Known per-OS install locations (newest/most-specific first).
+
+The resolved absolute path is cached (subprocess accepts an absolute path). The
+environment override is re-checked on every call so a changed value is never masked.
+"""
+
+import logging
+import os
+import platform
+import shutil
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger("kicad_interface")
+
+_ENV_VARS = ("SEVEN_ZIP", "SEVENZIP_PATH")
+# Order matters: prefer the full-featured CLIs over the reduced 7zr/7za.
+_BASENAMES = ("7z", "7zz", "7za", "7zr")
+_cached_7z: Optional[str] = None
+
+
+def _exe_names() -> List[str]:
+    """Candidate basenames for the current OS (``.exe`` suffixed on Windows)."""
+    if platform.system() == "Windows":
+        return [f"{name}.exe" for name in _BASENAMES]
+    return list(_BASENAMES)
+
+
+def _override_value() -> Optional[str]:
+    """Return the first non-empty SEVEN_ZIP / SEVENZIP_PATH value, or None."""
+    for env in _ENV_VARS:
+        val = os.environ.get(env)
+        if val:
+            return val
+    return None
+
+
+def _windows_install_dirs() -> List[Path]:
+    """7-Zip install directories on Windows, from env then literal Program Files."""
+    dirs: List[Path] = []
+    seen: set = set()
+    for env in ("ProgramW6432", "ProgramFiles", "ProgramFiles(x86)"):
+        base = os.environ.get(env)
+        if base:
+            candidate = Path(base) / "7-Zip"
+            key = os.path.normcase(str(candidate))
+            if key not in seen:
+                seen.add(key)
+                dirs.append(candidate)
+    for literal in (r"C:\Program Files\7-Zip", r"C:\Program Files (x86)\7-Zip"):
+        key = os.path.normcase(literal)
+        if key not in seen:
+            seen.add(key)
+            dirs.append(Path(literal))
+    return dirs
+
+
+def _candidate_paths() -> List[Path]:
+    """Well-known per-OS install locations for a 7-Zip CLI."""
+    system = platform.system()
+    candidates: List[Path] = []
+
+    if system == "Windows":
+        # 7z.exe is the full CLI; 7zr/7za are reduced fallbacks.
+        for directory in _windows_install_dirs():
+            for name in ("7z.exe", "7zr.exe", "7za.exe"):
+                candidates.append(directory / name)
+    elif system == "Darwin":
+        for base in ("/opt/homebrew/bin", "/usr/local/bin"):
+            for name in ("7z", "7zz", "7za"):
+                candidates.append(Path(base) / name)
+    else:  # Linux / *nix
+        for base in ("/usr/bin", "/usr/local/bin"):
+            for name in ("7z", "7zz", "7za", "7zr"):
+                candidates.append(Path(base) / name)
+        # Common snap/flatpak shims.
+        candidates.append(Path("/snap/bin/7z"))
+        candidates.append(Path("/var/lib/flatpak/exports/bin/7z"))
+    return candidates
+
+
+def _is_usable(path: Path) -> bool:
+    try:
+        return path.is_file()
+    except OSError:
+        return False
+
+
+def resolve_7z(force: bool = False) -> Optional[str]:
+    """Return the absolute path to a 7-Zip CLI, or ``None`` if none can be found.
+
+    The environment override is honoured first and re-checked on every call. An override
+    that is set but invalid returns ``None`` (we do not fall back — the user asked for a
+    specific binary). Auto-detected results are cached; pass ``force=True`` to bypass.
+    """
+    global _cached_7z
+
+    # 1. Explicit override — authoritative, always checked first (never cached).
+    override = _override_value()
+    if override is not None:
+        path = Path(override)
+        if path.is_file():
+            return str(path)
+        logger.warning(
+            "SEVEN_ZIP override %r does not point at a file; refusing to fall back to "
+            "another 7-Zip. Fix or unset the variable.",
+            override,
+        )
+        return None
+
+    if not force and _cached_7z is not None:
+        return _cached_7z
+
+    # 2. PATH.
+    for name in _exe_names():
+        on_path = shutil.which(name)
+        if on_path:
+            _cached_7z = on_path
+            return _cached_7z
+
+    # 3. Known install locations.
+    for candidate in _candidate_paths():
+        if _is_usable(candidate):
+            _cached_7z = str(candidate)
+            return _cached_7z
+
+    return None
+
+
+def seven_zip_not_found_message() -> str:
+    """Build a clear, actionable error listing every location tried."""
+    lines: List[str] = ["Could not locate a 7-Zip CLI (7z/7zz/7za/7zr). Tried, in order:"]
+
+    override = _override_value()
+    if override is not None:
+        lines.append(f"  - $SEVEN_ZIP = {override}  (set, but not a file)")
+    else:
+        lines.append("  - $SEVEN_ZIP / $SEVENZIP_PATH  (not set)")
+
+    lines.append("  - PATH lookup of " + ", ".join(_exe_names()))
+    for candidate in _candidate_paths():
+        lines.append(f"  - {candidate}")
+
+    lines.append(
+        "Install 7-Zip (Windows: https://www.7-zip.org/) or p7zip (macOS: "
+        "`brew install sevenzip`; Linux: `apt install p7zip-full`), add it to PATH, or "
+        "set the SEVEN_ZIP environment variable to the full path of the 7z executable."
+    )
+    return "\n".join(lines)
+
+
+def reset_cache() -> None:
+    """Clear the cached resolution (primarily for tests)."""
+    global _cached_7z
+    _cached_7z = None

--- a/tests/test_jlcpcb_downloader.py
+++ b/tests/test_jlcpcb_downloader.py
@@ -402,3 +402,66 @@ def test_yaqwsx_max_volumes_is_a_high_safety_guard():
     """The constant is a runaway-loop guard, not the expected count: it must comfortably
     exceed the current ~41-volume archive so it never truncates a real download."""
     assert jlcpcb_downloader.YAQWSX_MAX_VOLUMES >= 100
+
+
+# --------------------------------------------------------------------------- #
+# 7-Zip resolution (env override -> PATH -> known install dirs)
+# --------------------------------------------------------------------------- #
+
+
+def test_find_7z_delegates_to_resolver(monkeypatch):
+    """_find_7z must use the shared resolver (so a 7-Zip off PATH is still found)."""
+    monkeypatch.setattr(jlcpcb_downloader, "resolve_7z", lambda: r"C:\Program Files\7-Zip\7z.exe")
+    assert jlcpcb_downloader._find_7z() == r"C:\Program Files\7-Zip\7z.exe"
+
+
+def test_download_yaqwsx_raises_clear_error_when_no_7z(tmp_path, monkeypatch):
+    """With no 7-Zip resolvable, download_yaqwsx must raise the multi-location message,
+    not the bare 'not found'."""
+    monkeypatch.setattr(jlcpcb_downloader, "resolve_7z", lambda: None)
+
+    with pytest.raises(RuntimeError) as exc:
+        jlcpcb_downloader.download_yaqwsx(tmp_path / "cache")
+
+    msg = str(exc.value)
+    assert "Could not locate a 7-Zip CLI" in msg
+    assert "SEVEN_ZIP" in msg
+
+
+def test_download_yaqwsx_uses_resolved_absolute_7z_path(tmp_path, monkeypatch):
+    """download_yaqwsx must invoke the resolved (absolute) 7-Zip path for extraction."""
+    import subprocess
+
+    seven_zip = r"C:\Program Files\7-Zip\7z.exe"
+    monkeypatch.setattr(jlcpcb_downloader, "resolve_7z", lambda: seven_zip)
+    monkeypatch.setattr(jlcpcb_downloader.shutil, "which", lambda name: "/usr/bin/" + name)
+
+    extract_cmds: list = []
+
+    def _run(cmd, *args, **kwargs):
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        r = _R()
+        if cmd and cmd[0] == "curl":
+            out = Path(cmd[cmd.index("-o") + 1])
+            name = cmd[-1].rsplit("/", 1)[-1]
+            if name == "cache.zip" or name == "cache.z01":
+                out.write_bytes(b"x" * 2000)
+                return r
+            r.returncode = 22  # 404 past last volume
+            return r
+        # 7-Zip extraction call.
+        extract_cmds.append(cmd[0])
+        out_dir = next(c[2:] for c in cmd if isinstance(c, str) and c.startswith("-o"))
+        (Path(out_dir) / "cache.sqlite3").write_bytes(b"db")
+        return r
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    out = jlcpcb_downloader.download_yaqwsx(tmp_path / "cache")
+
+    assert out.exists()
+    assert extract_cmds == [seven_zip]  # the absolute path was used, not a bare "7z"

--- a/tests/test_jlcpcb_downloader.py
+++ b/tests/test_jlcpcb_downloader.py
@@ -9,6 +9,7 @@ sources gracefully when none are usable.
 """
 
 import json
+import re
 import sqlite3
 import sys
 from pathlib import Path
@@ -302,3 +303,102 @@ def test_download_cdfer_skips_when_file_already_complete(tmp_path, monkeypatch):
     assert path == dest
     assert path.stat().st_size == len(payload)  # untouched
     assert last_mod.startswith("Wed, 01 Apr 2026")
+
+
+# --------------------------------------------------------------------------- #
+# yaqwsx split-archive volume download — count auto-detection
+# --------------------------------------------------------------------------- #
+
+
+def _fake_run_factory(num_volumes, calls=None):
+    """Build a subprocess.run stand-in for download_yaqwsx.
+
+    Simulates curl fetching cache.zXX volumes (success for 1..num_volumes, a 404-style
+    non-zero for the part past the last volume) and cache.zip, plus 7-Zip extraction
+    that materialises cache.sqlite3. Optionally records every curl URL in ``calls``.
+    """
+
+    def _run(cmd, *args, **kwargs):
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        res = _Result()
+        if cmd and cmd[0] == "curl":
+            url = cmd[-1]
+            if calls is not None:
+                calls.append(url)
+            out = Path(cmd[cmd.index("-o") + 1])
+            name = url.rsplit("/", 1)[-1]
+            if name == "cache.zip":
+                out.write_bytes(b"x" * 2000)
+                return res
+            m = re.fullmatch(r"cache\.z(\d+)", name)
+            if m and int(m.group(1)) <= num_volumes:
+                out.write_bytes(b"x" * 2000)
+                return res
+            res.returncode = 22  # curl -f exits 22 on HTTP 4xx (the 404 past last volume)
+            return res
+        # Otherwise it's the 7z extraction call: produce cache.sqlite3.
+        out_dir = next(c[2:] for c in cmd if isinstance(c, str) and c.startswith("-o"))
+        (Path(out_dir) / "cache.sqlite3").write_bytes(b"db")
+        return res
+
+    return _run
+
+
+def test_yaqwsx_autodetects_volume_count_past_old_caps(tmp_path, monkeypatch):
+    """The loop must fetch every real volume and stop at the first 404 — not a fixed cap.
+
+    Regression for the hardcoded 30-volume cap: with 40 live volumes it used to fetch
+    only z01..z30, leaving the split archive incomplete so 7-Zip extraction failed.
+    """
+    import subprocess
+
+    monkeypatch.setattr(jlcpcb_downloader, "_find_7z", lambda: "7z")
+    monkeypatch.setattr(jlcpcb_downloader.shutil, "which", lambda name: "/usr/bin/" + name)
+    monkeypatch.setattr(subprocess, "run", _fake_run_factory(40))
+
+    cache = tmp_path / "cache"
+    out = jlcpcb_downloader.download_yaqwsx(cache)
+
+    assert out == cache / "cache.sqlite3"
+    assert out.exists()
+    # All 40 volumes present (proves the loop went well past the old 30/80 caps).
+    for i in range(1, 41):
+        assert (cache / f"cache.z{i:02d}").exists(), f"missing volume {i}"
+    # The 404 probe past the last volume must not leave a partial file behind.
+    assert not (cache / "cache.z41").exists()
+    assert (cache / "cache.zip").exists()
+
+
+def test_yaqwsx_skips_existing_volumes_on_rerun(tmp_path, monkeypatch):
+    """Re-running with all volumes already present must not re-download them.
+
+    Only the single 404 probe for the volume past the last one should hit curl.
+    """
+    import subprocess
+
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    for i in range(1, 41):
+        (cache / f"cache.z{i:02d}").write_bytes(b"x" * 2000)
+    (cache / "cache.zip").write_bytes(b"x" * 2000)
+
+    monkeypatch.setattr(jlcpcb_downloader, "_find_7z", lambda: "7z")
+    monkeypatch.setattr(jlcpcb_downloader.shutil, "which", lambda name: "/usr/bin/" + name)
+    calls: list = []
+    monkeypatch.setattr(subprocess, "run", _fake_run_factory(40, calls=calls))
+
+    out = jlcpcb_downloader.download_yaqwsx(cache)
+
+    assert out.exists()
+    # No existing volume re-downloaded and cache.zip skipped — only the z41 404 probe.
+    assert calls == [f"{jlcpcb_downloader.YAQWSX_BASE_URL}/cache.z41"]
+
+
+def test_yaqwsx_max_volumes_is_a_high_safety_guard():
+    """The constant is a runaway-loop guard, not the expected count: it must comfortably
+    exceed the current ~41-volume archive so it never truncates a real download."""
+    assert jlcpcb_downloader.YAQWSX_MAX_VOLUMES >= 100

--- a/tests/test_seven_zip_resolver.py
+++ b/tests/test_seven_zip_resolver.py
@@ -1,0 +1,157 @@
+"""Tests for the 7-Zip resolver (utils.seven_zip).
+
+The 7-Zip Windows installer drops 7z.exe into C:\\Program Files\\7-Zip but does not add
+it to PATH, so a bare shutil.which("7z") fails on a normal install. The resolver must
+find 7-Zip via: $SEVEN_ZIP override -> PATH -> known install locations, with a clear,
+actionable error (and absolute paths) when all fail. Mirrors the kicad-cli resolver.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+import utils.seven_zip as sz  # noqa: E402
+
+
+def _make_fake_7z(directory: Path, name: str = None) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    exe = directory / (name or sz._exe_names()[0])
+    exe.write_text("#!/bin/sh\n", encoding="utf-8")
+    exe.chmod(0o755)
+    return exe
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    sz.reset_cache()
+    for var in sz._ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+    sz.reset_cache()
+
+
+# --------------------------------------------------------------------------- #
+# Resolution order
+# --------------------------------------------------------------------------- #
+
+
+class TestResolutionOrder:
+    def test_env_override_valid_wins(self, tmp_path, monkeypatch):
+        exe = _make_fake_7z(tmp_path / "custom")
+        monkeypatch.setenv("SEVEN_ZIP", str(exe))
+        assert sz.resolve_7z(force=True) == str(exe)
+
+    def test_env_override_invalid_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SEVEN_ZIP", str(tmp_path / "missing.exe"))
+        assert sz.resolve_7z(force=True) is None
+
+    def test_invalid_override_does_not_fall_back(self, tmp_path, monkeypatch):
+        """An explicit (but wrong) override must fail rather than silently picking
+        another 7-Zip discoverable on PATH / in an install dir."""
+        on_path = _make_fake_7z(tmp_path / "onpath")
+        monkeypatch.setattr(sz.shutil, "which", lambda name: str(on_path))
+        monkeypatch.setenv("SEVENZIP_PATH", str(tmp_path / "bogus.exe"))
+        assert sz.resolve_7z(force=True) is None
+
+    def test_path_lookup_returns_absolute(self, tmp_path, monkeypatch):
+        on_path = _make_fake_7z(tmp_path / "bin")
+        monkeypatch.setattr(sz.shutil, "which", lambda name: str(on_path))
+        monkeypatch.setattr(sz, "_candidate_paths", lambda: [])
+        assert sz.resolve_7z(force=True) == str(on_path)
+
+    def test_known_install_dirs_when_not_on_path(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sz.shutil, "which", lambda name: None)
+        installed = _make_fake_7z(tmp_path / "7-Zip")
+        monkeypatch.setattr(sz, "_candidate_paths", lambda: [installed])
+        resolved = sz.resolve_7z(force=True)
+        assert resolved == str(installed)
+        assert Path(resolved).is_absolute()
+
+    def test_returns_none_when_nothing_found(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sz.shutil, "which", lambda name: None)
+        monkeypatch.setattr(sz, "_candidate_paths", lambda: [tmp_path / "nope" / "7z.exe"])
+        assert sz.resolve_7z(force=True) is None
+
+
+# --------------------------------------------------------------------------- #
+# Windows install-dir enumeration
+# --------------------------------------------------------------------------- #
+
+
+class TestWindowsInstallDirs:
+    def test_windows_candidates_cover_program_files_7zip(self, monkeypatch):
+        monkeypatch.setattr(sz.platform, "system", lambda: "Windows")
+        monkeypatch.setenv("ProgramW6432", r"C:\Program Files")
+        monkeypatch.setenv("ProgramFiles", r"C:\Program Files")
+        candidates = [str(c) for c in sz._candidate_paths()]
+        assert any(c.endswith(r"7-Zip\7z.exe") for c in candidates)
+        # Reduced CLIs are offered as fallbacks too.
+        assert any(c.endswith(r"7-Zip\7za.exe") for c in candidates)
+
+
+# --------------------------------------------------------------------------- #
+# Caching
+# --------------------------------------------------------------------------- #
+
+
+class TestCaching:
+    def test_autodetect_is_cached(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sz.shutil, "which", lambda name: None)
+        installed = _make_fake_7z(tmp_path / "7-Zip")
+        monkeypatch.setattr(sz, "_candidate_paths", lambda: [installed])
+        first = sz.resolve_7z(force=True)
+        monkeypatch.setattr(sz, "_candidate_paths", lambda: [])
+        assert sz.resolve_7z() == first  # served from cache
+
+    def test_env_override_rechecked_despite_cache(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sz.shutil, "which", lambda name: None)
+        installed = _make_fake_7z(tmp_path / "7-Zip")
+        monkeypatch.setattr(sz, "_candidate_paths", lambda: [installed])
+        assert sz.resolve_7z(force=True) == str(installed)
+        monkeypatch.setenv("SEVEN_ZIP", str(tmp_path / "bogus.exe"))
+        assert sz.resolve_7z() is None
+
+
+# --------------------------------------------------------------------------- #
+# Error message
+# --------------------------------------------------------------------------- #
+
+
+class TestNotFoundMessage:
+    def test_message_lists_locations_and_hints(self):
+        msg = sz.seven_zip_not_found_message()
+        assert "Could not locate a 7-Zip CLI" in msg
+        assert "SEVEN_ZIP" in msg
+        assert "PATH" in msg
+        assert "Install 7-Zip" in msg or "p7zip" in msg
+
+    def test_message_flags_invalid_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SEVEN_ZIP", str(tmp_path / "wrong.exe"))
+        msg = sz.seven_zip_not_found_message()
+        assert str(tmp_path / "wrong.exe") in msg
+        assert "not a file" in msg
+
+
+# --------------------------------------------------------------------------- #
+# Integration: the resolved binary actually runs
+# --------------------------------------------------------------------------- #
+
+
+def _real_7z() -> str:
+    sz.reset_cache()
+    return sz.resolve_7z(force=True)
+
+
+@pytest.mark.integration
+class TestResolvedBinaryRuns:
+    def test_resolved_7z_emits_banner(self):
+        exe = _real_7z()
+        if not exe or not Path(exe).is_file():
+            pytest.skip("no 7-Zip installed on this machine")
+        out = subprocess.run([exe], capture_output=True, text=True)
+        # 7-Zip prints its version banner mentioning "7-Zip" on stdout.
+        assert "7-Zip" in (out.stdout + out.stderr)


### PR DESCRIPTION
Makes the **yaqwsx JLCPCB download path** (`download_jlcpcb_database source=yaqwsx`)
actually work on a stock install. Two related fixes in the same flow:

---

## 1. Auto-detect the yaqwsx volume count (was a hardcoded cap of 30)
The yaqwsx source is a split 7-Zip archive (`cache.zip` + `cache.z01 … cache.zNN`) that
needs **every** volume to extract. The loop capped volumes at `YAQWSX_MAX_VOLUMES = 30`,
but the live archive has more (and the count changes as the catalog is rebuilt). Over the
cap → incomplete archive → `RuntimeError("7z extraction failed")` and no `cache.sqlite3`.

**Fix:** iterate with `itertools.count(1)` and rely on the existing first-404 break to stop
at the true last volume. `YAQWSX_MAX_VOLUMES` becomes a high runaway-loop **safety guard**
(999), not the expected count — auto-detected, never truncated again.

## 2. Resolve 7-Zip robustly (was PATH-only)
The extraction step needs a 7z CLI. On Windows 7-Zip installs to
`C:\Program Files\7-Zip\7z.exe` but is **not** added to `PATH`, so `_find_7z()` (PATH-only)
failed even with 7-Zip 26.01 installed:
`RuntimeError: yaqwsx fallback requires a 7z CLI (7z/7zz/7za) which was not found`.
Same class of bug as the kicad-cli resolver (#267) — same pattern applied.

**Fix:** a shared resolver (`utils/seven_zip.py`) wired into `_find_7z()`:
`$SEVEN_ZIP`/`$SEVENZIP_PATH` override → `PATH` (7z/7zz/7za/7zr) → known per-OS install dirs
(Windows `%ProgramW6432%`/`%ProgramFiles%`/`(x86)\7-Zip` + literals; macOS Homebrew/usr-local;
Linux usr/bin, usr-local, snap/flatpak). Install-dir hits return an **absolute path**; the
result is cached; the env override is re-checked each call. When nothing resolves,
`download_yaqwsx` raises a **clear, actionable** message listing every location tried plus the
install / PATH / `SEVEN_ZIP` options — not the bare "not found".

---

## Verification
**Volume auto-detect**
- Unit tests: fetches all 40 simulated volumes and stops at the `z41` 404 (past the old
  30/80 caps); a re-run with all volumes present re-downloads nothing.
- Live probe confirms the 404 break finds the true last volume (validates auto-detection).

**7-Zip resolution (Windows, 7-Zip 26.01 at `C:\Program Files\7-Zip`, NOT on PATH)**
1. Auto-detect resolves `…\7-Zip\7z.exe` (previously raised "not found"). ✅
2. 7-Zip on PATH → still works (PATH checked before install dirs). ✅
3. Bogus `$SEVEN_ZIP` → `None` + the clear multi-location error (no silent fallback). ✅
4. No 7-Zip anywhere → the new error naming install / PATH / env options. ✅
5. Resolved binary runs: `7z` prints its `7-Zip 26.01 (x64)` banner. ✅

> Note: the full ~421 MB download + extraction + ~7M-part build still requires network +
> a 7z CLI; the volume-fetch and 7-Zip-resolution fixes (the two bugs) are covered by the
> unit tests, the live volume probe, and the real-binary checks above. Conversion
> (`convert_source_sqlite`) is covered by existing tests.

New tests: `tests/test_seven_zip_resolver.py` + 7-Zip cases in `tests/test_jlcpcb_downloader.py`.
Full suite: **1093 passed, 12 skipped.** Pre-commit hooks (black, isort, flake8, mypy) pass.

## PR Checklist
- [x] Code follows style guidelines
- [x] All tests pass locally
- [x] New tests added for new behavior
- [x] Commit messages follow convention
- [x] No merge conflicts
