### PR TITLE
fix: resolve kicad-cli robustly instead of failing when not on PATH

### DIFF
--- a/python/commands/board/view.py
+++ b/python/commands/board/view.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pcbnew
 from PIL import Image
+from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
 
 logger = logging.getLogger("kicad_interface")
 
@@ -138,7 +139,6 @@ class BoardViewCommands:
         - "file": image is written next to the .kicad_pcb file and ``filePath`` is returned.
         """
         import glob
-        import shutil
         import subprocess
         import tempfile
 
@@ -173,12 +173,11 @@ class BoardViewCommands:
             layers: List[str] = params.get("layers", [])
             response_mode = params.get("responseMode", "inline")
 
-            kicad_cli = shutil.which("kicad-cli") or shutil.which("kicad-cli.exe")
+            kicad_cli = resolve_kicad_cli()
             if not kicad_cli:
                 return {
                     "success": False,
-                    "message": "kicad-cli not found in PATH",
-                    "errorDetails": "Install KiCad and ensure kicad-cli is on PATH",
+                    "message": kicad_cli_not_found_message(),
                 }
 
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -287,8 +286,7 @@ class BoardViewCommands:
         except FileNotFoundError:
             return {
                 "success": False,
-                "message": "kicad-cli not found in PATH",
-                "errorDetails": "Install KiCad and ensure kicad-cli is on PATH",
+                "message": kicad_cli_not_found_message(),
             }
         except Exception as e:
             logger.error(f"Error getting board 2D view: {e}")

--- a/python/commands/design_rules.py
+++ b/python/commands/design_rules.py
@@ -7,6 +7,7 @@ import os
 from typing import Any, Dict, List, Optional, Tuple
 
 import pcbnew
+from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
 
 logger = logging.getLogger("kicad_interface")
 
@@ -209,8 +210,7 @@ class DesignRuleCommands:
             if not kicad_cli:
                 return {
                     "success": False,
-                    "message": "kicad-cli not found",
-                    "errorDetails": "KiCAD CLI tool not found in system. Install KiCAD 8.0+ or set PATH.",
+                    "message": kicad_cli_not_found_message(),
                 }
 
             # Create temporary JSON output file
@@ -364,48 +364,12 @@ class DesignRuleCommands:
             }
 
     def _find_kicad_cli(self) -> Optional[str]:
-        """Find kicad-cli executable"""
-        import platform
-        import shutil
+        """Find kicad-cli executable via the centralized resolver.
 
