### PR TITLE
fix(schematic): drag net labels with a moved/rotated pin to prevent silent re-netting

### DIFF
--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -1684,6 +1684,7 @@ class SchematicHandlersMixin:
                 "wiresMoved": drag_summary.get("endpoints_moved", 0),
                 "wiresRemoved": drag_summary.get("wires_removed", 0),
                 "wiresSynthesized": drag_summary.get("wires_synthesized", 0),
+                "labelsMoved": drag_summary.get("labels_moved", 0),
             }
 
         except Exception as e:
@@ -1767,6 +1768,7 @@ class SchematicHandlersMixin:
                 "mirror": effective_mirror,
                 "wiresMoved": drag_summary.get("endpoints_moved", 0),
                 "wiresRemoved": drag_summary.get("wires_removed", 0),
+                "labelsMoved": drag_summary.get("labels_moved", 0),
             }
 
         except Exception as e:

--- a/python/commands/wire_dragger.py
+++ b/python/commands/wire_dragger.py
@@ -27,6 +27,9 @@ _K = {
         "xy",
         "wire",
         "junction",
+        "label",
+        "global_label",
+        "hierarchical_label",
         "property",
         "stroke",
         "width",
@@ -299,13 +302,14 @@ class WireDragger:
 
         old_to_new: {(old_x, old_y): (new_x, new_y)}
 
-        Returns {'endpoints_moved': N, 'wires_removed': M}.
+        Returns {'endpoints_moved': N, 'wires_removed': M, 'labels_moved': L}.
         """
         wire_k = _K["wire"]
         pts_k = _K["pts"]
         xy_k = _K["xy"]
         junction_k = _K["junction"]
         at_k = _K["at"]
+        label_ks = (_K["label"], _K["global_label"], _K["hierarchical_label"])
 
         def find_new(x: float, y: float) -> Optional[Tuple[float, float]]:
             for (ox, oy), (nx, ny) in old_to_new.items():
@@ -314,6 +318,7 @@ class WireDragger:
             return None
 
         endpoints_moved = 0
+        labels_moved = 0
         zero_length_indices = []
 
         # First pass: update wire endpoints
@@ -362,9 +367,26 @@ class WireDragger:
                         sub[2] = nc[1]
                     break
 
+        # Third pass: drag net labels that sit exactly on a moved pin so they
+        # stay attached to it. Without this, a label coincident with a rotated
+        # pin is left behind while the pin's wiring moves away — silently
+        # re-netting it (e.g. a test-point label merging onto an adjacent rail).
+        for item in sch_data:
+            if not (isinstance(item, list) and item and item[0] in label_ks):
+                continue
+            for sub in item[1:]:
+                if isinstance(sub, list) and sub and sub[0] == at_k and len(sub) >= 3:
+                    nc = find_new(float(sub[1]), float(sub[2]))
+                    if nc is not None:
+                        sub[1] = nc[0]
+                        sub[2] = nc[1]
+                        labels_moved += 1
+                    break
+
         return {
             "endpoints_moved": endpoints_moved,
             "wires_removed": len(zero_length_indices),
+            "labels_moved": labels_moved,
         }
 
     @staticmethod

--- a/src/tools/schematic.ts
+++ b/src/tools/schematic.ts
@@ -1099,6 +1099,7 @@ edit_schematic_component and set its value to an empty string.`,
       if (result.success) {
         const moved = result.wiresMoved ?? 0;
         const removed = result.wiresRemoved ?? 0;
+        const labels = result.labelsMoved ?? 0;
         return {
           content: [
             {
@@ -1107,7 +1108,8 @@ edit_schematic_component and set its value to an empty string.`,
                 `Moved ${args.reference} from (${result.oldPosition.x}, ${result.oldPosition.y}) ` +
                 `to (${result.newPosition.x}, ${result.newPosition.y})` +
                 (moved > 0 ? `, ${moved} wire endpoint(s) updated` : "") +
-                (removed > 0 ? `, ${removed} zero-length wire(s) removed` : ""),
+                (removed > 0 ? `, ${removed} zero-length wire(s) removed` : "") +
+                (labels > 0 ? `, ${labels} net label(s) moved to stay attached` : ""),
             },
           ],
         };
@@ -1131,7 +1133,13 @@ edit_schematic_component and set its value to an empty string.`,
     {
       schematicPath: z.string().describe("Path to the .kicad_sch file"),
       reference: z.string().describe("Reference designator (e.g., R1, U1)"),
-      angle: z.number().describe("Rotation angle in degrees (0, 90, 180, 270)"),
+      angle: z
+        .number()
+        .describe(
+          "Absolute rotation in degrees (0, 90, 180, 270). This is the symbol's " +
+            "final orientation, not a relative increment — passing 90 sets the " +
+            "symbol to 90° regardless of its current angle (unlike KiCad's UI 'R' key).",
+        ),
       mirror: z.enum(["x", "y"]).optional().describe("Optional mirror axis"),
     },
     async (args: {
@@ -1142,11 +1150,16 @@ edit_schematic_component and set its value to an empty string.`,
     }) => {
       const result = await callKicadScript("rotate_schematic_component", args);
       if (result.success) {
+        const moved = result.wiresMoved ?? 0;
+        const labels = result.labelsMoved ?? 0;
         return {
           content: [
             {
               type: "text",
-              text: `Rotated ${args.reference} to ${args.angle}°${args.mirror ? ` (mirrored ${args.mirror})` : ""}`,
+              text:
+                `Rotated ${args.reference} to ${args.angle}°${args.mirror ? ` (mirrored ${args.mirror})` : ""}` +
+                (moved > 0 ? `, ${moved} wire endpoint(s) updated` : "") +
+                (labels > 0 ? `, ${labels} net label(s) moved to stay attached` : ""),
             },
           ],
         };

--- a/tests/test_wire_dragger_labels.py
+++ b/tests/test_wire_dragger_labels.py
@@ -1,0 +1,64 @@
+"""Tests for WireDragger dragging net labels along with a moved/rotated pin.
+
+Regression guard: when a symbol is moved or rotated with wire-dragging enabled,
+a net label sitting exactly on one of its pins used to be left behind while the
+pin's wiring moved away.  The label would then detach from the pin's net and, if
+another net's wire happened to occupy that coordinate, silently merge onto it
+(e.g. a test-point label ending up on an adjacent power rail).  drag_wires must
+now carry coincident net labels along so they stay attached.
+"""
+
+import sys
+from pathlib import Path
+
+from sexpdata import Symbol as S
+
+PYTHON_DIR = Path(__file__).parent.parent / "python"
+sys.path.insert(0, str(PYTHON_DIR))
+
+from commands.wire_dragger import WireDragger  # noqa: E402
+
+
+def _sch_with_label_on_pin(label_token="label"):
+    """A wire from (100,100)->(100,90) plus a net label at the (100,100) pin."""
+    return [
+        S("kicad_sch"),
+        [S("wire"), [S("pts"), [S("xy"), 100.0, 100.0], [S("xy"), 100.0, 90.0]]],
+        [S(label_token), "DRAIN_TP", [S("at"), 100.0, 100.0, 0]],
+    ]
+
+
+class TestLabelDragOnRotate:
+    def test_label_follows_moved_pin(self):
+        sch = _sch_with_label_on_pin()
+        summary = WireDragger.drag_wires(sch, {(100.0, 100.0): (110.0, 100.0)})
+        assert summary["labels_moved"] == 1
+        label = next(i for i in sch if isinstance(i, list) and str(i[0]) == "label")
+        at = next(p for p in label if isinstance(p, list) and str(p[0]) == "at")
+        assert (at[1], at[2]) == (110.0, 100.0)
+
+    def test_global_and_hierarchical_labels_also_move(self):
+        for token in ("global_label", "hierarchical_label"):
+            sch = _sch_with_label_on_pin(token)
+            summary = WireDragger.drag_wires(sch, {(100.0, 100.0): (110.0, 100.0)})
+            assert summary["labels_moved"] == 1, token
+
+    def test_label_not_on_pin_is_untouched(self):
+        sch = [
+            S("kicad_sch"),
+            [S("wire"), [S("pts"), [S("xy"), 100.0, 100.0], [S("xy"), 100.0, 90.0]]],
+            [S("label"), "OTHER", [S("at"), 50.0, 50.0, 0]],
+        ]
+        summary = WireDragger.drag_wires(sch, {(100.0, 100.0): (110.0, 100.0)})
+        assert summary["labels_moved"] == 0
+        label = next(i for i in sch if isinstance(i, list) and str(i[0]) == "label")
+        at = next(p for p in label if isinstance(p, list) and str(p[0]) == "at")
+        assert (at[1], at[2]) == (50.0, 50.0)
+
+    def test_no_labels_reported_when_none_present(self):
+        sch = [
+            S("kicad_sch"),
+            [S("wire"), [S("pts"), [S("xy"), 100.0, 100.0], [S("xy"), 100.0, 90.0]]],
+        ]
+        summary = WireDragger.drag_wires(sch, {(100.0, 100.0): (110.0, 100.0)})
+        assert summary["labels_moved"] == 0


### PR DESCRIPTION
## Summary

When `move_schematic_component` / `rotate_schematic_component` drag connected
wires to follow a symbol's pins, a net label sitting exactly on a moved pin is
now carried along with it — fixing a bug where the label was left behind and
could **silently re-net** onto a neighbouring signal.

## Why

`WireDragger.drag_wires()` moved wire endpoints and junctions to follow rotated/
moved pins, but not net labels. A `label` / `global_label` / `hierarchical_label`
coincident with a pin was left at the old coordinate while the pin's wiring moved
away. The label then detached from the pin's net and, if another net's wire
occupied that coordinate, silently merged onto it.

Observed: rotating a diode moved a drain test-point label onto the **+12V** rail.
This is a connectivity-correctness bug — the change is invisible unless you diff
the netlist, which is exactly what makes it dangerous.

## Changes

- **`wire_dragger.py`**: `drag_wires()` gains a third pass that drags
  `label` / `global_label` / `hierarchical_label` sitting on a moved pin, using
  the same coordinate-match tolerance already used for wire endpoints and
  junctions. Returns `labels_moved`.
- **`schematic_handlers.py`**: move and rotate handlers report `labelsMoved`.
- **`src/tools/schematic.ts`**: the move/rotate tool responses surface how many
  labels were relocated, so the caller is told when a label moved. Also clarifies
  the rotate tool's `angle` as an **absolute** target (final orientation), not a
  relative increment like KiCad's UI `R` key.

## Test plan

- `pytest tests/test_wire_dragger_labels.py` — 4 passing: a label follows a moved
  pin; global/hierarchical labels also move; a label *not* on a pin is untouched;
  no false positives when no labels are present.
- Existing `test_rotate_schematic_mirror.py`, `test_ipc_rotate_absolute.py` pass.
- flake8 + isort clean. (black must be run via a Python ≥3.10 pre-commit env.)

Independent of the canonical-formatting fix (separate PR); the two branches touch
different regions of `wire_dragger.py` / `schematic_handlers.py` and merge cleanly.
