### PR TITLE
Fail fast on concurrent calls (no more apparent freezes) + fix IPC socket fd leak

### DIFF
--- a/python/kicad_api/ipc_backend.py
+++ b/python/kicad_api/ipc_backend.py
@@ -133,8 +133,22 @@ class IPCBackend(KiCADBackend):
             return "unknown"
 
     def disconnect(self) -> None:
-        """Disconnect from KiCAD."""
+        """Disconnect from KiCAD.
+
+        kipy does not expose a public close(), but it holds a persistent pynng
+        socket at ``KiCad._client._conn``. Simply dropping the reference orphans
+        that socket and leaks its OS file descriptors (they are not released
+        promptly by GC), so long-lived sessions that reconnect accumulate fds.
+        Close the underlying socket explicitly, tolerating any internal changes.
+        """
         if self._kicad:
+            try:
+                conn = getattr(getattr(self._kicad, "_client", None), "_conn", None)
+                if conn is not None and hasattr(conn, "close"):
+                    conn.close()
+                    logger.debug("Closed underlying KiCAD IPC socket")
+            except Exception as e:
+                logger.debug(f"Error closing IPC socket during disconnect: {e}")
             self._kicad = None
             self._connected = False
             logger.info("Disconnected from KiCAD IPC")

--- a/src/server.ts
+++ b/src/server.ts
@@ -229,6 +229,10 @@ export class KiCADMcpServer {
     reject: Function;
   }> = [];
   private processingRequest = false;
+  /** Name of the command currently being processed by the Python bridge (for busy diagnostics). */
+  private inFlightCommand: string | null = null;
+  /** Epoch ms when the in-flight command started (for busy diagnostics). */
+  private inFlightStartedAt: number | null = null;
   private responseBuffer: string = "";
   private currentRequestHandler: {
     resolve: Function;
@@ -673,17 +677,23 @@ export class KiCADMcpServer {
         this.responseBuffer = "";
         this.processingRequest = false;
         this.currentRequestHandler = null;
+        this.inFlightCommand = null;
+        this.inFlightStartedAt = null;
         resolve();
       }, timeoutMs);
 
       // Use the existing request infrastructure to avoid race conditions
       // with the persistent stdout handler.
       this.processingRequest = true;