-        # Try system PATH first
-        cli_name = "kicad-cli.exe" if platform.system() == "Windows" else "kicad-cli"
-        cli_path = shutil.which(cli_name)
-        if cli_path:
-            return cli_path
-
-        # Try common installation paths (version-specific)
-        if platform.system() == "Windows":
-            common_paths = [
-                r"C:\Program Files\KiCad\10.0\bin\kicad-cli.exe",
-                r"C:\Program Files\KiCad\9.0\bin\kicad-cli.exe",
-                r"C:\Program Files\KiCad\8.0\bin\kicad-cli.exe",
-                r"C:\Program Files (x86)\KiCad\10.0\bin\kicad-cli.exe",
-                r"C:\Program Files (x86)\KiCad\9.0\bin\kicad-cli.exe",
-                r"C:\Program Files (x86)\KiCad\8.0\bin\kicad-cli.exe",
-                r"C:\Program Files\KiCad\bin\kicad-cli.exe",
-            ]
-            for path in common_paths:
-                if os.path.exists(path):
-                    return path
-        elif platform.system() == "Darwin":  # macOS
-            common_paths = [
-                "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
-                "/usr/local/bin/kicad-cli",
-            ]
-            for path in common_paths:
-                if os.path.exists(path):
-                    return path
-        else:  # Linux
-            common_paths = [
-                "/usr/bin/kicad-cli",
-                "/usr/local/bin/kicad-cli",
-            ]
-            for path in common_paths:
-                if os.path.exists(path):
-                    return path
-
-        return None
+        Resolution order: $KICAD_CLI override -> next to the running interpreter
+        (KiCad's bundled python bin/) -> PATH -> known per-OS install locations.
+        """
+        return resolve_kicad_cli()
 
     def get_drc_violations(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/python/commands/export.py
+++ b/python/commands/export.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 import pcbnew
+from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
 
 logger = logging.getLogger("kicad_interface")
 
@@ -366,8 +367,7 @@ class ExportCommands:
             if not kicad_cli:
                 return {
                     "success": False,
-                    "message": "kicad-cli not found",
-                    "errorDetails": "KiCAD CLI tool not found. Install KiCAD 8.0+ or set PATH.",
+                    "message": kicad_cli_not_found_message(),
                 }
 
             # Build command based on format
@@ -604,45 +604,15 @@ class ExportCommands:
             json.dump({"components": components}, f, indent=2)
 
     def _find_kicad_cli(self) -> Optional[str]:
-        """Find kicad-cli executable in system PATH or common locations
+        """Find kicad-cli executable via the centralized resolver.
+
+        Resolution order: $KICAD_CLI override -> next to the running interpreter
+        (KiCad's bundled python bin/) -> PATH -> known per-OS install locations.
 
         Returns:
             Path to kicad-cli executable, or None if not found
         """
-        import platform
-        import shutil
-
-        # Try system PATH first
-        cli_path = shutil.which("kicad-cli")
-        if cli_path:
-            return cli_path
-
-        # Try platform-specific default locations
-        system = platform.system()
-
-        if system == "Windows":
-            possible_paths = [
-                r"C:\Program Files\KiCad\9.0\bin\kicad-cli.exe",
-                r"C:\Program Files\KiCad\8.0\bin\kicad-cli.exe",
-                r"C:\Program Files (x86)\KiCad\9.0\bin\kicad-cli.exe",
-                r"C:\Program Files (x86)\KiCad\8.0\bin\kicad-cli.exe",
-            ]
-        elif system == "Darwin":  # macOS
-            possible_paths = [
-                "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
-                "/usr/local/bin/kicad-cli",
-            ]
-        else:  # Linux
-            possible_paths = [
-                "/usr/bin/kicad-cli",
-                "/usr/local/bin/kicad-cli",
-            ]
-
-        for path in possible_paths:
-            if os.path.exists(path):
-                return path
-
-        return None
+        return resolve_kicad_cli()
 
     def _dev_copy_mcp_log(self, output_dir: str) -> None:
         """DEV MODE: Copy the MCP server log for the current session into the project folder.

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -22,10 +22,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pcbnew
 import sexpdata
-
 from commands.library_schematic import LibraryManager as SchematicLibraryManager
 from commands.schematic import SchematicManager
 from commands.wire_manager import WireManager
+from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
 
 logger = logging.getLogger("kicad_interface")
 
@@ -90,6 +90,11 @@ def _svg_to_png(svg_path: str, width: int, height: int) -> Optional[bytes]:
 
 class SchematicHandlersMixin:
     """Schematic-domain handlers mixed into KiCADInterface."""
+
+    # Provided by the host KiCADInterface this mixin is composed into. Declared here so
+    # mypy can resolve ``self.board`` when type-checking this module in isolation (the
+    # module docstring notes the mixin relies on the host's ``self.board``).
+    board: Any
 
     def _handle_create_schematic(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Create a new schematic"""
@@ -991,8 +996,11 @@ class SchematicHandlersMixin:
 
             import subprocess
 
+            kicad_cli = resolve_kicad_cli()
+            if not kicad_cli:
+                return {"success": False, "message": kicad_cli_not_found_message()}
             cmd = [
-                "kicad-cli",
+                kicad_cli,
                 "sch",
                 "export",
                 "pdf",
@@ -1015,7 +1023,7 @@ class SchematicHandlersMixin:
                 }
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except Exception as e:
             logger.error(f"Error exporting schematic to PDF: {str(e)}")
             return {"success": False, "message": str(e)}
@@ -1220,10 +1228,13 @@ class SchematicHandlersMixin:
             height = params.get("height", 900)
 
             # Step 1: Export schematic to SVG via kicad-cli
+            kicad_cli = resolve_kicad_cli()
+            if not kicad_cli:
+                return {"success": False, "message": kicad_cli_not_found_message()}
             with tempfile.TemporaryDirectory() as tmpdir:
                 svg_path = os.path.join(tmpdir, "schematic.svg")
                 cmd = [
-                    "kicad-cli",
+                    kicad_cli,
                     "sch",
                     "export",
                     "svg",
@@ -1277,7 +1288,7 @@ class SchematicHandlersMixin:
                 }
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except Exception as e:
             logger.error(f"Error getting schematic view: {e}")
             import traceback
@@ -2037,8 +2048,11 @@ class SchematicHandlersMixin:
 
             os.makedirs(output_dir, exist_ok=True)
 
+            kicad_cli = resolve_kicad_cli()
+            if not kicad_cli:
+                return {"success": False, "message": kicad_cli_not_found_message()}
             cmd = [
-                "kicad-cli",
+                kicad_cli,
                 "sch",
                 "export",
                 "svg",
@@ -2075,7 +2089,7 @@ class SchematicHandlersMixin:
             return {"success": True, "file": {"path": output_path}}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except Exception as e:
             logger.error(f"Error exporting schematic SVG: {e}")
             return {"success": False, "message": str(e)}

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -36,8 +36,8 @@ if sys.platform == "win32":
 
 import sexpdata
 from annotations import AnnotationLoader
-from commands.wire_manager import WireManager
 from commands.schematic_handlers import SchematicHandlersMixin
+from commands.wire_manager import WireManager
 from resources.resource_definitions import RESOURCE_DEFINITIONS, handle_resource_read
 
 # Import tool schemas, resource definitions, and IPC API annotations
@@ -182,9 +182,9 @@ utils_dir = os.path.join(os.path.dirname(__file__))
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)
 
-from utils.kicad_process import KiCADProcessManager, check_and_launch_kicad
-
 # Import platform helper and add KiCAD paths
+from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
+from utils.kicad_process import KiCADProcessManager, check_and_launch_kicad
 from utils.platform_helper import PlatformHelper
 
 logger.info(f"Detecting KiCAD Python paths for {PlatformHelper.get_platform_name()}...")
@@ -2141,36 +2141,13 @@ class KiCADInterface(SchematicHandlersMixin):
 
     @staticmethod
     def _find_kicad_cli_static() -> Optional[str]:
-        """Return path to kicad-cli executable, or None."""
-        import platform
-        import shutil
+        """Return path to kicad-cli executable, or None.
 
-        cli = shutil.which("kicad-cli")
-        if cli:
-            return cli
-
-        system = platform.system()
-        if system == "Windows":
-            candidates = [
-                r"C:\Program Files\KiCad\9.0\bin\kicad-cli.exe",
-                r"C:\Program Files\KiCad\8.0\bin\kicad-cli.exe",
-                r"C:\Program Files (x86)\KiCad\9.0\bin\kicad-cli.exe",
-                r"C:\Program Files (x86)\KiCad\8.0\bin\kicad-cli.exe",
-            ]
-        elif system == "Darwin":
-            candidates = [
-                "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
-                "/usr/local/bin/kicad-cli",
-            ]
-        else:
-            candidates = [
-                "/usr/bin/kicad-cli",
-                "/usr/local/bin/kicad-cli",
-            ]
-        for path in candidates:
-            if os.path.exists(path):
-                return path
-        return None
+        Delegates to the centralized resolver (env override -> interpreter-adjacent ->
+        PATH -> known install dirs) so kicad-cli is found even when KiCad's bin/ is not
+        on PATH (the default on Windows).
+        """
+        return resolve_kicad_cli()
 
     # ------------------------------------------------------------------
 
@@ -2193,7 +2170,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             fmt_map = {
                 "KiCad": "kicadxml",
@@ -2228,7 +2205,7 @@ class KiCADInterface(SchematicHandlersMixin):
                 }
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 60 seconds"}
         except Exception as e:
@@ -2261,7 +2238,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_dir = str(Path(output_dir).expanduser().resolve())
             Path(output_dir).mkdir(parents=True, exist_ok=True)
@@ -2329,7 +2306,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputDir": output_dir, "files": files}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -2361,7 +2338,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_dir = str(Path(output_dir).expanduser().resolve())
             # kicad-cli drill requires the output dir path to end with a separator
@@ -2411,7 +2388,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputDir": output_dir, "files": files}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 120 seconds"}
         except Exception as e:
