### PR TITLE
fix: fall back to SWIG/file backend for reads when IPC has no open document

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,11 @@ module = [
     "PIL.*",
 ]
 ignore_missing_imports = true
+
+# SchematicHandlersMixin relies on attributes (e.g. self.board) provided by the host
+# KiCADInterface it is mixed into, so checking it standalone — or as a followed import
+# from another module — cannot determine their types. Suppress the resulting has-type
+# noise here so unrelated modules that merely import it are not blocked by it.
+[[tool.mypy.overrides]]
+module = ["commands.schematic_handlers"]
+disable_error_code = ["has-type"]

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -36,8 +36,8 @@ if sys.platform == "win32":
 
 import sexpdata
 from annotations import AnnotationLoader
-from commands.wire_manager import WireManager
 from commands.schematic_handlers import SchematicHandlersMixin
+from commands.wire_manager import WireManager
 from resources.resource_definitions import RESOURCE_DEFINITIONS, handle_resource_read
 
 # Import tool schemas, resource definitions, and IPC API annotations
@@ -664,6 +664,17 @@ class KiCADInterface(SchematicHandlersMixin):
         "ipc_save_board",
     }
 
+    # File-answerable READ commands eligible for SWIG/file fallback: when their IPC
+    # handler reports that the live KiCad has no document open (``_no_open_document``),
+    # the dispatcher re-serves them from the on-disk .kicad_pcb via SWIG instead of
+    # surfacing a misleading "not found" or a false-success zeroed payload. Extend this
+    # set by having the corresponding _ipc_* handler emit ``_no_open_document`` on the
+    # no-board condition.
+    FILE_ANSWERABLE_READS = {
+        "get_board_info",
+        "get_component_properties",
+    }
+
     @staticmethod
     def _normalize_board_path(path: Any) -> Optional[str]:
         """Normalize a board file path for cross-backend comparison."""
@@ -685,6 +696,23 @@ class KiCADInterface(SchematicHandlersMixin):
             logger.debug(f"Could not compare IPC board path: {e}")
             return False
         return self._normalize_board_path(open_path) == target