+      this.inFlightCommand = "startup warm-up (pcbnew/wxApp initialization)";
+      this.inFlightStartedAt = Date.now();
       this.currentRequestHandler = {
         resolve: (result: any) => {
           clearTimeout(timeoutHandle);
           this.processingRequest = false;
           this.currentRequestHandler = null;
+          this.inFlightCommand = null;
+          this.inFlightStartedAt = null;
           if (result?.success) {
             logger.info(
               `Warm-up succeeded: pcbnew ${result.version} (${result.elapsed_s}s)`
@@ -699,6 +709,8 @@ export class KiCADMcpServer {
           clearTimeout(timeoutHandle);
           this.processingRequest = false;
           this.currentRequestHandler = null;
+          this.inFlightCommand = null;
+          this.inFlightStartedAt = null;
           logger.warn(`Warm-up failed: ${err.message} — continuing`);
           resolve(); // don't fail the whole server
         },
@@ -722,6 +734,34 @@ export class KiCADMcpServer {
       if (!this.pythonProcess) {
         logger.error("Python process is not running");
         reject(new Error("Python process for KiCAD scripting is not running"));
+        return;
+      }
+
+      // Fail fast if an operation is already in progress. The KiCAD bridge is
+      // single-threaded: commands are serialized over one stdio connection and
+      // one IPC socket, so a concurrent call would otherwise sit silently in the
+      // queue — potentially for minutes behind a slow export/DRC — and look like
+      // a freeze to the caller. Surface it as an actionable error instead so the
+      // agent knows to wait for the current operation and retry sequentially.
+      if (this.processingRequest) {
+        const running = this.inFlightCommand ?? "another operation";
+        const elapsedS =
+          this.inFlightStartedAt !== null
+            ? Math.round((Date.now() - this.inFlightStartedAt) / 1000)
+            : null;
+        const elapsedStr = elapsedS !== null ? ` (running for ${elapsedS}s)` : "";
+        logger.warn(
+          `Rejecting "${command}" — busy with "${running}"${elapsedStr}`,
+        );
+        reject(
+          new Error(
+            `KiCAD MCP server is busy: still processing "${running}"${elapsedStr}. ` +
+              `This server handles ONE KiCAD operation at a time — commands are serialized ` +
+              `over a single connection to KiCAD. Do not issue KiCAD tool calls in parallel; ` +
+              `wait for the in-flight operation to finish, then retry "${command}". ` +
+              `Exports, DRC, and schematic sync can take a while on large designs.`,
+          ),
+        );
         return;
       }
 
@@ -870,6 +910,8 @@ export class KiCADMcpServer {
     this.responseBuffer = "";
     this.currentRequestHandler = null;
     this.processingRequest = false;
+    this.inFlightCommand = null;
+    this.inFlightStartedAt = null;
 
     // Resolve the promise with the result
     handler.resolve(result);
@@ -893,6 +935,10 @@ export class KiCADMcpServer {
     // Get the next request
     const { request, resolve, reject } = this.requestQueue.shift()!;
 
+    // Record in-flight command for busy diagnostics
+    this.inFlightCommand = request.command;
+    this.inFlightStartedAt = Date.now();
+
     try {
       logger.debug(`Processing KiCAD command: ${request.command}`);
 
@@ -912,6 +958,8 @@ export class KiCADMcpServer {
         this.responseBuffer = "";
         this.currentRequestHandler = null;
         this.processingRequest = false;
+        this.inFlightCommand = null;
+        this.inFlightStartedAt = null;
 
         // Reject the promise
         reject(new Error(`Command timeout after ${timeoutDuration / 1000}s: ${request.command}`));
@@ -932,6 +980,8 @@ export class KiCADMcpServer {
       // Reset processing flag
       this.processingRequest = false;
       this.currentRequestHandler = null;
+      this.inFlightCommand = null;
+      this.inFlightStartedAt = null;
 
       // Process next request
       setTimeout(() => this.processNextRequest(), 0);


### PR DESCRIPTION
## Problem

The KiCAD bridge is single-threaded — commands are serialized over one stdio connection and one IPC socket (`callKicadScript` → `requestQueue` → `processNextRequest`). When an operation is already in flight, a second concurrent tool call sits **silently in the queue** behind it, potentially for up to the 10-minute long-op timeout used by `export_*`, `run_drc`, and `sync_schematic_to_board`. With no feedback, this presents to MCP clients as a **frozen server**.

This is easy to hit in practice: LLM agents frequently batch multiple tool calls in a single turn, which the MCP client dispatches concurrently. The first slow call blocks all siblings, and the agent reports "the MCP froze."

Separately, `IPCBackend.disconnect()` leaks file descriptors: it dropped the kipy `KiCad` reference without closing the underlying `pynng` socket. Long-lived sessions that reconnect accumulate fds (observed a bridge climb past 20+ open sockets over a session).

## Changes

**1. Fail fast with an actionable error on concurrent calls.** When an operation is in flight, new commands are rejected immediately instead of queueing indefinitely. The error explains that the server is serialized, names the in-flight command and how long it has been running, and tells the caller to wait and retry sequentially:

> KiCAD MCP server is busy: still processing "export_gerber" (running for 42s). This server handles ONE KiCAD operation at a time — commands are serialized over a single connection to KiCad. Do not issue KiCAD tool calls in parallel; wait for the in-flight operation to finish, then retry "get_board_info". Exports, DRC, and schematic sync can take a while on large designs.

An agent that receives this backs off and serializes its calls, instead of hanging. The startup warm-up is labeled (`startup warm-up (...)`) so calls during that brief window get an accurate message too.

**2. Close the IPC socket on disconnect.** kipy exposes no public `close()`, but holds a persistent `pynng` socket at `KiCad._client._conn`. `disconnect()` now closes it explicitly, guarded with `getattr`/try-except so it degrades gracefully if kipy internals change.

## Verification

- **Concurrency:** fired two concurrent `get_backend_state` calls at a fresh server over raw MCP stdio — one succeeds, the other returns the busy error naming the in-flight command. Sequential calls are unaffected (the first resolves before the second is issued, so the guard never trips).
- **fd leak:** ran 10 connect/disconnect cycles — fds stay flat (delta +2 from baseline, stable) vs. growing ~3 per cycle before the fix.

## Note / possible follow-up

The 10-minute blocking behavior of long ops is architectural (serialized stdio). This PR makes it *visible and non-hanging* rather than eliminating it. A future change could run long exports without holding the request loop (e.g. a job/poll model) so unrelated queries stay responsive during a big export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)