### PR TITLE
fix: write blank KiCad 10 schematic on create_project (#221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`create_project` now writes a blank KiCad 10 schematic** (issue #221).
+  Previously it copied `template_with_symbols_expanded.kicad_sch`, which
+  contains placed `_TEMPLATE_R/C/D` symbol instances, so every "new" project
+  opened with three stray components on the canvas. It also hardcoded the
+  KiCad 9 era schematic format `(version 20250114)`. `create_project` now
+  copies `empty.kicad_sch` (no placed components) and the schematic format
+  version is bumped to `20260306` (KiCad 10.0.4) in both the template and the
+  inline fallback.
+
 - **`rotate_component` now treats `angle` as an absolute target rotation**,
   matching its schema description. Previously the IPC backend added the
   supplied angle to the current rotation, so two consecutive

--- a/python/commands/project.py
+++ b/python/commands/project.py
@@ -61,13 +61,16 @@ class ProjectCommands:
             board.SetFileName(board_path)
             pcbnew.SaveBoard(board_path, board)
 
-            # Create schematic from template (use expanded template with symbol definitions)
+            # Create schematic from the empty template (no pre-seeded symbols).
+            # A new project must start as a genuinely blank schematic; the
+            # symbol-seeded templates injected hidden _TEMPLATE_R/C/D instances
+            # that bled into every new project (see issue #221).
             schematic_path = project_path.replace(".kicad_pro", ".kicad_sch")
             template_sch_path = os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),
                 "..",
                 "templates",
-                "template_with_symbols_expanded.kicad_sch",
+                "empty.kicad_sch",
             )
 
             if os.path.exists(template_sch_path):
@@ -100,7 +103,7 @@ class ProjectCommands:
 
                 schematic_uuid = str(uuid_module.uuid4())
                 with open(schematic_path, "w", encoding="utf-8", newline="\n") as f:
-                    f.write('(kicad_sch (version 20250114) (generator "KiCAD-MCP-Server")\n\n')
+                    f.write('(kicad_sch (version 20260306) (generator "KiCAD-MCP-Server")\n\n')
                     f.write(f"  (uuid {schematic_uuid})\n\n")
                     f.write('  (paper "A4")\n\n')
                     f.write("  (lib_symbols\n  )\n\n")

--- a/python/templates/empty.kicad_sch
+++ b/python/templates/empty.kicad_sch
@@ -1,4 +1,4 @@
-(kicad_sch (version 20250114) (generator "KiCAD-MCP-Server")
+(kicad_sch (version 20260306) (generator "KiCAD-MCP-Server")
 
   (uuid b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e)
 


### PR DESCRIPTION
## Summary

Fixes #221.

`create_project` produced a "new" project that was neither blank nor in the
current KiCad format. Two defects, both fixed here:

1. **Pre-seeded components.** `create_project` copied
   `template_with_symbols_expanded.kicad_sch`, which contains **placed**
   `_TEMPLATE_R`, `_TEMPLATE_C`, and `_TEMPLATE_D` symbol instances. Every new
   project therefore opened with three stray components on the canvas.
   `create_project` now copies `empty.kicad_sch`, which has **no placed
   component instances**.

2. **Outdated schematic format.** Both the template and the inline fallback
   hardcoded the KiCad 9 era format `(version 20250114)`. Bumped to
   `20260306` (KiCad 10.0.4) so the generated schematic opens cleanly in
   KiCad 10 without a format-upgrade prompt.

### Note on `lib_symbols`

`empty.kicad_sch` retains the `Device:R/C/LED` definitions in its
`lib_symbols` block. These are **library definitions, not placed components** —
they render nothing, appear in no BOM/ERC, and KiCad prunes unused entries on
the first save. They are also the shared geometry source for ~20 schematic test
fixtures, so the file is deliberately left as the "empty project" (no placed
parts) rather than a literally empty file.

## Out of scope for this PR

- The non-conformant `.kicad_pro` stub (#220) — separate root cause, tracked
  independently.
- `create_schematic`'s use of the symbol-seeded template (#243).

## Test plan

- [x] All schematic test fixtures that consume `empty.kicad_sch` pass under
      `--timeout=60 --timeout-method=thread` (bbox/pin/angle set matches clean
      `main` at 46 passed; 126 more across component/label/snap files; net/wire
      /delete group green).
- [x] Baseline diff (clean `main` worktree vs. branch) confirms the change
      introduces no new failures.
- [ ] CI passes on the PR.
