### PR TITLE
Always import the SWIG pcbnew fallback, even when IPC connects at startup

### DIFF
--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -36,8 +36,8 @@ if sys.platform == "win32":
 
 import sexpdata
 from annotations import AnnotationLoader
-from commands.wire_manager import WireManager
 from commands.schematic_handlers import SchematicHandlersMixin
+from commands.wire_manager import WireManager
 from resources.resource_definitions import RESOURCE_DEFINITIONS, handle_resource_read
 
 # Import tool schemas, resource definitions, and IPC API annotations
@@ -231,11 +231,19 @@ if KICAD_BACKEND in ("auto", "ipc"):
         logger.info(f"IPC backend connection failed: {e}")
         ipc_backend = None
 
-# Fall back to SWIG backend if IPC not available
-if not USE_IPC_BACKEND and KICAD_BACKEND != "ipc":
+# Import the SWIG pcbnew module whenever it isn't explicitly disabled.
+#
+# pcbnew is the *fallback* backend even when IPC is the primary one: an
+# IPC-pinned session that later downgrades to SWIG (GUI busy or closed, or the
+# #223 stale-board safety) still needs pcbnew to load/edit the board. The old
+# `not USE_IPC_BACKEND` guard skipped this import whenever IPC connected at
+# startup, so those later SWIG board ops hit "name 'pcbnew' is not defined" —
+# surfaced to callers as a bogus "dehydrated SWIG proxy that could not be
+# recovered" (schematic/file ops kept working because they never touch pcbnew).
+if KICAD_BACKEND != "ipc":
     # Import KiCAD's Python API (SWIG)
     try:
-        logger.info("Attempting to import pcbnew module (SWIG backend)...")
+        logger.info("Importing pcbnew module (SWIG backend / fallback)...")
         import pcbnew  # type: ignore
 
         logger.info(f"Successfully imported pcbnew module from: {pcbnew.__file__}")
@@ -275,13 +283,22 @@ Linux Troubleshooting:
 
         logger.error(help_message)
 
-        error_response = {
-            "success": False,
-            "message": "Failed to import pcbnew module - KiCAD Python API not found",
-            "errorDetails": f"Error: {str(e)}\n\n{help_message}\n\nPython sys.path:\n{chr(10).join(sys.path)}",
-        }
-        print(json.dumps(error_response))
-        sys.exit(1)
+        # A missing pcbnew is fatal only when there is no working IPC backend.
+        # If IPC connected, keep running IPC-only rather than killing the whole
+        # server — board SWIG fallback just won't be available.
+        if USE_IPC_BACKEND:
+            logger.warning(
+                "pcbnew (SWIG) could not be imported, but the IPC backend is "
+                "active — continuing IPC-only; SWIG board fallback is unavailable"
+            )
+        else:
+            error_response = {
+                "success": False,
+                "message": "Failed to import pcbnew module - KiCAD Python API not found",
+                "errorDetails": f"Error: {str(e)}\n\n{help_message}\n\nPython sys.path:\n{chr(10).join(sys.path)}",
+            }
+            print(json.dumps(error_response))
+            sys.exit(1)
     except Exception as e:
         logger.error(f"Unexpected error importing pcbnew: {e}")
         logger.error(traceback.format_exc())


### PR DESCRIPTION
## Problem

`pcbnew` (the SWIG backend) is imported only inside `if not USE_IPC_BACKEND`. So whenever KiCad is running and **IPC connects at startup** (the default `auto` path), the SWIG import is **skipped entirely** — pcbnew is never loaded into the process.

Any later fall-back to SWIG then fails:
- an IPC-pinned session that downgrades to SWIG (GUI busy/closed, or the #223 stale-board safety), or
- `sync_schematic_to_board` loading the board via `pcbnew.LoadBoard`,

hits `name 'pcbnew' is not defined`, which callers see as the misleading *"pcbnew.LoadBoard failed or returned a dehydrated SWIG proxy that could not be recovered."* Schematic/file operations keep working because they never touch pcbnew — which makes it look board-specific and intermittent (it's actually deterministic per session: if IPC connected at startup, SWIG board ops are dead for that process's lifetime).

## Fix

Import pcbnew whenever the backend isn't explicitly `ipc`-only, regardless of whether IPC connected. A failed import is fatal only when there's also no working IPC backend; otherwise the server continues IPC-only with a warning (so a genuinely pcbnew-less, IPC-only host still runs).

## Verification

From the startup log with KiCad running (IPC connects):

Before:
```
✓ Using IPC backend - real-time UI sync enabled!
Warm-up failed after 0.0s: name 'pcbnew' is not defined
```
After:
```
✓ Using IPC backend - real-time UI sync enabled!
Importing pcbnew module (SWIG backend / fallback)...
Successfully imported pcbnew module from: /usr/lib/python3/dist-packages/pcbnew.py
```
`pcbnew.LoadBoard` then loads the board and `sync_schematic_to_board` proceeds.

## Related

Likely the same class as some "SWIG dehydration requires restart" reports (#249) — this fixes the *pcbnew-never-imported* case. Note it does **not** address genuine mid-session SWIG proxy invalidation (#247), which is a different root cause.

*(One incidental line: pre-commit's isort normalized a pre-existing import order in the same file.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)