### PR TITLE
Rasterize schematic view with cairosvg so renders fit inline size caps

### DIFF
--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -22,7 +22,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pcbnew
 import sexpdata
-
 from commands.library_schematic import LibraryManager as SchematicLibraryManager
 from commands.schematic import SchematicManager
 from commands.wire_manager import WireManager
@@ -31,16 +30,34 @@ logger = logging.getLogger("kicad_interface")
 
 
 def _svg_to_png(svg_path: str, width: int, height: int) -> Optional[bytes]:
-    """Convert SVG to PNG. No cffi dependency.
+    """Convert SVG to PNG at the requested pixel dimensions.
 
     Priority:
-      1. pymupdf (fitz) — bundled MuPDF renderer, pure Python, no system deps
-      2. Inkscape CLI — accurate KiCAD SVG rendering
-      3. ImageMagick convert — broad availability fallback
+      1. cairosvg — the declared dependency (see requirements.txt); honors
+         output_width/output_height and reliably rasterizes KiCAD SVGs.
+      2. pymupdf (fitz) — bundled MuPDF renderer, if installed.
+      3. Inkscape CLI — accurate KiCAD SVG rendering, if installed.
+      4. ImageMagick convert — broad availability fallback.
     Returns PNG bytes or None if all converters fail.
+
+    Rasterizing here is essential: returning the raw KiCAD SVG instead
+    produces a full-sheet vector document (title block, grid, every path
+    and font) whose text easily exceeds an MCP client's inline size cap,
+    and width/height have no effect on it.
     """
     import subprocess
     import tempfile
+
+    try:
+        import cairosvg
+
+        return cairosvg.svg2png(
+            url=svg_path,
+            output_width=int(width),
+            output_height=int(height),
+        )
+    except Exception:
+        pass
 
     try:
         import fitz

--- a/tests/test_svg_to_png_render.py
+++ b/tests/test_svg_to_png_render.py
@@ -1,0 +1,74 @@
+"""Tests for ``_svg_to_png`` used by ``get_schematic_view``.
+
+Regression guard for the bug where the converter chain (pymupdf → inkscape
+→ ImageMagick) had no available backend on a stock install, so the function
+returned ``None`` and the handler silently fell back to emitting the raw
+full-sheet SVG — which ignores width/height and blows past MCP clients'
+inline size cap. cairosvg is a declared dependency and must be used.
+
+conftest.py pre-installs a MagicMock for ``pcbnew`` so the module imports
+without a real KiCAD install.
+"""
+
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.unit
+
+from commands.schematic_handlers import _svg_to_png  # noqa: E402
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+SAMPLE_SVG = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="80mm" '
+    'viewBox="0 0 100 80">'
+    '<rect x="10" y="10" width="60" height="40" fill="none" stroke="black" '
+    'stroke-width="1"/>'
+    '<line x1="10" y1="30" x2="70" y2="30" stroke="black" stroke-width="0.5"/>'
+    "</svg>"
+)
+
+
+def _png_dimensions(png: bytes) -> tuple[int, int]:
+    """Read width/height from a PNG's IHDR chunk (bytes 16:24, big-endian)."""
+    width, height = struct.unpack(">II", png[16:24])
+    return width, height
+
+
+@pytest.fixture()
+def svg_file(tmp_path: Path) -> str:
+    path = tmp_path / "sample.svg"
+    path.write_text(SAMPLE_SVG, encoding="utf-8")
+    return str(path)
+
+
+def test_returns_png_bytes_not_none(svg_file: str) -> None:
+    """A converter must be available on a stock install (cairosvg) — never None."""
+    png = _svg_to_png(svg_file, 200, 150)
+    assert png is not None, "no SVG->PNG converter available; would fall back to oversized SVG"
+    assert png.startswith(PNG_MAGIC)
+
+
+def test_honors_requested_dimensions(svg_file: str) -> None:
+    """width/height must control the raster size (they were previously ignored)."""
+    png = _svg_to_png(svg_file, 200, 150)
+    assert png is not None
+    assert _png_dimensions(png) == (200, 150)
+
+    smaller = _svg_to_png(svg_file, 80, 60)
+    assert smaller is not None
+    assert _png_dimensions(smaller) == (80, 60)
+
+
+def test_smaller_dimensions_shrink_payload(svg_file: str) -> None:
+    """Shrinking dimensions must shrink the payload — the core promise to callers."""
+    big = _svg_to_png(svg_file, 1200, 900)
+    small = _svg_to_png(svg_file, 300, 225)
+    assert big is not None and small is not None
+    assert len(small) < len(big)


### PR DESCRIPTION
## Problem

`get_schematic_view` / `get_schematic_view_region` can't produce an image under an MCP client's inline cap (~1MB), and `width`/`height` have no effect on the payload.

Root cause in `_svg_to_png` (`python/commands/schematic_handlers.py`): it tries pymupdf → inkscape → ImageMagick, **none of which are declared dependencies**. On a stock install the only image library present is **cairosvg** (which *is* in `requirements.txt`), so every converter fails, `_svg_to_png` returns `None`, and the handler silently falls back to returning the raw full-sheet SVG as text — a complete page (title block, grid, every path/font) that routinely exceeds 1MB and, being vector, ignores width/height.

## Change

Use **cairosvg** as the primary converter (already a declared dependency; honors `output_width`/`output_height`). pymupdf/inkscape/convert remain as fallbacks. Adds `tests/test_svg_to_png_render.py` covering: returns PNG (not None), honors requested dimensions, and smaller dimensions shrink the payload.

| Output | base64 size |
|---|---|
| Raw SVG (old fallback) | multi-MB, ignores width/height |
| cairosvg PNG @ 1200x900 | ~0.020 MB |
| cairosvg PNG @ 800x600 | ~0.012 MB |

## Testing / notes

New test passes; lint clean (Black/isort). Note: `mypy` reports a **pre-existing** `has-type` error on unrelated board-loading code in this file (present on `main`); left untouched to keep this PR single-purpose. Some other schematic tests hang/error in a KiCad-less environment on `main` too — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)