### PR TITLE
feat: add close_project command (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to the KiCAD MCP Server project are documented here.
   template-missing fallback in `create_schematic` and `create_project` wrote the
   stale KiCad 9 header `(version 20250114) (generator "KiCAD-MCP-Server")`. It
   now writes `(version 20260306) (generator "eeschema") (generator_version
-  "10.0")`, matching what eeschema writes for a new file. This covers only the
+"10.0")`, matching what eeschema writes for a new file. This covers only the
   fallback path; the main templates (which still carry the KiCad 9 version and
   the `_TEMPLATE_*` clone-source instances used by `add_schematic_component`)
   are tracked separately because rewriting them touches the component-cloning
@@ -107,6 +107,16 @@ All notable changes to the KiCAD MCP Server project are documented here.
   the failure on a real-world user schematic.
 
 ### New MCP Tools
+
+- `close_project` (#225) — Symmetric counterpart to `open_project` /
+  `create_project`. Optionally saves the board (`save`, default `true`), then
+  drops the in-memory board (SWIG + IPC) and clears all per-project session
+  state (session-backend pin, disk signature, project paths). Lets an agent
+  hand control back so the user — or the agent itself — can edit project files
+  directly without a later MCP save clobbering those changes, which previously
+  required manual open/close choreography. If `save=true` and the save fails,
+  the close is refused so work is never silently lost; if `save=false` on a
+  board with unsaved changes, the close proceeds with a warning.
 
 - `add_gnd_stitching_vias` — Drop GND stitching vias across the board with
   collision checking against every non-GND segment, via, and pad on every

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -18,11 +18,10 @@ import subprocess
 import tempfile
 import traceback
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import pcbnew
 import sexpdata
-
 from commands.library_schematic import LibraryManager as SchematicLibraryManager
 from commands.schematic import SchematicManager
 from commands.wire_manager import WireManager
@@ -90,6 +89,14 @@ def _svg_to_png(svg_path: str, width: int, height: int) -> Optional[bytes]:
 
 class SchematicHandlersMixin:
     """Schematic-domain handlers mixed into KiCADInterface."""
+
+    # Attributes/methods supplied by the concrete KiCADInterface this mixin is
+    # mixed into. Declaring them here (type-check time only, no runtime effect)
+    # gives mypy a definite type for `self.board` at the reference sites below,
+    # breaking the attribute-resolution cycle that otherwise raises
+    # "Cannot determine type of 'board'" whenever kicad_interface.py is checked.
+    if TYPE_CHECKING:
+        board: Any
 
     def _handle_create_schematic(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Create a new schematic"""

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -36,8 +36,8 @@ if sys.platform == "win32":
 
 import sexpdata
 from annotations import AnnotationLoader
-from commands.wire_manager import WireManager
 from commands.schematic_handlers import SchematicHandlersMixin
+from commands.wire_manager import WireManager
 from resources.resource_definitions import RESOURCE_DEFINITIONS, handle_resource_read
 
 # Import tool schemas, resource definitions, and IPC API annotations
@@ -422,6 +422,7 @@ class KiCADInterface(SchematicHandlersMixin):
             # Project commands
             "create_project": self._handle_create_project,
             "open_project": self._handle_open_project,
+            "close_project": self._handle_close_project,
             "save_project": self.project_commands.save_project,
             "snapshot_project": self._handle_snapshot_project,
             "get_project_info": self.project_commands.get_project_info,
@@ -1426,6 +1427,106 @@ class KiCADInterface(SchematicHandlersMixin):
                 or params.get("filename")
             )
             self._refresh_symbol_library_for_project(project_path)
+        return result
+
+    def _clear_project_state(self) -> None:
+        """Drop the in-memory board (SWIG + IPC) and reset all per-project session
+        state, returning the interface to its just-initialized, no-project state.
+
+        Symmetric with the state that open_project / create_project establish, so
+        a subsequent open/create starts from a clean slate (issue #225).
+        """
+        self.board = None
+        # Propagate the None board to every command handler (project, board,
+        # component, routing, design-rule, export, freerouting).
+        self._update_command_handlers()
+        self.ipc_board_api = None
+        self.session_backend = None
+        self.session_board_path = None
+        self._board_disk_signature = None
+        self._last_auto_save_status = None
+        self.project_filename = None
+        self._current_project_path = None
+
+    def _handle_close_project(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Close the currently loaded project (issue #225).
+
+        Symmetric counterpart to open_project / create_project: optionally save,
+        then drop the in-memory board (SWIG + IPC) and clear all session state so
+        the agent can orchestrate file-based edits without the MCP holding a
+        board that a later save could clobber.
+
+        params:
+          save (bool, default True): save the board to disk before closing. If
+            the save fails, the close is refused so work is never silently lost.
+            When False and the board has unsaved changes, the close proceeds but
+            the response warns that in-memory changes were discarded.
+        """
+        save = params.get("save", True)
+        board_path = self._current_board_path()
+        loaded = board_path is not None or self.board is not None
+
+        if not loaded:
+            # Idempotent: nothing to close. Still scrub any lingering state.
+            self._clear_project_state()
+            return {
+                "success": True,
+                "message": "No project was loaded; nothing to close",
+                "closed": False,
+                "saved": False,
+            }
+
+        warnings = []
+        saved = False
+        saved_path = None
+
+        if save and self.board is not None:
+            try:
+                save_result = self.project_commands.save_project({})
+            except Exception as e:  # noqa: BLE001 - surfaced to caller below
+                logger.error("close_project: save failed: %s", e)
+                return {
+                    "success": False,
+                    "message": "Refusing to close: saving the project failed",
+                    "errorDetails": str(e),
+                    "closed": False,
+                    "saved": False,
+                }
+            if not save_result.get("success"):
+                return {
+                    "success": False,
+                    "message": "Refusing to close: saving the project failed",
+                    "errorDetails": save_result.get("errorDetails") or save_result.get("message"),
+                    "closed": False,
+                    "saved": False,
+                }
+            saved = True
+            saved_path = (save_result.get("project") or {}).get("path")
+        elif not save:
+            dirty = self._dirty_state(board_path)
+            if dirty.get("dirty"):
+                warnings.append(
+                    "Project closed without saving (save=False); in-memory changes "
+                    "since the last save were discarded."
+                )
+
+        closed_path = board_path or self.session_board_path
+        self._clear_project_state()
+
+        result: Dict[str, Any] = {
+            "success": True,
+            "message": (
+                f"Closed project: {os.path.basename(closed_path)}"
+                if closed_path
+                else "Closed project"
+            ),
+            "closed": True,
+            "saved": saved,
+        }
+        if saved_path:
+            result["savedPath"] = saved_path
+        if warnings:
+            result["warnings"] = warnings
         return result
 
     def _handle_place_component(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -57,6 +57,20 @@ PROJECT_TOOLS = [
         },
     },
     {
+        "name": "close_project",
+        "title": "Close Current Project",
+        "description": "Closes the currently loaded project: optionally saves the board, then drops the in-memory board (SWIG and IPC) and clears all session state. Symmetric counterpart to open_project/create_project. Use this to release the project so the user or agent can edit project files directly without a later MCP save clobbering those changes.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "save": {
+                    "type": "boolean",
+                    "description": "Save the board to disk before closing (default true). If false and there are unsaved changes, the close proceeds but the response warns they were discarded.",
+                }
+            },
+        },
+    },
+    {
         "name": "save_project",
         "title": "Save Current Project",
         "description": "Saves the current board to disk. Can optionally save to a new location.",
@@ -265,7 +279,7 @@ BOARD_TOOLS = [
                 "layers": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Layer names to include, e.g. [\"F.Cu\",\"B.Cu\",\"Edge.Cuts\"]. Omit for all layers.",
+                    "description": 'Layer names to include, e.g. ["F.Cu","B.Cu","Edge.Cuts"]. Omit for all layers.',
                 },
                 "responseMode": {
                     "type": "string",
@@ -758,8 +772,7 @@ COMPONENT_TOOLS = [
                 "refs": {
                     "type": "array",
                     "description": (
-                        "Limit the check to these refs (default: every "
-                        "footprint on the board)."
+                        "Limit the check to these refs (default: every " "footprint on the board)."
                     ),
                     "items": {"type": "string"},
                 },
@@ -775,8 +788,7 @@ COMPONENT_TOOLS = [
                 "include_boundary": {
                     "type": "boolean",
                     "description": (
-                        "Also flag courtyards that extend past the board outline "
-                        "(default true)."
+                        "Also flag courtyards that extend past the board outline " "(default true)."
                     ),
                     "default": True,
                 },
@@ -1083,8 +1095,7 @@ ROUTING_TOOLS = [
                 "viaDrill": {
                     "type": "number",
                     "description": (
-                        "Via drill diameter in mm (default 0.3). "
-                        "Must be smaller than viaSize."
+                        "Via drill diameter in mm (default 0.3). " "Must be smaller than viaSize."
                     ),
                     "default": 0.3,
                 },
@@ -1123,9 +1134,7 @@ ROUTING_TOOLS = [
                 },
                 "edgeMargin": {
                     "type": "number",
-                    "description": (
-                        "Keep-out from the board edge in mm. Default 0.5."
-                    ),
+                    "description": ("Keep-out from the board edge in mm. Default 0.5."),
                     "default": 0.5,
                 },
                 "maxVias": {

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -47,6 +47,31 @@ export function registerProjectTools(server: McpServer, callKicadScript: Functio
     },
   );
 
+  // Close project tool
+  server.tool(
+    "close_project",
+    "Close the currently loaded KiCAD project: optionally save, then drop the in-memory board and clear session state. Use this to hand control back so the user (or the agent) can edit project files directly without the MCP later clobbering those changes on save.",
+    {
+      save: z
+        .boolean()
+        .optional()
+        .describe(
+          "Save the board to disk before closing (default true). If false and there are unsaved changes, the close proceeds but the response warns they were discarded.",
+        ),
+    },
+    async (args: { save?: boolean }) => {
+      const result = await callKicadScript("close_project", args);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
   // Save project tool
   server.tool(
     "save_project",

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -190,6 +190,7 @@ export const directToolNames = [
   // Project lifecycle
   "create_project",
   "open_project",
+  "close_project",
   "save_project",
   "snapshot_project",
   "get_project_info",

--- a/tests/test_close_project.py
+++ b/tests/test_close_project.py
@@ -1,0 +1,155 @@
+"""
+Tests for the close_project command (issue #225).
+
+close_project is the symmetric counterpart to open_project / create_project:
+it optionally saves, then drops the in-memory board (SWIG + IPC) and clears all
+per-project session state.
+
+KiCADInterface.__init__ scans the system footprint/symbol libraries, which is
+slow and environment-dependent, so these tests build the interface via
+object.__new__ and populate just the attributes the handler under test touches.
+"""
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+
+class _FakeBoard:
+    """Minimal stand-in that passes KiCADInterface._is_board_healthy."""
+
+    def __init__(self, filename: str) -> None:
+        self._filename = filename
+
+    def GetFileName(self) -> str:
+        return self._filename
+
+    def GetDesignSettings(self) -> object:
+        return object()
+
+    def GetBoardEdgesBoundingBox(self) -> object:
+        return object()
+
+
+class _FakeProjectCommands:
+    def __init__(self, save_result: Any) -> None:
+        self.board: Any = None
+        self._save_result = save_result
+        self.save_calls = 0
+
+    def save_project(self, params: dict) -> Any:
+        self.save_calls += 1
+        if isinstance(self._save_result, Exception):
+            raise self._save_result
+        return self._save_result
+
+
+def _make_interface(board: Any, project_commands: Any) -> Any:
+    """Build a KiCADInterface without running its heavy __init__."""
+    from kicad_interface import KiCADInterface
+
+    iface = object.__new__(KiCADInterface)
+    iface.board = board
+    iface.project_commands = project_commands
+    # Command handlers that _update_command_handlers writes .board onto.
+    for name in (
+        "board_commands",
+        "component_commands",
+        "routing_commands",
+        "design_rule_commands",
+        "export_commands",
+        "freerouting_commands",
+    ):
+        setattr(iface, name, types.SimpleNamespace(board=board))
+    # Per-project session state populated by a real open/create.
+    iface.ipc_board_api = object()
+    iface.session_backend = "swig"
+    iface.session_board_path = "/proj/board.kicad_pcb"
+    iface._board_disk_signature = (123, "abc")
+    iface._last_auto_save_status = None
+    iface.project_filename = "/proj/board.kicad_pro"
+    iface._current_project_path = Path("/proj")
+    return iface
+
+
+@pytest.mark.unit
+class TestCloseProject:
+    def test_no_project_loaded_is_idempotent(self) -> None:
+        pc = _FakeProjectCommands({"success": True})
+        iface = _make_interface(board=None, project_commands=pc)
+
+        result = iface._handle_close_project({})
+
+        assert result["success"] is True
+        assert result["closed"] is False
+        assert pc.save_calls == 0
+
+    def test_close_saves_by_default_and_clears_state(self) -> None:
+        board = _FakeBoard("/proj/board.kicad_pcb")
+        pc = _FakeProjectCommands({"success": True, "project": {"path": "/proj/board.kicad_pcb"}})
+        iface = _make_interface(board=board, project_commands=pc)
+
+        result = iface._handle_close_project({})
+
+        assert result["success"] is True
+        assert result["closed"] is True
+        assert result["saved"] is True
+        assert result["savedPath"] == "/proj/board.kicad_pcb"
+        assert pc.save_calls == 1
+        # State fully scrubbed, symmetric with a fresh interface.
+        assert iface.board is None
+        assert iface.ipc_board_api is None
+        assert iface.session_backend is None
+        assert iface.session_board_path is None
+        assert iface._board_disk_signature is None
+        assert iface.project_filename is None
+        assert iface._current_project_path is None
+        # Board reference cleared on every command handler too.
+        assert iface.board_commands.board is None
+        assert iface.export_commands.board is None
+
+    def test_save_false_on_dirty_board_warns_but_closes(self) -> None:
+        board = _FakeBoard("/proj/board.kicad_pcb")
+        pc = _FakeProjectCommands({"success": True})
+        iface = _make_interface(board=board, project_commands=pc)
+        # Make _dirty_state report dirty without touching the disk.
+        iface._last_auto_save_status = {"memChangesUnsaved": True}
+
+        result = iface._handle_close_project({"save": False})
+
+        assert result["success"] is True
+        assert result["closed"] is True
+        assert result["saved"] is False
+        assert pc.save_calls == 0
+        assert any("discarded" in w for w in result.get("warnings", []))
+        assert iface.board is None
+
+    def test_save_failure_refuses_to_close(self) -> None:
+        board = _FakeBoard("/proj/board.kicad_pcb")
+        pc = _FakeProjectCommands({"success": False, "message": "disk full"})
+        iface = _make_interface(board=board, project_commands=pc)
+
+        result = iface._handle_close_project({})
+
+        assert result["success"] is False
+        assert result["closed"] is False
+        # Board NOT dropped — work is preserved so the caller can retry.
+        assert iface.board is board
+        assert iface.session_backend == "swig"
+
+    def test_save_exception_refuses_to_close(self) -> None:
+        board = _FakeBoard("/proj/board.kicad_pcb")
+        pc = _FakeProjectCommands(RuntimeError("boom"))
+        iface = _make_interface(board=board, project_commands=pc)
+
+        result = iface._handle_close_project({})
+
+        assert result["success"] is False
+        assert result["closed"] is False
+        assert "boom" in result["errorDetails"]
+        assert iface.board is board


### PR DESCRIPTION
## Summary

Implements #225 — adds a `close_project` command, the symmetric counterpart to `open_project` / `create_project`. As you noted in the issue, this shares the create_project/backend lifecycle plumbing from #220–#223, which has since landed.

Today an agent has to choreograph closing manually (ask the user to close in KiCad, let them edit/stash/commit, then reopen via MCP) because the MCP keeps an in-memory board that a later save can clobber. `close_project` lets the agent release the project itself, so it can mix file-based and MCP-based edits without user involvement.

## Behavior

Matches the design you sketched (save-or-warn, drop the in-memory board + IPC board, clear state):

- **`save` (bool, default `true`)** — saves the board before closing.
  - If `save=true` and the save **fails**, the close is **refused** (`success: false`) so work is never silently lost; the board stays loaded for a retry.
  - If `save=false` and the board has unsaved changes, the close proceeds with a `warnings` entry noting the in-memory changes were discarded.
- **Drops board + clears state**: `self.board = None` propagated to every command handler via `_update_command_handlers()`, plus `ipc_board_api`, the session-backend pin (`session_backend` / `session_board_path`, #223), the disk signature, auto-save status, and project paths — returning the interface to its fresh `__init__` no-project state.
- **Idempotent**: closing with nothing loaded returns `success: true` with `closed: false`.

## Changes

- **`python/kicad_interface.py`** — new `_handle_close_project` + `_clear_project_state` helper; registered `close_project` in `command_routes`.
- **`src/tools/project.ts`** — `close_project` MCP tool with optional `save` boolean.
- **`src/tools/registry.ts`** — added `close_project` to `directToolNames` (project lifecycle).
- **`python/schemas/tool_schemas.py`** — `PROJECT_TOOLS` schema entry.
- **`tests/test_close_project.py`** — 5 unit tests (idempotent no-op, save-and-clear, `save=false` warns on a dirty board, save-failure refuses to close, save-exception refuses to close).
- **`CHANGELOG.md`** — New MCP Tools entry.

### Incidental: a pre-existing mypy blocker on `kicad_interface.py`

While committing I hit a **pre-existing** mypy failure that reproduces on untouched `main` and blocks *any* commit touching `kicad_interface.py` (the pre-commit hook forbids `--no-verify`, and CI runs the same mypy):

```
python/commands/schematic_handlers.py:2642: error: Cannot determine type of "board"  [has-type]
python/commands/schematic_handlers.py:2643: error: Cannot determine type of "board"  [has-type]
```

`SchematicHandlersMixin` reads `self.board`, but `board` is only defined on the concrete `KiCADInterface`; when mypy follows the import into the mixin it hits an attribute-resolution cycle. I added a type-check-time-only declaration (`if TYPE_CHECKING: board: Any`) to the mixin — no runtime effect — which is exactly the contract the mixin's own module docstring already describes ("every `self.board` … is supplied by the interface"). Happy to split this into its own PR if you'd prefer it separate.

## Testing

```
pytest tests/test_close_project.py --timeout=60 --timeout-method=thread   # 5 passed
npm run build                                                             # clean
npm run test:ts                                                           # 24 passed
```

All pre-commit hooks (black, isort, prettier, flake8, mypy, eslint) pass.

## Notes

`close_project` saves via the SWIG `save_project` path (the in-memory board the MCP owns), consistent with how `save_project` behaves for SWIG-pinned sessions.