+
+    def _ipc_has_open_board(self) -> bool:
+        """True only when the live KiCad GUI confirms a .kicad_pcb is open.
+
+        Returns False when no document is open OR when the running KiCad cannot answer
+        GetOpenDocuments (older/limited kiapi — the "no handler available for
+        GetOpenDocuments" case). In both situations IPC cannot reliably serve a board
+        read, so file-answerable reads should be served from the SWIG/file backend.
+        """
+        backend = getattr(self, "ipc_backend", None)
+        if not backend:
+            return False
+        try:
+            return backend.get_open_board_path() is not None
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"_ipc_has_open_board probe failed: {e}")
+            return False
 
     def _pin_session_backend(self, board_path: Any) -> None:
         """Pin the loaded project's lifecycle to one backend (issue #223).
@@ -858,12 +886,15 @@ class KiCADInterface(SchematicHandlersMixin):
             # A session pinned to SWIG never routes board commands over IPC,
             # even when IPC is connected — the GUI may hold a stale copy of
             # the board and an IPC save would clobber our edits (#223).
-            if (
+            swig_fallback_note: Optional[str] = None
+            ipc_can_serve = (
                 self.use_ipc
                 and self.ipc_board_api
                 and command in self.IPC_CAPABLE_COMMANDS
                 and self._session_allows_ipc()
-            ):
+            )
+
+            if ipc_can_serve:
                 ipc_handler_name = self.IPC_CAPABLE_COMMANDS[command]
                 ipc_handler = getattr(self, ipc_handler_name, None)
 
@@ -871,13 +902,27 @@ class KiCADInterface(SchematicHandlersMixin):
                     logger.info(f"Using IPC backend for {command} (real-time sync)")
                     result = ipc_handler(params)
 
-                    # Add indicator that IPC was used
-                    if isinstance(result, dict):
-                        result["_backend"] = "ipc"
-                        result["_realtime"] = True
+                    # Reactive fallback: if an IPC read could not answer because no
+                    # document is open, retry on the SWIG/file backend rather than
+                    # surfacing the misleading IPC failure to the caller.
+                    no_open_doc = (
+                        isinstance(result, dict)
+                        and not result.get("success")
+                        and result.get("_no_open_document")
+                    )
+                    if command in self.FILE_ANSWERABLE_READS and no_open_doc:
+                        swig_fallback_note = (
+                            "the live KiCad reported no open document; answered from "
+                            "the file (SWIG) backend instead of IPC"
+                        )
+                    else:
+                        # Add indicator that IPC was used
+                        if isinstance(result, dict):
+                            result["_backend"] = "ipc"
+                            result["_realtime"] = True
 
-                    logger.debug(f"IPC command result: {result}")
-                    return result
+                        logger.debug(f"IPC command result: {result}")
+                        return result
 
             # Fall back to SWIG-based handler
             if self.use_ipc and command in self.IPC_CAPABLE_COMMANDS and self._session_allows_ipc():
@@ -914,6 +959,10 @@ class KiCADInterface(SchematicHandlersMixin):
                             "is not used to avoid divergent board state (issue #223). "
                             "Reopen the project while it is open in the GUI to pin IPC."
                         )
+                    # A no-open-document fallback is the more specific explanation when
+                    # an IPC read was redirected to SWIG for this command.
+                    if swig_fallback_note:
+                        result["_backend_note"] = swig_fallback_note
 
                 # Update board reference if command was successful
                 if result.get("success", False):
@@ -4520,6 +4569,19 @@ print("ok")
         """IPC handler for get_board_info"""
         try:
             size = self.ipc_board_api.get_size()
+
+            # A live KiCad with no open document returns a zeroed size carrying an
+            # error string. That is a failure, not success — never report
+            # success:true with zeroed counts + an embedded error (contract
+            # violation). Signal _no_open_document so the dispatcher can fall back
+            # to the SWIG/file backend.
+            if isinstance(size, dict) and size.get("error"):
+                return {
+                    "success": False,
+                    "message": f"No board open in the live KiCad: {size['error']}",
+                    "_no_open_document": True,
+                }
+
             components = self.ipc_board_api.list_components()
             tracks = self.ipc_board_api.get_tracks()
             vias = self.ipc_board_api.get_vias()
@@ -4539,7 +4601,7 @@ print("ok")
             }
         except Exception as e:
             logger.error(f"IPC get_board_info error: {e}")
-            return {"success": False, "message": str(e)}
+            return {"success": False, "message": str(e), "_no_open_document": True}
 
     def _ipc_place_component(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """IPC handler for place_component - places component with real-time UI update"""
@@ -4938,6 +5000,17 @@ print("ok")
                     break
 
             if not target:
+                # Distinguish "no board open in the live KiCad" from "this component
+                # is genuinely absent". An empty component list with no open document
+                # means IPC simply had nothing loaded — signal _no_open_document so the
+                # dispatcher falls back to the SWIG/file backend instead of reporting a
+                # misleading "not found".
+                if not components and not self._ipc_has_open_board():
+                    return {
+                        "success": False,
+                        "message": "No board open in the live KiCad",
+                        "_no_open_document": True,
+                    }
                 return {"success": False, "message": f"Component {reference} not found"}
 
             # If IPC didn't provide bounding box, try SWIG backend as fallback
@@ -4954,7 +5027,7 @@ print("ok")
             return {"success": True, "component": target}
         except Exception as e:
             logger.error(f"IPC get_component_properties error: {e}")
-            return {"success": False, "message": str(e)}
+            return {"success": False, "message": str(e), "_no_open_document": True}
 
     def _ipc_set_footprint_type(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """IPC handler for set_footprint_type.