@@ -2444,7 +2421,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             Path(output_path).parent.mkdir(parents=True, exist_ok=True)
@@ -2488,7 +2465,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -2520,7 +2497,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -2556,7 +2533,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -2589,7 +2566,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -2611,7 +2588,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -2644,7 +2621,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -2681,7 +2658,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -2715,7 +2692,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -2760,7 +2737,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -2794,7 +2771,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -2865,7 +2842,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -2899,7 +2876,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -2969,7 +2946,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -3003,7 +2980,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -3072,7 +3049,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -3108,7 +3085,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -3173,7 +3150,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -3215,7 +3192,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -3299,7 +3276,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 300 seconds"}
         except Exception as e:
@@ -3330,7 +3307,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -3382,7 +3359,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -3413,7 +3390,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -3463,7 +3440,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -3493,7 +3470,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_dir = str(Path(output_dir).expanduser().resolve())
             Path(output_dir).mkdir(parents=True, exist_ok=True)
@@ -3540,7 +3517,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputDir": output_dir, "files": files}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -3570,7 +3547,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_dir = str(Path(output_dir).expanduser().resolve())
             Path(output_dir).mkdir(parents=True, exist_ok=True)
@@ -3616,7 +3593,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputDir": output_dir, "files": files}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -3646,7 +3623,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_dir = str(Path(output_dir).expanduser().resolve())
             Path(output_dir).mkdir(parents=True, exist_ok=True)
