### PR TITLE
Fix get_board_2d_view: pass --layers and rasterize inline PNG via cairosvg

### DIFF
--- a/python/commands/board/view.py
+++ b/python/commands/board/view.py
@@ -170,7 +170,17 @@ class BoardViewCommands:
                     "message": f"Unsupported format '{fmt}'. Use 'png', 'jpg', or 'svg'.",
                     "errorDetails": f"Got: {fmt}",
                 }
-            layers: List[str] = params.get("layers", [])
+            # `pcb export svg` requires at least one layer on KiCad 9+ — omitting
+            # it fails with "At least one layer must be specified" and no output.
+            # Default to a readable 2D view (copper + silkscreen + board outline)
+            # when the caller doesn't specify layers.
+            layers: List[str] = params.get("layers") or [
+                "F.Cu",
+                "B.Cu",
+                "F.SilkS",
+                "B.SilkS",
+                "Edge.Cuts",
+            ]
             response_mode = params.get("responseMode", "inline")
 
             kicad_cli = shutil.which("kicad-cli") or shutil.which("kicad-cli.exe")

--- a/python/commands/board/view.py
+++ b/python/commands/board/view.py
@@ -15,16 +15,33 @@ logger = logging.getLogger("kicad_interface")
 
 
 def _svg_to_png(svg_path: str, width: int, height: int) -> Optional[bytes]:
-    """Convert SVG to PNG. No cffi dependency.
+    """Convert SVG to PNG at the requested pixel dimensions.
 
     Priority:
-      1. pymupdf (fitz) — bundled MuPDF renderer, pure Python, no system deps
-      2. Inkscape CLI — accurate KiCAD SVG rendering
-      3. ImageMagick convert — broad availability fallback
+      1. cairosvg — the declared dependency (see requirements.txt); honors
+         output_width/output_height and reliably rasterizes KiCAD SVGs.
+      2. pymupdf (fitz) — bundled MuPDF renderer, if installed.
+      3. Inkscape CLI — accurate KiCAD SVG rendering, if installed.
+      4. ImageMagick convert — broad availability fallback.
     Returns PNG bytes or None if all converters fail.
+
+    Without a working converter, get_board_2d_view's inline PNG mode fails
+    (historically surfaced as a misleading "kicad-cli SVG export failed"),
+    even though the kicad-cli plot itself succeeded — file/SVG mode works.
     """
     import subprocess
     import tempfile
+
+    try:
+        import cairosvg
+
+        return cairosvg.svg2png(
+            url=svg_path,
+            output_width=int(width),
+            output_height=int(height),
+        )
+    except Exception:
+        pass
 
     try:
         import fitz

--- a/tests/test_get_board_2d_view_save_to_file.py
+++ b/tests/test_get_board_2d_view_save_to_file.py
@@ -227,3 +227,29 @@ def test_kicad10_export_cmd_uses_file_output_and_mode_single(tmp_path):
     out_idx = argv.index("--output")
     out_arg = argv[out_idx + 1]
     assert out_arg.endswith(".svg")  # a file path, not a directory
+
+
+# ---------------------------------------------------------------------------
+# --layers regression (KiCad 9+ requires at least one layer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_board_svg_export_always_passes_layers(tmp_path):
+    """`pcb export svg` must receive --layers with a non-empty spec even when the
+    caller specifies no layers. KiCad 9+ fails with "At least one layer must be
+    specified" (and writes no file) otherwise."""
+    cmd, root, board_path = _make_view_cmd(tmp_path)
+    fake_result = MagicMock(returncode=0, stderr="", stdout="")
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kicad-cli"),
+        patch("subprocess.run", return_value=fake_result) as run,
+    ):
+        cmd.get_board_2d_view({"pcbPath": str(board_path), "format": "svg"})
+
+    export_calls = [c.args[0] for c in run.call_args_list if c.args and "export" in c.args[0]]
+    assert export_calls, "kicad-cli export was not invoked"
+    argv = export_calls[0]
+    assert "--layers" in argv, f"--layers missing from command: {argv}"
+    assert argv[argv.index("--layers") + 1], "--layers passed with an empty spec"

--- a/tests/test_get_board_2d_view_save_to_file.py
+++ b/tests/test_get_board_2d_view_save_to_file.py
@@ -253,3 +253,31 @@ def test_board_svg_export_always_passes_layers(tmp_path):
     argv = export_calls[0]
     assert "--layers" in argv, f"--layers missing from command: {argv}"
     assert argv[argv.index("--layers") + 1], "--layers passed with an empty spec"
+
+
+# ---------------------------------------------------------------------------
+# SVG -> PNG conversion (inline mode) must work on a stock install
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_svg_to_png_converts_via_cairosvg(tmp_path):
+    """_svg_to_png must return PNG bytes at the requested size on a stock install
+    (cairosvg is a declared dependency). If it returns None, inline PNG mode fails
+    with a misleading "kicad-cli SVG export failed" even though the plot succeeded."""
+    from commands.board.view import _svg_to_png
+
+    svg = tmp_path / "b.svg"
+    svg.write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="50mm" height="40mm" '
+        'viewBox="0 0 50 40"><rect x="5" y="5" width="30" height="20" '
+        'fill="none" stroke="black"/></svg>',
+        encoding="utf-8",
+    )
+    png = _svg_to_png(str(svg), 400, 320)
+    assert png is not None, "no SVG->PNG converter available (inline PNG would fail)"
+    assert png[:4] == b"\x89PNG"
+    import struct
+
+    width, height = struct.unpack(">II", png[16:24])
+    assert (width, height) == (400, 320)


### PR DESCRIPTION
## Problem

`get_board_2d_view` fails to return an image, for two independent reasons — both must be fixed for the tool to work:

1. **Export flag.** KiCad 9+ `pcb export svg` fails with *"At least one layer must be specified"* (no file written) unless `--layers` is passed, but the layers list defaulted to `[]` and the flag was only appended when non-empty.

2. **Inline PNG conversion.** `board/view.py` had its own copy of `_svg_to_png` that tried pymupdf → inkscape → ImageMagick — none of which are declared dependencies. On a stock install (only `cairosvg`, which *is* in `requirements.txt`) all converters failed, it returned `None`, and inline PNG mode failed with a misleading *"kicad-cli SVG export failed"* even though the plot itself succeeded (file/SVG mode worked). Same root cause as the schematic render path.

## Fix

1. Default `layers` to a readable 2D view (`F.Cu, B.Cu, F.SilkS, B.SilkS, Edge.Cuts`) when the caller specifies none; explicit layers still override.
2. Use `cairosvg` as the primary SVG→PNG converter (pymupdf/inkscape/convert remain fallbacks).

## Tests

- `--layers` is always present in the export command.
- `_svg_to_png` returns a PNG at the requested dimensions.

Verified end-to-end on a real board: inline PNG produced (~0.03 MB).

Fixes #235. Related: #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)