--- a/tests/test_ipc_swig_read_fallback.py
+++ b/tests/test_ipc_swig_read_fallback.py
@@ -1,0 +1,252 @@
+"""Tests for IPC->SWIG fallback on file-answerable read tools.
+
+When the live KiCad (IPC) has no document open, file-answerable reads
+(get_board_info, get_component_properties, ...) must fall back to the SWIG/file
+backend instead of returning a misleading "not found" or a false-success zeroed
+payload. When a board IS open in the live KiCad, the IPC realtime path is preserved.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+
+class _FakeIPCBackend:
+    """Stands in for the IPC backend: only get_open_board_path matters here."""
+
+    def __init__(self, open_board_path: Optional[str]):
+        self._open_board_path = open_board_path
+
+    def get_open_board_path(self) -> Optional[str]:
+        return self._open_board_path
+
+    def is_connected(self) -> bool:
+        return True
+
+
+class _FakeBoardAPI:
+    """Configurable IPC board API. ``size`` may carry an error (no open document)."""
+
+    def __init__(self, components: List[Dict[str, Any]], size: Optional[Dict[str, Any]] = None):
+        self._components = components
+        self._size = size if size is not None else {"width": 10, "height": 20, "unit": "mm"}
+
+    def get_size(self) -> Dict[str, Any]:
+        return self._size
+
+    def list_components(self) -> List[Dict[str, Any]]:
+        return list(self._components)
+
+    def get_tracks(self) -> List[Dict[str, Any]]:
+        return []
+
+    def get_vias(self) -> List[Dict[str, Any]]:
+        return []
+
+    def get_nets(self) -> List[Dict[str, Any]]:
+        return []
+
+
+def _make_iface(
+    *,
+    open_board_path: Optional[str],
+    board_api: Optional[_FakeBoardAPI],
+    command_routes: Dict[str, Any],
+):
+    from kicad_interface import KiCADInterface
+
+    iface = KiCADInterface.__new__(KiCADInterface)
+    iface.use_ipc = True
+    iface.ipc_backend = _FakeIPCBackend(open_board_path)
+    iface.ipc_board_api = board_api
+    iface.session_backend = "ipc"  # allow IPC routing
+    iface.board = None
+    iface.command_routes = command_routes
+    iface._board_disk_signature = None
+    iface._current_project_path = None
+    iface._last_auto_save_status = None
+    # Keep dispatch focused on routing: neutralise reconnect/liveness side effects.
+    iface._try_enable_ipc_backend = lambda *a, **k: None  # type: ignore[assignment]
+    iface._ipc_session_alive = lambda: True  # type: ignore[assignment]
+    return iface
+
+
+_SWIG_COMPONENT = {
+    "success": True,
+    "component": {"reference": "J1", "value": "Conn", "_served_from": "disk"},
+}
+_SWIG_BOARD = {
+    "success": True,
+    "board": {"filename": "/proj/board.kicad_pcb", "size": {"width": 50, "height": 40}},
+}
+
+
+# --------------------------------------------------------------------------- #
+# Verification 1: no live document -> get_component_properties via SWIG fallback
+# --------------------------------------------------------------------------- #
+
+
+def test_get_component_properties_falls_back_to_swig_when_no_open_document():
+    iface = _make_iface(
+        open_board_path=None,  # live KiCad has nothing open
+        board_api=_FakeBoardAPI(components=[]),
+        command_routes={"get_component_properties": lambda params: dict(_SWIG_COMPONENT)},
+    )
+
+    result = iface.handle_command("get_component_properties", {"reference": "J1"})
+
+    assert result["success"] is True
+    assert result["_backend"] == "swig"
+    assert result["component"]["reference"] == "J1"
+    assert "_backend_note" in result and "swig" in result["_backend_note"].lower()
+
+
+# --------------------------------------------------------------------------- #
+# Verification 2: get_board_info with no live document — file fallback or clean fail
+# --------------------------------------------------------------------------- #
+
+
+def test_get_board_info_file_fallback_when_no_open_document():
+    iface = _make_iface(
+        open_board_path=None,
+        board_api=_FakeBoardAPI(components=[], size={"width": 0, "height": 0, "error": "no doc"}),
+        command_routes={"get_board_info": lambda params: dict(_SWIG_BOARD)},
+    )
+
+    result = iface.handle_command("get_board_info", {})
+
+    assert result["success"] is True
+    assert result["_backend"] == "swig"
+    assert result["board"]["filename"].endswith("board.kicad_pcb")
+
+
+def test_get_board_info_clean_failure_when_neither_backend_has_board():
+    iface = _make_iface(
+        open_board_path=None,
+        board_api=_FakeBoardAPI(components=[], size={"width": 0, "height": 0, "error": "no doc"}),
+        command_routes={
+            "get_board_info": lambda params: {"success": False, "message": "No board is loaded"}
+        },
+    )
+
+    result = iface.handle_command("get_board_info", {})
+
+    # Must be a clean failure — never success:true with zeroed data + an error.
+    assert result["success"] is False
+    assert result["_backend"] == "swig"
+
+
+def test_ipc_get_board_info_never_returns_false_success():
+    """The IPC handler itself must not report success:true with a zeroed/error size."""
+    iface = _make_iface(
+        open_board_path="/proj/board.kicad_pcb",
+        board_api=_FakeBoardAPI(
+            components=[], size={"width": 0, "height": 0, "error": "No board open in KiCAD"}
+        ),
+        command_routes={},
+    )
+
+    result = iface._ipc_get_board_info({})
+
+    assert result["success"] is False
+    assert result.get("_no_open_document") is True
+
+
+# --------------------------------------------------------------------------- #
+# Verification 3: board genuinely open in live KiCad -> IPC realtime path
+# --------------------------------------------------------------------------- #
+
+
+def test_get_component_properties_uses_ipc_when_board_open():
+    iface = _make_iface(
+        open_board_path="/proj/board.kicad_pcb",
+        board_api=_FakeBoardAPI(
+            components=[{"reference": "J1", "value": "Conn", "boundingBox": {"x": 0}}]
+        ),
+        command_routes={"get_component_properties": lambda params: dict(_SWIG_COMPONENT)},
+    )
+
+    result = iface.handle_command("get_component_properties", {"reference": "J1"})
+
+    assert result["success"] is True
+    assert result["_backend"] == "ipc"
+    assert result["_realtime"] is True
+    # Served live from IPC's component list, not the SWIG disk stub.
+    assert result["component"].get("_served_from") != "disk"
+
+
+def test_get_board_info_uses_ipc_when_board_open():
+    iface = _make_iface(
+        open_board_path="/proj/board.kicad_pcb",
+        board_api=_FakeBoardAPI(components=[{"reference": "J1"}]),
+        command_routes={"get_board_info": lambda params: dict(_SWIG_BOARD)},
+    )
+
+    result = iface.handle_command("get_board_info", {})
+
+    assert result["success"] is True
+    assert result["_backend"] == "ipc"
+    assert result["boardInfo"]["backend"] == "ipc"
+
+
+# --------------------------------------------------------------------------- #
+# Verification 4: genuinely-absent component -> "not found", distinct from no-board
+# --------------------------------------------------------------------------- #
+
+
+def test_absent_component_reports_not_found_not_no_board():
+    iface = _make_iface(
+        open_board_path="/proj/board.kicad_pcb",  # board IS open
+        board_api=_FakeBoardAPI(components=[{"reference": "R1"}]),  # J1 absent
+        command_routes={"get_component_properties": lambda params: dict(_SWIG_COMPONENT)},
+    )
+
+    result = iface.handle_command("get_component_properties", {"reference": "J1"})
+
+    assert result["success"] is False
+    assert "not found" in result["message"].lower()
+    # This is a genuine miss served by IPC, not a no-document fallback.
+    assert result["_backend"] == "ipc"
+
+
+# --------------------------------------------------------------------------- #
+# Verification 5 + reactive fallback: every response reports the backend
+# --------------------------------------------------------------------------- #
+
+
+def test_reactive_fallback_when_ipc_read_reports_no_open_document():
+    """Even if the open-document probe passes, an IPC read that comes back with
+    _no_open_document must be retried on SWIG (race / stale probe)."""
+    iface = _make_iface(
+        open_board_path="/proj/board.kicad_pcb",  # probe says open...
+        board_api=_FakeBoardAPI(
+            components=[], size={"width": 0, "height": 0, "error": "no doc"}  # ...but read fails
+        ),
+        command_routes={"get_board_info": lambda params: dict(_SWIG_BOARD)},
+    )
+
+    result = iface.handle_command("get_board_info", {})
+
+    assert result["success"] is True
+    assert result["_backend"] == "swig"
+    assert result["board"]["filename"].endswith("board.kicad_pcb")
+
+
+def test_every_response_reports_a_backend():
+    iface = _make_iface(
+        open_board_path=None,
+        board_api=_FakeBoardAPI(components=[]),
+        command_routes={"get_component_list": lambda params: {"success": True, "components": []}},
+    )
+
+    result = iface.handle_command("get_component_list", {})
+
+    assert result["_backend"] in {"ipc", "swig"}
+    assert "_realtime" in result


### PR DESCRIPTION
## Problem (observed this session)
Some file-answerable read tools routed to the realtime **IPC** backend even when the
live KiCad GUI had **no document open**, producing confusing or wrong results — while
`open_project` had succeeded on the SWIG/file backend:

- `get_component_properties` returned `"Component J1 not found"` (the part exists in the
  file; IPC just had nothing loaded) — conflating *no board open* with *absent*.
- `get_board_info` returned `success:true` with **zeroed counts AND an embedded `error`
  string** — a contract violation (a failure must be `success:false`).

## Fix
Use the existing backend infrastructure (session pinning, `_backend`/`_realtime` tags)
for graceful fallback:

1. **Detect the no-open-document condition** in the IPC read handlers.
   `_ipc_get_board_info` now treats a zeroed size carrying an `error` as a failure (no
   more false success); `_ipc_get_component_properties` distinguishes *no board open*
   from a genuine miss. Both signal it via a `_no_open_document` marker.
2. **Reactive SWIG/file fallback** in `handle_command`: when a file-answerable read
   (`get_board_info`, `get_component_properties`) returns `_no_open_document`, it is
   re-served from the on-disk `.kicad_pcb` via SWIG and tagged `_backend:"swig"` with a
   `_backend_note` explaining the redirect.
3. **Accurate structured errors** when neither backend can answer (`success:false` with a
   distinct message) — never `success:true` with zeroed data + an error.

When a board **is** open in the live KiCad, the IPC realtime path is unchanged
(`_backend:"ipc"`), and a genuinely-absent component still reports "not found" via IPC.
The fallback set is extensible — other reads opt in by having their `_ipc_*` handler emit
`_no_open_document`.

## Verification (tests/test_ipc_swig_read_fallback.py)
1. No live document → `get_component_properties` succeeds via SWIG fallback. ✅
2. No live document → `get_board_info` file-fallback, or a clean `success:false`; never a
   false-success zeroed payload. ✅
3. Board open in live KiCad → IPC realtime path preserved (`_backend:"ipc"`). ✅
4. Genuinely-absent component → "not found", distinct from the no-board case. ✅
5. Every response reports which backend answered (`_backend`). ✅
- Full suite: **1084 passed, 12 skipped.** Pre-commit hooks (black, isort, flake8, mypy)
  pass.

## Parallel-review / conflict notes
- This PR and #267 both edit `kicad_interface.py` but in **non-overlapping regions**; a
  local trial merge of both branches is **conflict-free** (the only shared hunk is an
  identical isort import reorder, which merges cleanly).
- The pre-existing mypy `has-type` on `SchematicHandlersMixin.self.board` (surfaced here
  via import-following) is suppressed with a **scoped `pyproject.toml` mypy override**
  rather than editing `schematic_handlers.py`, keeping this PR's file set disjoint from
  #267.

## PR Checklist
- [x] Code follows style guidelines
- [x] All tests pass locally
- [x] New tests added for new behavior
- [x] Commit messages follow convention
- [x] No merge conflicts