@@ -3688,7 +3665,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputDir": output_dir, "files": files}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -3718,7 +3695,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_dir = str(Path(output_dir).expanduser().resolve())
             Path(output_dir).mkdir(parents=True, exist_ok=True)
@@ -3765,7 +3742,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputDir": output_dir, "files": files}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -3796,7 +3773,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             output_path = str(Path(output_path).expanduser().resolve())
             parent = Path(output_path).parent
@@ -3818,7 +3795,7 @@ class KiCADInterface(SchematicHandlersMixin):
             return {"success": True, "outputPath": output_path}
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 180 seconds"}
         except Exception as e:
@@ -3845,7 +3822,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
             kicad_cli = self._find_kicad_cli_static()
             if not kicad_cli:
-                return {"success": False, "message": "kicad-cli not found in PATH"}
+                return {"success": False, "message": kicad_cli_not_found_message()}
 
             with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as tmp:
                 tmp_path = tmp.name
@@ -3904,7 +3881,7 @@ class KiCADInterface(SchematicHandlersMixin):
                     pass
 
         except FileNotFoundError:
-            return {"success": False, "message": "kicad-cli not found in PATH"}
+            return {"success": False, "message": kicad_cli_not_found_message()}
         except subprocess.TimeoutExpired:
             return {"success": False, "message": "kicad-cli timed out after 60 seconds"}
         except Exception as e:

