### PR TITLE
fix: add_schematic_component emits (pin N (uuid)) entries for ERC (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,20 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`add_schematic_component` emits `(pin "N" (uuid ...))` entries** (#241):
+  `DynamicSymbolLoader.create_component_instance` built the placed `(symbol ...)`
+  block with `lib_id`, `at`, `uuid`, properties, and `instances`, but no per-pin
+  entries. KiCad needs one `(pin "N" (uuid ...))` per pin to bind wires to pins,
+  so ERC reported every pin as unconnected even when wires were drawn correctly.
+  Each placed instance now carries one entry per pin, with pin numbers read from
+  the embedded `lib_symbols` definition for the placed `(unit ...)` (sub-symbols
+  with unit 0 are common to all units) and a freshly generated UUID per pin.
+
 - **Fallback schematic writer emits the KiCad 10 header** (#221, partial): the
   template-missing fallback in `create_schematic` and `create_project` wrote the
   stale KiCad 9 header `(version 20250114) (generator "KiCAD-MCP-Server")`. It
   now writes `(version 20260306) (generator "eeschema") (generator_version
-  "10.0")`, matching what eeschema writes for a new file. This covers only the
+"10.0")`, matching what eeschema writes for a new file. This covers only the
   fallback path; the main templates (which still carry the KiCad 9 version and
   the `_TEMPLATE_*` clone-source instances used by `add_schematic_component`)
   are tracked separately because rewriting them touches the component-cloning

--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -513,6 +513,58 @@ class DynamicSymbolLoader:
         except Exception:
             return {}
 
+    def _extract_lib_pin_numbers(
+        self,
+        schematic_path: Path,
+        library_name: str,
+        symbol_name: str,
+        unit: int = 1,
+    ) -> list:
+        """
+        Return the ordered, de-duplicated list of pin numbers for the requested
+        unit, read from the lib_symbols definition (which must already have the
+        symbol injected).
+
+        Pins live in per-unit sub-symbols named '<symbol>_<unit>_<bodystyle>'.
+        Sub-symbols with unit 0 are common to every unit, so pins for a placed
+        '(unit N)' are gathered from sub-symbols whose unit is N or 0. Duplicate
+        numbers (e.g. from an alternate DeMorgan body style) are dropped while
+        preserving first-seen order. Returns an empty list on failure.
+        """
+        try:
+            with open(schematic_path, encoding="utf-8") as f:
+                content = f.read()
+
+            lib_start = content.find("(lib_symbols")
+            if lib_start == -1:
+                return []
+
+            sym_start = content.find(f'(symbol "{library_name}:{symbol_name}"', lib_start)
+            if sym_start == -1:
+                return []
+
+            sym_block = self._extract_paren_block(content, sym_start)
+
+            import re
+
+            pin_numbers: list = []
+            seen = set()
+            # Walk each child sub-symbol; its name encodes the unit it belongs to.
+            for m in re.finditer(r'\(symbol\s+"([^"]+)_(\d+)_(\d+)"', sym_block):
+                sub_unit = int(m.group(2))
+                if sub_unit not in (unit, 0):
+                    continue
+                sub_block = self._extract_paren_block(sym_block, m.start())
+                for pm in re.finditer(r'\(number\s+"([^"]+)"', sub_block):
+                    number = pm.group(1)
+                    if number not in seen:
+                        seen.add(number)
+                        pin_numbers.append(number)
+
+            return pin_numbers
+        except Exception:
+            return []
+
     @staticmethod
     def _rotate_offset(dx: float, dy: float, angle_deg: float) -> tuple:
         """
@@ -579,6 +631,14 @@ class DynamicSymbolLoader:
         fp_x, fp_y, _, _ = _prop_at("Footprint", 0, 0, 0)
         ds_x, ds_y, _, _ = _prop_at("Datasheet", 0, 0, 0)
 
+        # Build one (pin "N" (uuid ...)) entry per pin in the lib definition.
+        # KiCad requires these to bind wires to pins; without them ERC reports
+        # every pin as unconnected (issue #241).
+        pin_numbers = self._extract_lib_pin_numbers(schematic_path, library_name, symbol_name, unit)
+        pins_str = "".join(
+            f'\n    (pin "{number}" (uuid "{uuid.uuid4()}"))' for number in pin_numbers
+        )
+
         mirror_str = " (mirror y)" if mirror_y else ""
         instance_block = f"""  (symbol (lib_id "{full_lib_id}") (at {x} {y} {angle}){mirror_str} (unit {unit})
     (in_bom yes) (on_board yes) (dnp no)
@@ -602,7 +662,7 @@ class DynamicSymbolLoader:
           (unit {unit})
         )
       )
-    )
+    ){pins_str}
   )"""
 
         with open(schematic_path, "r", encoding="utf-8") as f:

--- a/tests/test_add_schematic_component.py
+++ b/tests/test_add_schematic_component.py
@@ -294,6 +294,84 @@ class TestCreateComponentInstanceSubSheet:
 
 
 # ---------------------------------------------------------------------------
+# Pin entries — (pin "N" (uuid ...)) required for ERC (issue #241)
+# ---------------------------------------------------------------------------
+
+
+def _instance_block(content: str, reference: str) -> str:
+    """Return the placed (symbol (lib_id ...) ...) block carrying `reference`."""
+    from commands.dynamic_symbol_loader import DynamicSymbolLoader
+
+    search = 0
+    while True:
+        start = content.find("(symbol (lib_id ", search)
+        if start == -1:
+            raise AssertionError(f"No instance block found for {reference}")
+        block = DynamicSymbolLoader._extract_paren_block(content, start)
+        if f'(reference "{reference}")' in block:
+            return block
+        search = start + 1
+
+
+@pytest.mark.unit
+class TestCreateComponentInstancePinEntries:
+    """Each placed instance must carry one (pin "N" (uuid ...)) per lib pin.
+
+    Without these, KiCad cannot bind wires to pins and ERC reports every pin
+    as unconnected (issue #241).
+    """
+
+    def setup_method(self) -> None:
+        from commands.dynamic_symbol_loader import DynamicSymbolLoader
+
+        self.DynamicSymbolLoader = DynamicSymbolLoader
+
+    def _loader(self) -> Any:
+        return self.DynamicSymbolLoader()
+
+    def test_resistor_gets_two_pin_entries(self, tmp_path: Any) -> None:
+        sch = tmp_path / "test.kicad_sch"
+        shutil.copy(EMPTY_SCH, sch)
+        self._loader().create_component_instance(
+            sch, "Device", "R", reference="R1", value="10k", x=10, y=10
+        )
+        block = _instance_block(sch.read_text(), "R1")
+        pins = re.findall(r'\(pin "([^"]+)" \(uuid "[^"]+"\)\)', block)
+        assert sorted(pins) == ["1", "2"]
+
+    def test_pin_uuids_are_unique(self, tmp_path: Any) -> None:
+        sch = tmp_path / "test.kicad_sch"
+        shutil.copy(EMPTY_SCH, sch)
+        self._loader().create_component_instance(
+            sch, "Device", "R", reference="R1", value="10k", x=10, y=10
+        )
+        block = _instance_block(sch.read_text(), "R1")
+        uuids = re.findall(r'\(pin "[^"]+" \(uuid "([^"]+)"\)\)', block)
+        assert len(uuids) == len(set(uuids)), "Each pin must get a distinct UUID"
+
+    def test_led_gets_two_pin_entries(self, tmp_path: Any) -> None:
+        sch = tmp_path / "test.kicad_sch"
+        shutil.copy(EMPTY_SCH, sch)
+        self._loader().create_component_instance(
+            sch, "Device", "LED", reference="D1", value="LED", x=10, y=10
+        )
+        block = _instance_block(sch.read_text(), "D1")
+        pins = re.findall(r'\(pin "([^"]+)" \(uuid "[^"]+"\)\)', block)
+        assert sorted(pins) == ["1", "2"]
+
+    def test_instance_still_round_trips_via_sexpdata(self, tmp_path: Any) -> None:
+        import sexpdata
+
+        sch = tmp_path / "test.kicad_sch"
+        shutil.copy(EMPTY_SCH, sch)
+        self._loader().create_component_instance(
+            sch, "Device", "R", reference="R1", value="10k", x=10, y=10
+        )
+        parsed = sexpdata.loads(sch.read_text())
+        assert parsed[0] == sexpdata.Symbol("kicad_sch")
+
+
+# ---------------------------------------------------------------------------
 # Mirror parameter — known gap
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #241. Components added via `add_schematic_component` were missing the `(pin "N" (uuid ...))` entries KiCad requires to bind wires to pins, so ERC reported **every** pin as unconnected even when wires were drawn correctly.

`DynamicSymbolLoader.create_component_instance` synthesizes the placed `(symbol ...)` block as a string template with `lib_id`, `at`, `unit`, `uuid`, `property`, and `instances` — but emitted no per-pin entries. KiCad's own save format writes one `(pin "number" (uuid "..."))` per pin defined in the embedded `lib_symbol`. Without them the schematic is invalid for ERC purposes.

## Changes

- **`python/commands/dynamic_symbol_loader.py`**
  - New helper `_extract_lib_pin_numbers(...)` reads pin numbers from the already-injected `lib_symbols` definition. Pins live in per-unit sub-symbols named `<symbol>_<unit>_<bodystyle>`; pins for a placed `(unit N)` are gathered from sub-symbols whose unit is **N or 0** (unit 0 is common to all units), so multi-unit parts get the correct pins. Duplicate numbers (e.g. from an alternate DeMorgan body style) are dropped while preserving order.
  - `create_component_instance` now appends one `(pin "N" (uuid "..."))` per pin — each with a freshly generated UUID — after the `(instances ...)` block.

- **`tests/test_add_schematic_component.py`** — new `TestCreateComponentInstancePinEntries`:
  - a placed resistor gets exactly pins `1`/`2`, a placed LED gets `1`/`2`
  - each pin gets a distinct UUID
  - the resulting schematic still round-trips via `sexpdata`

- **`CHANGELOG.md`** — Bug Fixes entry under `[Unreleased]`.

## Testing

```
pytest tests/test_add_schematic_component.py::TestCreateComponentInstancePinEntries \
       tests/test_add_schematic_component.py::TestCreateComponentInstanceUnit \
       tests/test_add_schematic_component.py::TestCreateComponentInstanceSubSheet \
       --timeout=60 --timeout-method=thread
# 13 passed
```

All pre-commit hooks (black, isort, prettier, flake8, mypy) pass.

## Notes

This only touches the synthesis path in `DynamicSymbolLoader` (the path the live `add_schematic_component` tool uses) and is independent of the `_TEMPLATE_*` / template-rewrite work tracked under #221/#220.
