### PR TITLE
Bound IPC connect so a busy KiCad falls back to SWIG instead of hanging

### DIFF
--- a/python/kicad_api/ipc_backend.py
+++ b/python/kicad_api/ipc_backend.py
@@ -17,12 +17,22 @@ Key Benefits over SWIG:
 import logging
 import os
 import platform
+import threading
+import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from kicad_api.base import APINotAvailableError, BoardAPI, ConnectionError, KiCADBackend
 
 logger = logging.getLogger(__name__)
+
+# Hard wall-clock cap for a single IPC connection attempt. kipy dials with
+# pynng's block_on_dial=True, which has NO timeout (only send/recv are capped),
+# so if KiCad's GUI thread is busy (e.g. reloading a library we just wrote to,
+# or any modal/progress state) and not servicing its socket, a connect can hang
+# until the client's ~240s watchdog fires. Bounding it here turns that into a
+# fast fall-back to the SWIG/file backend instead of an apparent freeze.
+IPC_CONNECT_TIMEOUT_S = float(os.getenv("KICAD_IPC_CONNECT_TIMEOUT", "5"))
 
 # Unit conversion constant: KiCAD IPC uses nanometers internally
 MM_TO_NM = 1_000_000
@@ -85,20 +95,14 @@ class IPCBackend(KiCADBackend):
             last_error = None
             for path in socket_paths_to_try:
                 try:
-                    if path:
-                        logger.debug(f"Trying socket path: {path}")
-                        self._kicad = KiCad(socket_path=path)
-                    else:
-                        logger.debug("Trying auto-detection")
-                        self._kicad = KiCad()
-
-                    # Verify connection with ping (ping returns None on success)
-                    self._kicad.ping()
-                    logger.info(f"Connected via socket: {path or 'auto-detected'}")
+                    logger.debug(f"Trying socket path: {path or 'auto-detect'}")
+                    kicad, elapsed = self._open_with_timeout(KiCad, path, IPC_CONNECT_TIMEOUT_S)
+                    self._kicad = kicad
+                    logger.info(f"Connected via socket: {path or 'auto-detected'} ({elapsed:.2f}s)")
                     break
                 except Exception as e:
                     last_error = e
-                    logger.debug(f"Failed to connect via {path}: {e}")
+                    logger.debug(f"Failed to connect via {path or 'auto-detect'}: {e}")
                     continue
             else:
                 # None of the paths worked
@@ -122,6 +126,43 @@ class IPCBackend(KiCADBackend):
                 "Preferences > Plugins > Enable IPC API Server"
             )
             raise ConnectionError(f"IPC connection failed: {e}") from e
+
+    def _open_with_timeout(self, KiCad: Any, path: Optional[str], timeout_s: float):
+        """Open one kipy connection and ping it, bounded by a wall-clock timeout.
+
+        kipy's dial uses pynng block_on_dial=True (no timeout), so the open+ping
+        can hang if KiCad is busy and not servicing its socket. Run it in a
+        daemon thread and give up after ``timeout_s`` — a stuck thread is
+        orphaned (harmless: daemon, dies with the process) rather than blocking
+        the command loop until the client's ~240s watchdog fires.
+
+        Returns (kicad, elapsed_seconds). Raises TimeoutError on overrun, or the
+        underlying exception if the attempt failed fast.
+        """
+        result: Dict[str, Any] = {}
+        start = time.monotonic()
+
+        def worker() -> None:
+            try:
+                kicad = KiCad(socket_path=path) if path else KiCad()
+                kicad.ping()  # returns None on success, raises on failure
+                result["kicad"] = kicad
+            except Exception as e:  # noqa: BLE001 — surfaced to caller below
+                result["error"] = e
+
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+        t.join(timeout_s)
+        elapsed = time.monotonic() - start
+
+        if t.is_alive():
+            raise TimeoutError(
+                f"IPC connect exceeded {timeout_s:.1f}s (KiCad busy or not servicing "
+                f"its socket); falling back to SWIG"
+            )
+        if "error" in result:
+            raise result["error"]
+        return result["kicad"], elapsed
 
     def _get_kicad_version(self) -> str:
         """Get KiCAD version string."""

--- a/tests/test_ipc_connect_timeout.py
+++ b/tests/test_ipc_connect_timeout.py
@@ -1,0 +1,59 @@
+"""IPCBackend._open_with_timeout bounds a stuck kipy dial.
+
+kipy dials with pynng block_on_dial=True (no timeout), so a busy KiCad that
+isn't servicing its socket could make connect() hang until the client's ~240s
+watchdog fires. _open_with_timeout caps a single attempt so the caller falls
+back to SWIG in seconds instead.
+"""
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.unit
+
+from kicad_api.ipc_backend import IPCBackend  # noqa: E402
+
+
+def test_bounds_a_stuck_dial():
+    class StuckKiCad:
+        def __init__(self, socket_path=None):
+            time.sleep(30)  # emulate a GUI-busy hang
+
+        def ping(self):
+            pass
+
+    b = IPCBackend()
+    t0 = time.monotonic()
+    with pytest.raises(TimeoutError):
+        b._open_with_timeout(StuckKiCad, "ipc:///tmp/x.sock", 0.5)
+    assert time.monotonic() - t0 < 5.0  # bounded, not the 30s sleep
+
+
+def test_returns_fast_connection():
+    class FastKiCad:
+        def __init__(self, socket_path=None):
+            pass
+
+        def ping(self):
+            pass
+
+    kicad, elapsed = IPCBackend()._open_with_timeout(FastKiCad, None, 5.0)
+    assert isinstance(kicad, FastKiCad)
+    assert elapsed >= 0.0
+
+
+def test_propagates_fast_failure():
+    class FailKiCad:
+        def __init__(self, socket_path=None):
+            raise ConnectionError("connection refused")
+
+        def ping(self):
+            pass
+
+    with pytest.raises(ConnectionError):
+        IPCBackend()._open_with_timeout(FailKiCad, None, 5.0)


### PR DESCRIPTION
## Problem

kipy dials with `pynng.Req0(dial=..., block_on_dial=True)`, and `block_on_dial=True` has **no timeout** (only send/recv are capped, at 2s). When KiCad's GUI thread is busy and not servicing its socket — e.g. auto-reloading a library/table the MCP just wrote, or any modal/progress state — `IPCBackend.connect()` can block until the MCP client's ~240s watchdog fires. To the caller it looks like a frozen server; only afterward does the session fall back to SWIG.

## Fix

Run each kipy open+ping in a daemon thread with a wall-clock join timeout (`KICAD_IPC_CONNECT_TIMEOUT`, default 5s). A stuck attempt is abandoned (the daemon thread dies with the process) and `connect()` fails fast, so callers fall back to the SWIG/file backend in seconds instead of ~240s. A healthy connect is unaffected (sub-second).

## Tests

`tests/test_ipc_connect_timeout.py`:
- a simulated stuck dial is bounded to the timeout (not the 30s sleep)
- a healthy connection returns fast
- a fast failure propagates unchanged

## Related

#248 / #251 (operations that appear to hang). This bounds the IPC *connect* path specifically; it's complementary to serializing/queue behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)