--- a/python/utils/kicad_cli.py
+++ b/python/utils/kicad_cli.py
@@ -1,0 +1,178 @@
+"""Robust resolution of the ``kicad-cli`` executable.
+
+KiCad's Windows installer does **not** add ``KiCad\\<ver>\\bin`` to ``PATH``, so a
+bare ``shutil.which("kicad-cli")`` fails on an otherwise-normal install even though
+``kicad-cli.exe`` is sitting right there in the install's ``bin`` directory. Every MCP
+tool that shells out to ``kicad-cli`` (netlist/gerber/drill/pos/pdf/svg/... exports,
+ERC/DRC) then fails with a misleading "not found in PATH" error.
+
+This module centralises resolution so every cli-backed tool uses the same logic:
+
+    1. Explicit override: ``$KICAD_CLI`` / ``$KICAD_CLI_PATH`` (if set). An explicit
+       override is authoritative — if it is set but does not point at a real file we
+       refuse to silently fall back to a different binary.
+    2. Adjacent to the running interpreter: ``Path(sys.executable).parent / kicad-cli``.
+       The MCP backend runs under KiCad's bundled Python (``KiCad\\<ver>\\bin\\python``,
+       which is how it imports ``pcbnew``); ``kicad-cli`` lives in that same ``bin``
+       directory, making this the most reliable source for this server.
+    3. ``PATH`` lookup.
+    4. Known per-OS install locations (newest KiCad version first).
+
+The resolved path is cached. The environment override is re-checked on every call so a
+test (or a user) can change it without a stale cache masking the new value.
+"""
+
+import logging
+import os
+import platform
+import shutil
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger("kicad_interface")
+
+_ENV_VARS = ("KICAD_CLI", "KICAD_CLI_PATH")
+_cached_cli: Optional[str] = None
+
+
+def _cli_name() -> str:
+    """Executable basename for the current OS."""
+    return "kicad-cli.exe" if platform.system() == "Windows" else "kicad-cli"
+
+
+def _override_value() -> Optional[str]:
+    """Return the first non-empty KICAD_CLI / KICAD_CLI_PATH value, or None."""
+    for env in _ENV_VARS:
+        val = os.environ.get(env)
+        if val:
+            return val
+    return None
+
+
+def _candidate_paths() -> List[Path]:
+    """Well-known per-OS install locations for kicad-cli, newest version first."""
+    name = _cli_name()
+    system = platform.system()
+    candidates: List[Path] = []
+
+    if system == "Windows":
+        for base in (r"C:\Program Files\KiCad", r"C:\Program Files (x86)\KiCad"):
+            base_dir = Path(base)
+            if base_dir.is_dir():
+                versions = sorted(
+                    (p for p in base_dir.iterdir() if p.is_dir()),
+                    key=lambda p: p.name,
+                    reverse=True,
+                )
+                candidates.extend(v / "bin" / name for v in versions)
+            # Some installs drop straight into <base>\bin without a version dir.
+            candidates.append(base_dir / "bin" / name)
+    elif system == "Darwin":
+        candidates.extend(
+            [
+                Path("/Applications/KiCad/KiCad.app/Contents/MacOS") / name,
+                Path("/usr/local/bin") / name,
+                Path("/opt/homebrew/bin") / name,
+            ]
+        )
+    else:  # Linux / *nix
+        candidates.extend(
+            [
+                Path("/usr/bin") / name,
+                Path("/usr/local/bin") / name,
+                Path("/app/bin") / name,  # Flatpak sandbox
+                Path("/var/lib/flatpak/app/org.kicad.KiCad/current/active/files/bin") / name,
+                Path.home() / ".local" / "bin" / name,
+            ]
+        )
+    return candidates
+
+
+def resolve_kicad_cli(force: bool = False) -> Optional[str]:
+    """Return the absolute path to ``kicad-cli``, or ``None`` if it cannot be found.
+
+    The environment override is honoured first and re-checked on every call. An override
+    that is set but invalid returns ``None`` (we do not fall back to auto-detection — the
+    user asked for a specific binary). Auto-detected results are cached; pass
+    ``force=True`` to bypass the cache.
+    """
+    global _cached_cli
+
+    # 1. Explicit override — authoritative, always checked first (never cached so a
+    #    changed/cleared env var takes effect immediately).
+    override = _override_value()
+    if override is not None:
+        path = Path(override)
+        if path.is_file():
+            return str(path)
+        logger.warning(
+            "KICAD_CLI override %r does not point at a file; refusing to fall back to "
+            "another kicad-cli. Fix or unset the variable.",
+            override,
+        )
+        return None
+
+    if not force and _cached_cli is not None:
+        return _cached_cli
+
+    name = _cli_name()
+
+    # 2. Adjacent to the running interpreter (KiCad's bundled python bin/).
+    try:
+        adjacent = Path(sys.executable).parent / name
+        if adjacent.is_file():
+            _cached_cli = str(adjacent)
+            return _cached_cli
+    except (OSError, ValueError):
+        pass
+
+    # 3. PATH.
+    on_path = shutil.which(name) or shutil.which("kicad-cli")
+    if on_path:
+        _cached_cli = on_path
+        return _cached_cli
+
+    # 4. Known install locations.
+    for candidate in _candidate_paths():
+        if candidate.is_file():
+            _cached_cli = str(candidate)
+            return _cached_cli
+
+    return None
+
+
+def kicad_cli_not_found_message() -> str:
+    """Build a clear, actionable error message listing every location tried.
+
+    Replaces the old bare ``"kicad-cli not found in PATH"`` so users can see exactly
+    where the resolver looked and how to point it at their install.
+    """
+    name = _cli_name()
+    lines: List[str] = ["Could not locate kicad-cli. Tried, in order:"]
+
+    override = _override_value()
+    if override is not None:
+        lines.append(f"  - ${{KICAD_CLI}} = {override}  (set, but not a file)")
+    else:
+        lines.append("  - $KICAD_CLI / $KICAD_CLI_PATH  (not set)")
+
+    try:
+        lines.append(f"  - next to the Python interpreter: {Path(sys.executable).parent / name}")
+    except (OSError, ValueError):
+        pass
+    lines.append(f"  - PATH lookup of {name}")
+    for candidate in _candidate_paths():
+        lines.append(f"  - {candidate}")
+
+    lines.append(
+        "Set the KICAD_CLI environment variable to the full path of kicad-cli "
+        "(e.g. on Windows: C:\\Program Files\\KiCad\\10.0\\bin\\kicad-cli.exe) and retry."
+    )
+    return "\n".join(lines)
+
+
+def reset_cache() -> None:
+    """Clear the cached resolution (primarily for tests)."""
+    global _cached_cli
+    _cached_cli = None

