### PR TITLE
Inherit the library symbol's Footprint when placing a schematic instance

### DIFF
--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -529,6 +529,35 @@ class DynamicSymbolLoader:
         ry = -dx * math.sin(rad) + dy * math.cos(rad)
         return round(rx, 3), round(ry, 3)
 
+    def _extract_lib_property_value(
+        self, schematic_path: Path, library_name: str, symbol_name: str, prop_name: str
+    ) -> str:
+        """Return a property's VALUE from the injected lib_symbols definition.
+
+        Used to inherit fields (e.g. Footprint) from the library symbol onto a
+        placed instance, matching KiCad's own placement behavior. Returns "" if
+        the symbol or property isn't found.
+        """
+        try:
+            import re
+
+            with open(schematic_path, encoding="utf-8") as f:
+                content = f.read()
+            lib_start = content.find("(lib_symbols")
+            if lib_start == -1:
+                return ""
+            sym_start = content.find(f'(symbol "{library_name}:{symbol_name}"', lib_start)
+            if sym_start == -1:
+                return ""
+            sym_block = self._extract_paren_block(content, sym_start)
+            m = re.search(
+                r'\(property\s+"' + re.escape(prop_name) + r'"\s+"([^"]*)"',
+                sym_block,
+            )
+            return m.group(1) if m else ""
+        except Exception:
+            return ""
+
     def create_component_instance(
         self,
         schematic_path: Path,
@@ -560,6 +589,15 @@ class DynamicSymbolLoader:
 
         # --- read property offsets from the already-injected lib_symbols block -----
         lib_props = self._extract_lib_property_positions(schematic_path, library_name, symbol_name)
+
+        # Inherit the library symbol's own Footprint when the caller didn't
+        # specify one, so a footprint set via create_symbol propagates to placed
+        # instances (KiCad does this on placement). Without it, instances stay
+        # unfootprinted until an explicit edit_schematic_component.
+        if not footprint:
+            footprint = self._extract_lib_property_value(
+                schematic_path, library_name, symbol_name, "Footprint"
+            )
 
         _DEFAULT_EFFECTS = "(effects (font (size 1.27 1.27)))"
 

--- a/tests/test_symbol_footprint_inherit.py
+++ b/tests/test_symbol_footprint_inherit.py
@@ -1,0 +1,64 @@
+"""Placed schematic instances inherit the library symbol's Footprint.
+
+Regression guard: create_component_instance previously wrote the Footprint
+straight from its (empty-default) argument and never consulted the library
+symbol, so a footprint set via create_symbol never propagated to placements —
+only a later edit_schematic_component set it. KiCad inherits the field on
+placement; the loader now does too.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.unit
+
+from commands.dynamic_symbol_loader import DynamicSymbolLoader  # noqa: E402
+
+# Minimal schematic whose lib_symbols entry carries a Footprint value.
+_SCH = """(kicad_sch (version 20231120) (generator test)
+  (lib_symbols
+    (symbol "MyLib:ESP32" (in_bom yes) (on_board yes)
+      (property "Reference" "U" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "ESP32" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "RF_Module:ESP32-C3-MINI-1" (at 0 -2.54 0) \
+(effects (font (size 1.27 1.27)) (hide yes)))
+      (property "Datasheet" "~" (at 0 -5 0) (effects (font (size 1.27 1.27)) (hide yes)))
+    )
+  )
+)
+"""
+
+
+def _placed_footprint(schematic_text: str) -> str:
+    """Return the Footprint value of the placed instance (outside lib_symbols)."""
+    instance = schematic_text[schematic_text.rfind("(symbol (lib_id") :]
+    m = re.search(r'\(property "Footprint" "([^"]*)"', instance)
+    return m.group(1) if m else ""
+
+
+@pytest.fixture()
+def schematic(tmp_path: Path) -> Path:
+    p = tmp_path / "t.kicad_sch"
+    p.write_text(_SCH, encoding="utf-8")
+    return p
+
+
+def test_placement_inherits_library_footprint(schematic: Path) -> None:
+    """No footprint passed -> inherit the library symbol's Footprint."""
+    loader = DynamicSymbolLoader(project_path=schematic.parent)
+    loader.create_component_instance(schematic, "MyLib", "ESP32", reference="U1", x=100, y=100)
+    assert _placed_footprint(schematic.read_text(encoding="utf-8")) == "RF_Module:ESP32-C3-MINI-1"
+
+
+def test_explicit_footprint_overrides_library(schematic: Path) -> None:
+    """An explicit footprint argument still wins over the library value."""
+    loader = DynamicSymbolLoader(project_path=schematic.parent)
+    loader.create_component_instance(
+        schematic, "MyLib", "ESP32", reference="U1", footprint="MyFP:Custom", x=100, y=100
+    )
+    assert _placed_footprint(schematic.read_text(encoding="utf-8")) == "MyFP:Custom"


### PR DESCRIPTION
## Problem

A footprint set on a library symbol (e.g. via `create_symbol`) doesn't propagate to placed instances. `create_component_instance` wrote the instance's `Footprint` property straight from its `footprint` argument (default `""`) and never consulted the library symbol, so placements stayed unfootprinted until an explicit `edit_schematic_component` set the field.

KiCad itself inherits the symbol's `Footprint` onto the instance at placement time.

## Fix

When the caller doesn't pass a footprint, default it to the library symbol's own `Footprint` value, read from the already-injected `lib_symbols` block. Explicit footprint arguments still override.

## Tests

`tests/test_symbol_footprint_inherit.py`:
- placement with no footprint inherits the library symbol's value
- an explicit footprint argument still overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)