### PR TITLE
fix: locate pins against their own unit for multi-unit symbols (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,22 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **Pin locations respect the owning unit of multi-unit symbols** (#239):
+  `get_schematic_pin_locations` / `get_pin_location` located every pin against
+  whichever placed `(symbol)` instance appeared first in file order, so for a
+  multi-unit part (e.g. a dual op-amp placed as separate units at different
+  positions) all pins collapsed onto that one unit's coordinates. Pins are now
+  tagged with their owning unit while parsing `lib_symbols` (the
+  `<name>_<unit>_<body>` sub-symbol), and each pin is located against the placed
+  instance carrying the matching `(unit N)` — with rotation/mirror read from that
+  same instance. Single-unit parts are unaffected (they fall back to the first
+  instance as before).
+
 - **Fallback schematic writer emits the KiCad 10 header** (#221, partial): the
   template-missing fallback in `create_schematic` and `create_project` wrote the
   stale KiCad 9 header `(version 20250114) (generator "KiCAD-MCP-Server")`. It
   now writes `(version 20260306) (generator "eeschema") (generator_version
-  "10.0")`, matching what eeschema writes for a new file. This covers only the
+"10.0")`, matching what eeschema writes for a new file. This covers only the
   fallback path; the main templates (which still carry the KiCad 9 version and
   the `_TEMPLATE_*` clone-source instances used by `add_schematic_component`)
   are tracked separately because rewriting them touches the component-cloning

--- a/python/commands/pin_locator.py
+++ b/python/commands/pin_locator.py
@@ -7,6 +7,7 @@ Uses S-expression parsing to extract pin data from symbol definitions.
 
 import logging
 import math
+import re
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -44,10 +45,25 @@ class PinLocator:
         """
         pins: Dict[str, Dict[str, Any]] = {}
 
-        def extract_pins_recursive(sexp: Any) -> None:
-            """Recursively search for pin definitions"""
+        # Sub-symbols in lib_symbols are named "<name>_<unit>_<bodystyle>", e.g.
+        # "NE5532_1_1" (unit 1), "NE5532_2_1" (unit 2), "NE5532_0_1" (unit 0 =
+        # common to every unit). Pins live inside these sub-symbols, so the pin's
+        # owning unit is the first index in the enclosing sub-symbol name. We track
+        # it while recursing so each pin can later be matched to the placed
+        # instance for that unit — without this, every pin inherits the first
+        # instance's position (issue #239).
+        unit_name_re = re.compile(r"_(\d+)_(\d+)$")
+
+        def extract_pins_recursive(sexp: Any, current_unit: int) -> None:
+            """Recursively search for pin definitions, tracking the enclosing unit."""
             if not isinstance(sexp, list):
                 return
+
+            # Descend into a unit sub-symbol: update the unit context for its pins.
+            if len(sexp) > 1 and sexp[0] == Symbol("symbol") and isinstance(sexp[1], (str, Symbol)):
+                m = unit_name_re.search(str(sexp[1]).strip('"'))
+                if m:
+                    current_unit = int(m.group(1))
 
             # Check if this is a pin definition
             if len(sexp) > 0 and sexp[0] == Symbol("pin"):
@@ -59,6 +75,7 @@ class PinLocator:
                     "length": 0,
                     "name": "",
                     "number": "",
+                    "unit": current_unit,
                     "type": str(sexp[1]) if len(sexp) > 1 else "passive",
                 }
 
@@ -96,12 +113,14 @@ class PinLocator:
                     if existing is None or pin_data["length"] > existing["length"]:
                         pins[pin_data["number"]] = pin_data
 
-            # Recurse into sublists
+            # Recurse into sublists, propagating the current unit context.
             for item in sexp:
                 if isinstance(item, list):
-                    extract_pins_recursive(item)
+                    extract_pins_recursive(item, current_unit)
 
-        extract_pins_recursive(symbol_def)
+        # Unit 0 = "common to all units"; used as the starting context so pins in
+        # symbols without a unit suffix (single-unit parts) fall back sensibly.
+        extract_pins_recursive(symbol_def, 0)
         return pins
 
     def get_symbol_pins(self, schematic_path: Path, lib_id: str) -> Dict[str, Dict]:
@@ -230,12 +249,18 @@ class PinLocator:
         return None
 
     def _get_symbol_transform(
-        self, schematic_path: Path, symbol_reference: str
+        self, schematic_path: Path, symbol_reference: str, unit: Optional[int] = None
     ) -> Optional[Tuple[float, float, float, bool, bool, str]]:
         """
         Read symbol position, rotation, mirror flags, and lib_id directly from the
         .kicad_sch file via sexpdata (authoritative — not kicad-skip cache, which
         does not reflect mirror/rotation changes made by rotate_schematic_component).
+
+        A multi-unit component is placed as several ``(symbol ...)`` instances that
+        share one reference but each carry their own ``(unit N)``, position, and
+        rotation. When ``unit`` is given, return the transform of the instance for
+        that unit; otherwise (or if that unit is not placed) return the first
+        instance, preserving the original single-unit behaviour.
 
         Returns (x, y, rotation, mirror_x, mirror_y, lib_id) or None.
         """
@@ -251,12 +276,75 @@ class PinLocator:
             logger.error(f"_get_symbol_transform: failed to parse {schematic_path}: {e}")
             return None
 
-        found = WireDragger.find_symbol(self._sexp_cache[sch_key], symbol_reference)
+        sch_data = self._sexp_cache[sch_key]
+
+        # Unit 0 ("common") pins are drawn on every unit and are not tied to a
+        # specific placed instance, so treat them like the default (first instance).
+        if unit:
+            found = self._find_symbol_instance_for_unit(sch_data, symbol_reference, unit)
+            if found is not None:
+                sym_x, sym_y, rotation, lib_id, mirror_x, mirror_y = found
+                return sym_x, sym_y, rotation, mirror_x, mirror_y, lib_id
+
+        found = WireDragger.find_symbol(sch_data, symbol_reference)
         if found is None:
             return None
 
         _, sym_x, sym_y, rotation, lib_id, mirror_x, mirror_y = found
         return sym_x, sym_y, rotation, mirror_x, mirror_y, lib_id
+
+    @staticmethod
+    def _find_symbol_instance_for_unit(
+        sch_data: list, reference: str, unit: int
+    ) -> Optional[Tuple[float, float, float, str, bool, bool]]:
+        """
+        Find the placed ``(symbol ...)`` instance for ``reference`` whose ``(unit N)``
+        equals ``unit``. Mirrors WireDragger.find_symbol's parsing (including the
+        trailing-underscore tolerance on the Reference property) but keys on unit.
+
+        Returns (x, y, rotation, lib_id, mirror_x, mirror_y) or None if no instance
+        with that unit exists.
+        """
+        for item in sch_data:
+            if not (isinstance(item, list) and item and item[0] == Symbol("symbol")):
+                continue
+
+            ref_val = None
+            inst_unit = None
+            x = y = rotation = 0.0
+            lib_id = ""
+            mirror_x = mirror_y = False
+
+            for sub in item[1:]:
+                if not (isinstance(sub, list) and sub):
+                    continue
+                tag = sub[0]
+                if tag == Symbol("property") and len(sub) >= 3:
+                    if str(sub[1]).strip('"') == "Reference":
+                        ref_val = str(sub[2]).strip('"')
+                elif tag == Symbol("at"):
+                    if len(sub) >= 3:
+                        x = float(sub[1])
+                        y = float(sub[2])
+                    if len(sub) >= 4:
+                        rotation = float(sub[3])
+                elif tag == Symbol("unit") and len(sub) >= 2:
+                    inst_unit = int(sub[1])
+                elif tag == Symbol("lib_id") and len(sub) >= 2:
+                    lib_id = str(sub[1]).strip('"')
+                elif tag == Symbol("mirror") and len(sub) >= 2:
+                    mv = str(sub[1])
+                    if mv == "x":
+                        mirror_x = True
+                    elif mv == "y":
+                        mirror_y = True
+
+            if ref_val is None or ref_val.rstrip("_") != reference:
+                continue
+            if inst_unit == unit:
+                return x, y, rotation, lib_id, mirror_x, mirror_y
+
+        return None
 
     def get_pin_angle(
         self, schematic_path: Path, symbol_reference: str, pin_number: str
@@ -288,6 +376,17 @@ class PinLocator:
                     pin_number = matched_num
                 else:
                     return None
+
+            # Use the transform of the instance for this pin's unit (a multi-unit
+            # part places each unit separately, possibly rotated/mirrored on its
+            # own), falling back to the first instance for common/single units.
+            pin_unit = pins[pin_number].get("unit")
+            if pin_unit:
+                unit_transform = self._get_symbol_transform(
+                    schematic_path, symbol_reference, pin_unit
+                )
+                if unit_transform is not None:
+                    _, _, symbol_rotation, mirror_x, mirror_y, _ = unit_transform
 
             pin_def_angle = pins[pin_number].get("angle", 0)
 
@@ -394,6 +493,26 @@ class PinLocator:
                     return None
 
             pin_data = pins[pin_number]
+
+            # For a multi-unit component, the pin belongs to a specific unit that
+            # is placed as its own instance at its own position/rotation. Re-read
+            # the transform for that unit so the pin is located against the correct
+            # instance instead of whichever unit happened to appear first (#239).
+            pin_unit = pin_data.get("unit")
+            if pin_unit:
+                unit_transform = self._get_symbol_transform(
+                    schematic_path, symbol_reference, pin_unit
+                )
+                if unit_transform is not None:
+                    (
+                        symbol_x,
+                        symbol_y,
+                        symbol_rotation,
+                        mirror_x,
+                        mirror_y,
+                        _,
+                    ) = unit_transform
+
             from commands.wire_dragger import WireDragger
 
             abs_x, abs_y = WireDragger.pin_world_xy(

--- a/tests/test_pin_locator_multi_unit.py
+++ b/tests/test_pin_locator_multi_unit.py
@@ -1,0 +1,162 @@
+"""
+Regression tests for issue #239:
+
+    get_schematic_pin_locations returns wrong coordinates for multi-unit components
+
+A multi-unit part (e.g. a dual op-amp) is placed as several ``(symbol ...)``
+instances that share one reference designator but each carry their own
+``(unit N)``, position and rotation. The pins for unit N live in the
+``<name>_N_<body>`` sub-symbol inside ``lib_symbols``.
+
+The bug: every pin was located against whichever instance appeared first in
+file order, so all pins collapsed onto that one unit's position. These tests
+place a 2-unit symbol at two distinct positions and assert each pin resolves
+against the instance for its own unit.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+PYTHON_DIR = Path(__file__).parent.parent / "python"
+sys.path.insert(0, str(PYTHON_DIR))
+
+
+# A minimal but valid schematic with one 2-unit symbol "TEST:DualAmp":
+#   unit 1 (pins 1,2,3) placed at (100, 100)
+#   unit 2 (pins 5,6,7) placed at (100, 150)
+# Pin library Y offsets are distinct per pin so a mislocated pin is obvious.
+MULTI_UNIT_SCH = """\
+(kicad_sch (version 20250114) (generator "test")
+  (uuid 00000000-0000-0000-0000-0000000000aa)
+  (paper "A4")
+  (lib_symbols
+    (symbol "TEST:DualAmp" (pin_names (offset 0)) (in_bom yes) (on_board yes)
+      (property "Reference" "U" (at 0 0 0))
+      (property "Value" "DualAmp" (at 0 0 0))
+      (symbol "DualAmp_1_1"
+        (pin input line (at 0 5.08 270) (length 2.54)
+          (name "+" (effects (font (size 1.27 1.27))))
+          (number "1" (effects (font (size 1.27 1.27))))
+        )
+        (pin input line (at 0 -5.08 90) (length 2.54)
+          (name "-" (effects (font (size 1.27 1.27))))
+          (number "2" (effects (font (size 1.27 1.27))))
+        )
+        (pin output line (at 7.62 0 180) (length 2.54)
+          (name "~" (effects (font (size 1.27 1.27))))
+          (number "3" (effects (font (size 1.27 1.27))))
+        )
+      )
+      (symbol "DualAmp_2_1"
+        (pin input line (at 0 5.08 270) (length 2.54)
+          (name "+" (effects (font (size 1.27 1.27))))
+          (number "5" (effects (font (size 1.27 1.27))))
+        )
+        (pin input line (at 0 -5.08 90) (length 2.54)
+          (name "-" (effects (font (size 1.27 1.27))))
+          (number "6" (effects (font (size 1.27 1.27))))
+        )
+        (pin output line (at 7.62 0 180) (length 2.54)
+          (name "~" (effects (font (size 1.27 1.27))))
+          (number "7" (effects (font (size 1.27 1.27))))
+        )
+      )
+    )
+  )
+  (symbol (lib_id "TEST:DualAmp") (at 100 100 0) (unit 1)
+    (uuid 00000000-0000-0000-0000-000000000001)
+    (property "Reference" "U1" (at 100 90 0))
+    (property "Value" "DualAmp" (at 100 110 0))
+  )
+  (symbol (lib_id "TEST:DualAmp") (at 100 150 0) (unit 2)
+    (uuid 00000000-0000-0000-0000-000000000002)
+    (property "Reference" "U1" (at 100 140 0))
+    (property "Value" "DualAmp" (at 100 160 0))
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+@pytest.fixture()
+def multi_unit_sch():
+    with tempfile.TemporaryDirectory() as tmp:
+        sch_path = Path(tmp) / "multi_unit.kicad_sch"
+        sch_path.write_text(MULTI_UNIT_SCH, encoding="utf-8")
+        yield sch_path
+
+
+@pytest.mark.integration
+class TestParseSymbolDefinitionUnits:
+    """parse_symbol_definition must tag each pin with its owning unit."""
+
+    def test_pins_carry_their_unit(self):
+        import sexpdata
+        from commands.pin_locator import PinLocator
+        from sexpdata import Symbol
+
+        sch_data = sexpdata.loads(MULTI_UNIT_SCH)
+        lib_symbols = next(
+            item
+            for item in sch_data
+            if isinstance(item, list) and item and item[0] == Symbol("lib_symbols")
+        )
+        sym_def = next(
+            item
+            for item in lib_symbols[1:]
+            if isinstance(item, list) and str(item[1]).strip('"') == "TEST:DualAmp"
+        )
+
+        pins = PinLocator.parse_symbol_definition(sym_def)
+
+        assert pins["1"]["unit"] == 1
+        assert pins["2"]["unit"] == 1
+        assert pins["3"]["unit"] == 1
+        assert pins["5"]["unit"] == 2
+        assert pins["6"]["unit"] == 2
+        assert pins["7"]["unit"] == 2
+
+
+@pytest.mark.integration
+class TestMultiUnitPinLocations:
+    """Each pin resolves against the placed instance for its own unit (#239)."""
+
+    def test_unit1_pin_uses_unit1_position(self, multi_unit_sch):
+        from commands.pin_locator import PinLocator
+
+        loc = PinLocator().get_pin_location(multi_unit_sch, "U1", "1")
+
+        assert loc is not None
+        # Unit 1 sits at y=100; pin lib-y +5.08 flips to screen -> 100 - 5.08.
+        assert loc[0] == pytest.approx(100.0)
+        assert loc[1] == pytest.approx(94.92)
+
+    def test_unit2_pin_uses_unit2_position_not_first_instance(self, multi_unit_sch):
+        from commands.pin_locator import PinLocator
+
+        loc = PinLocator().get_pin_location(multi_unit_sch, "U1", "5")
+
+        assert loc is not None
+        # Unit 2 sits at y=150. The bug reported it near unit 1 (~94.92); it must
+        # now track unit 2's instance: 150 - 5.08 = 144.92.
+        assert loc[1] == pytest.approx(144.92)
+        assert loc[1] != pytest.approx(94.92)
+
+    def test_all_pins_split_across_the_two_units(self, multi_unit_sch):
+        from commands.pin_locator import PinLocator
+
+        pins = PinLocator().get_all_symbol_pins(multi_unit_sch, "U1")
+
+        # Unit 1 pins cluster around y=100, unit 2 pins around y=150.
+        assert pins["1"][1] == pytest.approx(94.92)
+        assert pins["2"][1] == pytest.approx(105.08)
+        assert pins["5"][1] == pytest.approx(144.92)
+        assert pins["6"][1] == pytest.approx(155.08)
+        # The output pins (pin lib-y 0) sit exactly at each unit's center y.
+        assert pins["3"][1] == pytest.approx(100.0)
+        assert pins["7"][1] == pytest.approx(150.0)


### PR DESCRIPTION
## Summary

Fixes #239 — `get_schematic_pin_locations` / `get_pin_location` returned wrong
coordinates for multi-unit components.

A multi-unit part (e.g. an `NE5532` dual op-amp) is placed as several
`(symbol ...)` instances that share one reference designator but each carry
their own `(unit N)`, position, and rotation. The pins for unit N live in the
`<name>_<unit>_<body>` sub-symbol inside `lib_symbols`.

The locator ignored units entirely: it looked up the symbol transform with
`WireDragger.find_symbol`, which returns the **first** `(symbol)` instance in
file order, and applied that single position to every pin. So for the three-unit
NE5532 in the issue — units at y=175, y=210, y=245 — every pin came back near
y≈245 because the power unit happened to be written first.

## Fix (all in `python/commands/pin_locator.py`)

1. **Tag each pin with its owning unit.** `parse_symbol_definition` now tracks
   the enclosing sub-symbol while recursing and records `pin_data["unit"]` from
   the `_<unit>_<body>` suffix (unit 0 = "common to all units", used as the
   default context so single-unit parts are unchanged).
2. **Locate each pin against its unit's placed instance.** `_get_symbol_transform`
   takes an optional `unit`; a new `_find_symbol_instance_for_unit` helper scans
   the placed `(symbol)` instances and returns the one whose `(unit N)` matches
   (same Reference parsing and trailing-`_` tolerance as `find_symbol`).
   `get_pin_location` and `get_pin_angle` resolve the pin's unit and re-read the
   transform for that instance, so position **and** rotation/mirror come from the
   correct unit. If a unit isn't placed (or the pin is unit 0), it falls back to
   the first instance — preserving the original single-unit behaviour.

## Tests

New `tests/test_pin_locator_multi_unit.py` places a 2-unit symbol at two
distinct positions and asserts:

- `parse_symbol_definition` tags pins 1–3 as unit 1 and pins 5–7 as unit 2;
- unit-1 pins resolve against the unit-1 instance and unit-2 pins against the
  unit-2 instance (explicitly checking a unit-2 pin is **not** at the unit-1
  position, the exact failure in #239).

```
pytest tests/test_pin_locator_multi_unit.py                 # 4 passed
pytest tests/test_pin_locator_and_component.py \
       tests/test_pin_locator_y_flip.py \
       tests/test_pin_locator_duplicate_pin_defs.py \
       tests/test_get_pin_angle.py \
       tests/test_net_label_pin_snapping.py                 # no regressions
```

Single-unit parts are unaffected; the change is additive (`pin_data` gains a
`unit` key) and the default lookup path is unchanged when no unit is requested.