--- a/tests/test_kicad_cli_resolver.py
+++ b/tests/test_kicad_cli_resolver.py
@@ -1,0 +1,225 @@
+"""Tests for the centralized kicad-cli resolver (utils.kicad_cli).
+
+KiCad's Windows installer does not put KiCad\\<ver>\\bin on PATH, so a bare
+shutil.which("kicad-cli") fails on a normal install. The resolver must find kicad-cli
+via: $KICAD_CLI override -> next to the running interpreter (KiCad's bundled python) ->
+PATH -> known install locations, with a clear actionable error when all fail.
+"""
+
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+import utils.kicad_cli as kc  # noqa: E402
+
+TEMPLATES_DIR = Path(__file__).parent.parent / "python" / "templates"
+EMPTY_SCH = TEMPLATES_DIR / "empty.kicad_sch"
+
+
+def _make_fake_cli(directory: Path) -> Path:
+    """Create a file with the platform's kicad-cli basename inside ``directory``."""
+    directory.mkdir(parents=True, exist_ok=True)
+    cli = directory / kc._cli_name()
+    cli.write_text("#!/bin/sh\n", encoding="utf-8")
+    cli.chmod(0o755)
+    return cli
+
+
+@pytest.fixture(autouse=True)
+def _clean_resolver_state(monkeypatch):
+    """Each test starts with a clear cache and no override env vars."""
+    kc.reset_cache()
+    for var in kc._ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+    kc.reset_cache()
+
+
+# --------------------------------------------------------------------------- #
+# Resolution order
+# --------------------------------------------------------------------------- #
+
+
+class TestResolutionOrder:
+    def test_env_override_valid_wins(self, tmp_path, monkeypatch):
+        cli = _make_fake_cli(tmp_path / "custom")
+        monkeypatch.setenv("KICAD_CLI", str(cli))
+        assert kc.resolve_kicad_cli(force=True) == str(cli)
+
+    def test_env_override_invalid_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KICAD_CLI", str(tmp_path / "does_not_exist.exe"))
+        assert kc.resolve_kicad_cli(force=True) is None
+
+    def test_invalid_override_does_not_fall_back_to_other_binary(self, tmp_path, monkeypatch):
+        """An explicit (but wrong) override must fail rather than silently pick another
+        kicad-cli — even when one is discoverable next to the interpreter."""
+        interp_dir = tmp_path / "interp"
+        _make_fake_cli(interp_dir)
+        monkeypatch.setattr(sys, "executable", str(interp_dir / "python"))
+        monkeypatch.setenv("KICAD_CLI", str(tmp_path / "bogus.exe"))
+        assert kc.resolve_kicad_cli(force=True) is None
+
+    def test_interpreter_adjacent_is_preferred_over_path(self, tmp_path, monkeypatch):
+        interp_dir = tmp_path / "kicad_bin"
+        adjacent = _make_fake_cli(interp_dir)
+        monkeypatch.setattr(sys, "executable", str(interp_dir / "python"))
+        # PATH would resolve to a different binary, but interpreter-adjacent wins.
+        other = _make_fake_cli(tmp_path / "elsewhere")
+        monkeypatch.setattr(kc.shutil, "which", lambda name: str(other))
+        assert kc.resolve_kicad_cli(force=True) == str(adjacent)
+
+    def test_path_used_when_not_interpreter_adjacent(self, tmp_path, monkeypatch):
+        # Interpreter dir has no kicad-cli.
+        monkeypatch.setattr(sys, "executable", str(tmp_path / "empty" / "python"))
+        on_path = _make_fake_cli(tmp_path / "onpath")
+        monkeypatch.setattr(kc.shutil, "which", lambda name: str(on_path))
+        monkeypatch.setattr(kc, "_candidate_paths", lambda: [])
+        assert kc.resolve_kicad_cli(force=True) == str(on_path)
+
+    def test_known_install_locations_last(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sys, "executable", str(tmp_path / "empty" / "python"))
+        monkeypatch.setattr(kc.shutil, "which", lambda name: None)
+        known = _make_fake_cli(tmp_path / "install" / "bin")
+        monkeypatch.setattr(kc, "_candidate_paths", lambda: [known])
+        assert kc.resolve_kicad_cli(force=True) == str(known)
+
+    def test_returns_none_when_nothing_found(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sys, "executable", str(tmp_path / "empty" / "python"))
+        monkeypatch.setattr(kc.shutil, "which", lambda name: None)
+        monkeypatch.setattr(kc, "_candidate_paths", lambda: [tmp_path / "missing" / "kicad-cli"])
+        assert kc.resolve_kicad_cli(force=True) is None
+
+
+# --------------------------------------------------------------------------- #
+# Caching
+# --------------------------------------------------------------------------- #
+
+
+class TestCaching:
+    def test_autodetect_result_is_cached(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sys, "executable", str(tmp_path / "empty" / "python"))
+        monkeypatch.setattr(kc.shutil, "which", lambda name: None)
+        known = _make_fake_cli(tmp_path / "install" / "bin")
+        monkeypatch.setattr(kc, "_candidate_paths", lambda: [known])
+
+        first = kc.resolve_kicad_cli(force=True)
+        # Now make discovery impossible; cached value must still be returned.
+        monkeypatch.setattr(kc, "_candidate_paths", lambda: [])
+        assert kc.resolve_kicad_cli() == first
+
+    def test_env_override_rechecked_despite_cache(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sys, "executable", str(tmp_path / "empty" / "python"))
+        monkeypatch.setattr(kc.shutil, "which", lambda name: None)
+        known = _make_fake_cli(tmp_path / "install" / "bin")
+        monkeypatch.setattr(kc, "_candidate_paths", lambda: [known])
+        assert kc.resolve_kicad_cli(force=True) == str(known)  # populate cache
+
+        # Setting a bogus override must override the cache and yield None.
+        monkeypatch.setenv("KICAD_CLI", str(tmp_path / "bogus.exe"))
+        assert kc.resolve_kicad_cli() is None
+
+
+# --------------------------------------------------------------------------- #
+# Error message
+# --------------------------------------------------------------------------- #
+
+
+class TestNotFoundMessage:
+    def test_message_lists_locations_and_env_hint(self):
+        msg = kc.kicad_cli_not_found_message()
+        assert "Could not locate kicad-cli" in msg
+        assert "KICAD_CLI" in msg
+        assert "PATH" in msg
+        # Mentions at least one concrete candidate path and the actionable hint.
+        assert "kicad-cli" in msg
+        assert "Set the KICAD_CLI environment variable" in msg
+
+    def test_message_flags_invalid_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KICAD_CLI", str(tmp_path / "wrong.exe"))
+        msg = kc.kicad_cli_not_found_message()
+        assert str(tmp_path / "wrong.exe") in msg
+        assert "not a file" in msg
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: a cli-backed tool resolves kicad-cli without KiCad bin on PATH
+# --------------------------------------------------------------------------- #
+
+
+def _real_kicad_cli() -> Optional[str]:
+    found = shutil.which("kicad-cli") or shutil.which("kicad-cli.exe")
+    if found:
+        return found
+    for cand in kc._candidate_paths():
+        if cand.is_file():
+            return str(cand)
+    return None
+
+
+def _path_without_kicad(monkeypatch) -> None:
+    """Remove any KiCad bin entries from PATH to simulate the default Windows install."""
+    import os
+
+    parts = [p for p in os.environ.get("PATH", "").split(os.pathsep) if "kicad" not in p.lower()]
+    monkeypatch.setenv("PATH", os.pathsep.join(parts))
+
+
+@pytest.mark.integration
+class TestCliBackedToolEndToEnd:
+    def setup_method(self) -> None:
+        if not _real_kicad_cli():
+            pytest.skip("kicad-cli not available on this machine")
+
+    def test_export_netlist_succeeds_without_kicad_on_path(self, tmp_path, monkeypatch):
+        """generate/export netlist must succeed even when KiCad's bin is not on PATH."""
+        from kicad_interface import KiCADInterface
+
+        kc.reset_cache()
+        _path_without_kicad(monkeypatch)
+
+        sch = tmp_path / "board.kicad_sch"
+        shutil.copy(EMPTY_SCH, sch)
+        out = tmp_path / "board.net"
+
+        result = KiCADInterface()._handle_export_netlist(
+            {"schematicPath": str(sch), "outputPath": str(out)}
+        )
+        assert result["success"] is True, result
+        assert out.exists()
+
+    def test_resolved_cli_version_matches_running_kicad(self):
+        import subprocess
+
+        kc.reset_cache()
+        cli = kc.resolve_kicad_cli(force=True)
+        assert cli is not None
+        out = subprocess.run([cli, "version"], capture_output=True, text=True)
+        assert out.returncode == 0
+        # e.g. "10.0.4" — a bare major.minor.patch line.
+        assert out.stdout.strip()[0].isdigit()
+
+
+@pytest.mark.unit
+class TestCliBackedToolClearError:
+    def test_bogus_override_yields_actionable_error(self, tmp_path, monkeypatch):
+        """With KICAD_CLI pointing at a bogus path, a cli-backed tool must fail with the
+        new clear error (locations tried + env-var hint), not spawn a wrong binary."""
+        from kicad_interface import KiCADInterface
+
+        kc.reset_cache()
+        monkeypatch.setenv("KICAD_CLI", str(tmp_path / "nope" / "kicad-cli.exe"))
+
+        sch = tmp_path / "board.kicad_sch"
+        shutil.copy(EMPTY_SCH, sch)
+
+        result = KiCADInterface()._handle_export_netlist(
+            {"schematicPath": str(sch), "outputPath": str(tmp_path / "out.net")}
+        )
+        assert result["success"] is False
+        assert "Could not locate kicad-cli" in result["message"]
+        assert "KICAD_CLI" in result["message"]


