### PR TITLE
Fail fast with a clear error when a KiCAD operation is already in flight

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -229,6 +229,10 @@ export class KiCADMcpServer {
     reject: Function;
   }> = [];
   private processingRequest = false;
+  /** Name of the command currently being processed by the Python bridge (for busy diagnostics). */
+  private inFlightCommand: string | null = null;
+  /** Epoch ms when the in-flight command started (for busy diagnostics). */
+  private inFlightStartedAt: number | null = null;
   private responseBuffer: string = "";
   private currentRequestHandler: {
     resolve: Function;
@@ -600,7 +604,6 @@ export class KiCADMcpServer {
       await this.runWarmup(120_000);
       logger.info("Warm-up complete — pcbnew/wxApp initialised");
 
-
       // Write a ready message to stderr (for debugging)
       process.stderr.write("KiCAD MCP SERVER READY\n");
 
@@ -634,14 +637,14 @@ export class KiCADMcpServer {
   private async waitForReady(timeoutMs: number): Promise<void> {
     return new Promise((_resolve, reject) => {
       const timeout = setTimeout(() => {
-        reject(new Error(
-          `Python process did not send READY within ${timeoutMs / 1000} s`
-        ));
+        reject(new Error(`Python process did not send READY within ${timeoutMs / 1000} s`));
       }, timeoutMs);
-      this.readyPromise.then(() => {
-        clearTimeout(timeout);
-        _resolve();
-      }).catch(reject);
+      this.readyPromise
+        .then(() => {
+          clearTimeout(timeout);
+          _resolve();
+        })
+        .catch(reject);
     });
   }
 
@@ -668,30 +671,32 @@ export class KiCADMcpServer {
       const timeoutHandle = setTimeout(() => {
         logger.warn(
           `Warm-up timed out after ${timeoutMs / 1000} s — ` +
-          "continuing without full initialisation"
+            "continuing without full initialisation",
         );
         this.responseBuffer = "";
         this.processingRequest = false;
         this.currentRequestHandler = null;
+        this.inFlightCommand = null;
+        this.inFlightStartedAt = null;
         resolve();
       }, timeoutMs);
 
       // Use the existing request infrastructure to avoid race conditions
       // with the persistent stdout handler.
       this.processingRequest = true;
+      this.inFlightCommand = "startup warm-up (pcbnew/wxApp initialization)";
+      this.inFlightStartedAt = Date.now();
       this.currentRequestHandler = {
         resolve: (result: any) => {
           clearTimeout(timeoutHandle);
           this.processingRequest = false;
           this.currentRequestHandler = null;
+          this.inFlightCommand = null;
+          this.inFlightStartedAt = null;
           if (result?.success) {
-            logger.info(
-              `Warm-up succeeded: pcbnew ${result.version} (${result.elapsed_s}s)`
-            );
+            logger.info(`Warm-up succeeded: pcbnew ${result.version} (${result.elapsed_s}s)`);
           } else {
-            logger.warn(
-              `Warm-up returned failure: ${result?.message || "unknown"} — continuing`
-            );
+            logger.warn(`Warm-up returned failure: ${result?.message || "unknown"} — continuing`);
           }
           resolve();
         },
@@ -699,6 +704,8 @@ export class KiCADMcpServer {
           clearTimeout(timeoutHandle);
           this.processingRequest = false;
           this.currentRequestHandler = null;
+          this.inFlightCommand = null;
+          this.inFlightStartedAt = null;
           logger.warn(`Warm-up failed: ${err.message} — continuing`);
           resolve(); // don't fail the whole server
         },
@@ -722,6 +729,32 @@ export class KiCADMcpServer {
       if (!this.pythonProcess) {
         logger.error("Python process is not running");
         reject(new Error("Python process for KiCAD scripting is not running"));
+        return;
+      }
+
+      // Fail fast if an operation is already in progress. The KiCAD bridge is
+      // single-threaded: commands are serialized over one stdio connection and
+      // one IPC socket, so a concurrent call would otherwise sit silently in the
+      // queue — potentially for minutes behind a slow export/DRC — and look like
+      // a freeze to the caller. Surface it as an actionable error instead so the
+      // agent knows to wait for the current operation and retry sequentially.
+      if (this.processingRequest) {
+        const running = this.inFlightCommand ?? "another operation";
+        const elapsedS =
+          this.inFlightStartedAt !== null
+            ? Math.round((Date.now() - this.inFlightStartedAt) / 1000)
+            : null;
+        const elapsedStr = elapsedS !== null ? ` (running for ${elapsedS}s)` : "";
+        logger.warn(`Rejecting "${command}" — busy with "${running}"${elapsedStr}`);
+        reject(
+          new Error(
+            `KiCAD MCP server is busy: still processing "${running}"${elapsedStr}. ` +
+              `This server handles ONE KiCAD operation at a time — commands are serialized ` +
+              `over a single connection to KiCAD. Do not issue KiCAD tool calls in parallel; ` +
+              `wait for the in-flight operation to finish, then retry "${command}". ` +
+              `Exports, DRC, and schematic sync can take a while on large designs.`,
+          ),
+        );
         return;
       }
 
@@ -870,6 +903,8 @@ export class KiCADMcpServer {
     this.responseBuffer = "";
     this.currentRequestHandler = null;
     this.processingRequest = false;
+    this.inFlightCommand = null;
+    this.inFlightStartedAt = null;
 
     // Resolve the promise with the result
     handler.resolve(result);
@@ -893,6 +928,10 @@ export class KiCADMcpServer {
     // Get the next request
     const { request, resolve, reject } = this.requestQueue.shift()!;
 
+    // Record in-flight command for busy diagnostics
+    this.inFlightCommand = request.command;
+    this.inFlightStartedAt = Date.now();
+
     try {
       logger.debug(`Processing KiCAD command: ${request.command}`);
 
@@ -912,6 +951,8 @@ export class KiCADMcpServer {
         this.responseBuffer = "";
         this.currentRequestHandler = null;
         this.processingRequest = false;
+        this.inFlightCommand = null;
+        this.inFlightStartedAt = null;
 
         // Reject the promise
         reject(new Error(`Command timeout after ${timeoutDuration / 1000}s: ${request.command}`));
@@ -932,6 +973,8 @@ export class KiCADMcpServer {
       // Reset processing flag
       this.processingRequest = false;
       this.currentRequestHandler = null;
+      this.inFlightCommand = null;
+      this.inFlightStartedAt = null;
 
       // Process next request
       setTimeout(() => this.processNextRequest(), 0);


### PR DESCRIPTION
## Problem

The bridge is single-threaded — commands are serialized over one stdio connection and one IPC socket (`callKicadScript` → `requestQueue` → `processNextRequest`). While one command is in flight, a second concurrent tool call sits **silently in the queue** behind it, for up to the 10-minute long-op timeout used by `export_*` / `run_drc` / `sync_schematic_to_board`. With no feedback, this presents to MCP clients as a **frozen server** — and it's easy to hit because agents often batch tool calls in a single turn, which the client dispatches concurrently.

## Change (server.ts only)

When an operation is already in flight, reject new commands immediately with an actionable message that names the in-flight command and how long it has run, and tells the caller the server is serialized and to retry sequentially. The startup warm-up is labeled so calls during that brief window get an accurate message too. Sequential usage is unaffected (the first call resolves before the next is issued, so the guard never trips).

Example message:
> KiCAD MCP server is busy: still processing "export_gerber" (running for 42s). This server handles ONE KiCAD operation at a time … wait for the in-flight operation to finish, then retry "get_board_info".

## Relationship to open issues

Relates to #248 and #251, where a slow/blocking operation makes subsequent calls appear to hang. This surfaces the serialization and stops the pile-up; it does **not** by itself fix the underlying long-op behavior described in those issues (e.g. the `sync_schematic_to_board` algorithm in #248). Flagging rather than claiming to close them.

## Testing

`npm run test:ts` passes (24/24). Verified manually over raw MCP stdio: two concurrent `get_backend_state` calls → one succeeds, the other returns the busy error naming the in-flight command; sequential calls behave normally. Lint clean (Prettier/ESLint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)