### PR DESCRIPTION
## Problem
KiCad's Windows installer does **not** add `KiCad\<ver>\bin` to `PATH`. Every MCP tool
that shells out to `kicad-cli` then fails with a misleading **"kicad-cli not found in
PATH"** even though `kicad-cli.exe` is present in the install's `bin` directory. Observed
this session: `generate_netlist` returned `"Failed to generate netlist: kicad-cli not
found in PATH"`. The same failure hits the whole cli-backed family: `export_netlist`,
`export_gerbers`, `export_drill`, `export_pos`, `export_*` (pdf/svg/dxf/3d/bom/...),
`run_erc`/`run_drc`, the board 2D view, and schematic SVG/PDF export.

## Root cause
Resolution was bare-name/`PATH` only (`shutil.which("kicad-cli")` or spawning
`"kicad-cli"`), with several duplicated, out-of-date `_find_kicad_cli` helpers and no
fallback to the actual KiCad install location.

## Fix
Add one centralized resolver (`python/utils/kicad_cli.py`) and wire it into every
cli-backed tool. Resolution order:

1. **`$KICAD_CLI` / `$KICAD_CLI_PATH` override** — authoritative; an override that is set
   but invalid fails loudly rather than silently selecting a different binary.
2. **Adjacent to the running interpreter** — `Path(sys.executable).parent / kicad-cli`.
   The backend runs under KiCad's bundled Python (`KiCad\<ver>\bin\python`, which is how
   it imports `pcbnew`); `kicad-cli` lives in that same `bin` dir, making this the most
   reliable source for this server.
3. **`PATH`**.
4. **Known per-OS install locations** (newest KiCad version first; Windows
   `Program Files[ (x86)]\KiCad\*\bin`, macOS app bundle + Homebrew, Linux + Flatpak).

The resolved path is **cached** (the env override is re-checked every call so a changed
value isn't masked). When resolution fails, tools return a **clear, actionable error**
listing every location tried and how to set `KICAD_CLI`, replacing the bare
"not found in PATH".

This centralizes the duplicated `_find_kicad_cli` helpers (`kicad_interface`,
`design_rules`, `export`) onto the resolver, replaces the direct `"kicad-cli"` spawns in
`schematic_handlers` and `board/view`, and swaps all 47 bare error strings for the
detailed message. (The Node/TS layer does not spawn `kicad-cli` directly — it spawns this
Python backend — so no TS change is needed.)

## Verification (KiCad 10.0.4, with KiCad's bin NOT on PATH)
1. `export_netlist` against a real `.kicad_sch` **succeeds** (previously errored). ✅
2. Resolver finds `kicad-cli` via interpreter-adjacent / known-locations **without PATH**. ✅
3. Bogus `$KICAD_CLI` → tool fails with the **new clear error** (locations tried + env
   hint), and does not fall back to another binary. ✅
4. `kicad-cli` on `PATH` → still works (no regression). ✅
5. Resolved cli version (`10.0.4`) **matches the running KiCad**. ✅
- New `tests/test_kicad_cli_resolver.py` (14 tests, incl. an end-to-end `export_netlist`
  with PATH stripped of KiCad, and the bogus-override clear-error case).
- **Full suite: 1089 passed, 12 skipped.** Pre-commit hooks (black, isort, flake8, mypy)
  pass.

> Note: a one-line `board: Any` annotation was added to `SchematicHandlersMixin` so mypy
> can type-check that (edited) file standalone — a pre-existing per-file-mypy limitation
> surfaced because this PR touches the mixin.

## PR Checklist
- [x] Code follows style guidelines
- [x] All tests pass locally
- [x] New tests added for new behavior
- [x] Commit messages follow convention
- [x] No merge conflicts
