### PR TITLE
fix(schematic): write .kicad_sch in KiCad's canonical format, not minified

### DIFF
--- a/python/commands/schematic.py
+++ b/python/commands/schematic.py
@@ -5,6 +5,7 @@ import uuid
 from typing import Any, Optional
 
 from skip import Schematic
+from utils.sexpr_format import prettify
 
 logger = logging.getLogger("kicad_interface")
 
@@ -107,6 +108,13 @@ class SchematicManager:
         try:
             # kicad-skip uses write method, not save
             schematic.write(file_path)
+            # kicad-skip emits a semi-minified layout; reformat to KiCad's
+            # canonical pretty format so tool writes match eeschema's "Save"
+            # and produce minimal, reviewable diffs.
+            with open(file_path, "r", encoding="utf-8") as f:
+                content = f.read()
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(prettify(content))
             logger.info(f"Saved schematic to: {file_path}")
             return True
         except Exception as e:

--- a/python/commands/schematic_batch.py
+++ b/python/commands/schematic_batch.py
@@ -658,6 +658,7 @@ class SchematicBatchCommands:
         try:
             import sexpdata
             from sexpdata import Symbol
+            from utils.sexpr_format import dumps as kicad_dumps
 
             data = sexpdata.loads(sch_path.read_text(encoding="utf-8"))
             changed = False
@@ -681,7 +682,7 @@ class SchematicBatchCommands:
                         continue
                 new_data.append(item)
             if changed:
-                sch_path.write_text(sexpdata.dumps(new_data), encoding="utf-8")
+                sch_path.write_text(kicad_dumps(new_data), encoding="utf-8")
         except Exception as e:
             logger.warning(f"replace cleanup failed: {e}")
 

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -22,10 +22,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pcbnew
 import sexpdata
-
 from commands.library_schematic import LibraryManager as SchematicLibraryManager
 from commands.schematic import SchematicManager
 from commands.wire_manager import WireManager
+from utils.sexpr_format import dumps as kicad_dumps
 
 logger = logging.getLogger("kicad_interface")
 
@@ -1675,7 +1675,7 @@ class SchematicHandlersMixin:
             WireManager.sync_junctions(sch_data)
 
             with open(schematic_path, "w", encoding="utf-8") as f:
-                f.write(sexpdata.dumps(sch_data))
+                f.write(kicad_dumps(sch_data))
 
             return {
                 "success": True,
@@ -1758,7 +1758,7 @@ class SchematicHandlersMixin:
             WireManager.sync_junctions(sch_data)
 
             with open(schematic_path, "w", encoding="utf-8") as f:
-                f.write(_sexpdata.dumps(sch_data))
+                f.write(kicad_dumps(sch_data))
 
             return {
                 "success": True,
@@ -1989,7 +1989,7 @@ class SchematicHandlersMixin:
                 item[at_idx] = [_SYM_AT, float(new_x), float(new_y), rotation]
 
                 with open(schematic_path, "w", encoding="utf-8") as f:
-                    f.write(_sexpdata.dumps(sch_data))
+                    f.write(kicad_dumps(sch_data))
 
                 return {
                     "success": True,

--- a/python/commands/schematic_snap.py
+++ b/python/commands/schematic_snap.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 
 import sexpdata
 from sexpdata import Symbol
+from utils.sexpr_format import dumps as kicad_dumps
 
 logger = logging.getLogger("kicad_interface")
 
@@ -202,7 +203,7 @@ def snap_to_grid(
             continue
 
     with open(schematic_path, "w", encoding="utf-8") as fh:
-        fh.write(sexpdata.dumps(sch_data))
+        fh.write(kicad_dumps(sch_data))
 
     return {
         "snapped": snapped,

--- a/python/commands/wire_dragger.py
+++ b/python/commands/wire_dragger.py
@@ -267,10 +267,13 @@ class WireDragger:
         at_k = _K["at"]
         mirror_k = _K["mirror"]
 
-        # Update rotation in (at x y rot)
+        # Update rotation in (at x y rot). KiCad writes symbol angles as
+        # integers (0/90/180/270), so normalize integral values to int to
+        # match eeschema's output exactly (avoids a spurious "90.0" token).
+        rot_val = int(new_rotation) if float(new_rotation).is_integer() else new_rotation
         for sub in item[1:]:
             if isinstance(sub, list) and sub and sub[0] == at_k and len(sub) >= 4:
-                sub[3] = new_rotation
+                sub[3] = rot_val
                 break
 
         # Remove existing (mirror ...) token(s)

--- a/python/commands/wire_manager.py
+++ b/python/commands/wire_manager.py
@@ -16,6 +16,7 @@ from typing import Any, List, Optional, Tuple
 
 import sexpdata
 from sexpdata import Symbol
+from utils.sexpr_format import dumps as kicad_dumps
 
 logger = logging.getLogger("kicad_interface")
 
@@ -195,7 +196,7 @@ class WireManager:
 
             # Write back
             with open(schematic_path, "w", encoding="utf-8") as f:
-                output = sexpdata.dumps(sch_data)
+                output = kicad_dumps(sch_data)
                 f.write(output)
 
             logger.info(f"Successfully added wire to {schematic_path.name}")
@@ -275,7 +276,7 @@ class WireManager:
 
             # Write back
             with open(schematic_path, "w", encoding="utf-8") as f:
-                output = sexpdata.dumps(sch_data)
+                output = kicad_dumps(sch_data)
                 f.write(output)
 
             logger.info(f"Successfully added polyline wire to {schematic_path.name}")
@@ -347,7 +348,7 @@ class WireManager:
             sch_data.insert(sheet_instances_index, label_sexp)
 
             with open(schematic_path, "w", encoding="utf-8") as f:
-                f.write(sexpdata.dumps(sch_data))
+                f.write(kicad_dumps(sch_data))
 
             logger.info(f"Successfully added label '{text}' to {schematic_path.name}")
             return True
@@ -762,7 +763,7 @@ class WireManager:
 
             # Write back
             with open(schematic_path, "w", encoding="utf-8") as f:
-                output = sexpdata.dumps(sch_data)
+                output = kicad_dumps(sch_data)
                 f.write(output)
 
             logger.info(f"Successfully added no-connect to {schematic_path.name}")
@@ -845,7 +846,7 @@ class WireManager:
                     del sch_data[i]
                     WireManager.sync_junctions(sch_data)
                     with open(schematic_path, "w", encoding="utf-8") as f:
-                        f.write(sexpdata.dumps(sch_data))
+                        f.write(kicad_dumps(sch_data))
                     logger.info(f"Deleted wire from {start_point} to {end_point}")
                     return True
 
@@ -913,7 +914,7 @@ class WireManager:
 
                 del sch_data[i]
                 with open(schematic_path, "w", encoding="utf-8") as f:
-                    f.write(sexpdata.dumps(sch_data))
+                    f.write(kicad_dumps(sch_data))
                 logger.info(f"Deleted label '{net_name}'")
                 return True
 

--- a/python/utils/sexpr_format.py
+++ b/python/utils/sexpr_format.py
@@ -1,0 +1,188 @@
+"""KiCad-compatible S-expression serialization for schematic (.kicad_sch) files.
+
+Background
+----------
+The schematic write tools in this server manipulate the parsed s-expression tree
+with :mod:`sexpdata` and then serialize it back with ``sexpdata.dumps()``.  That
+function emits the *entire* file as a single minified line.  KiCad's own editor
+(eeschema) always writes the file in a canonical, multi-line "pretty" format.
+The mismatch means a one-symbol edit made through this server rewrites the whole
+file onto one line, producing unreviewable diffs (thousands of deletions, one
+insertion) and churning the file back and forth every time it is opened and saved
+in the KiCad UI.
+
+This module re-implements KiCad's canonical formatter so that tool writes are
+byte-for-byte identical to what eeschema's "Save" produces.  ``dumps()`` here is a
+drop-in replacement for ``sexpdata.dumps()`` for schematic data.
+
+Implementation
+--------------
+:func:`prettify` is a faithful port of KiCad's ``Prettify()``
+(``common/io/kicad/kicad_io_utils.cpp``) for ``FORMAT_MODE::DEFAULT`` -- the mode
+eeschema uses for ``.kicad_sch``.  It is a character-level transform over an
+already-serialized compact s-expression string (exactly how KiCad implements it),
+so it does not re-interpret atoms; it only decides where line breaks and
+indentation go.  Because :func:`sexpdata.dumps` already emits atoms (numbers,
+quoted/escaped strings) the same way KiCad does, the combination round-trips real
+eeschema files byte-for-byte.
+
+The two special cases that DEFAULT mode does not use (``COMPACT_TEXT_PROPERTIES``
+for board text and ``LIBRARY_TABLE`` for fp-lib-table rows) are intentionally
+omitted -- schematics never trigger them.
+
+Divergence note
+---------------
+``Prettify()`` has been layout-stable across KiCad 7-10; this port was verified
+byte-identical against ``kicad-cli`` (KiCad 10) output.  If a future KiCad
+release changes the layout, tool writes would drift from UI saves again -- but
+only cosmetically: :func:`dumps` re-parses its own output and falls back to the
+(minified but data-correct) compact form if the layout pass ever fails to
+round-trip, so a formatter change can never corrupt schematic data.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import sexpdata
+
+logger = logging.getLogger("kicad_interface")
+
+# Formatting constants, mirrored from KiCad's Prettify().
+_QUOTE_CHAR = '"'
+_INDENT_CHAR = "\t"
+_INDENT_SIZE = 1
+# Long runs of (xy ...) points are kept on one line until this column.
+_XY_SPECIAL_CASE_COLUMN_LIMIT = 99
+# Whitespace inside a list past this column becomes a newline + indent.
+_CONSECUTIVE_TOKEN_WRAP_THRESHOLD = 72
+
+
+def _is_whitespace(c: str) -> bool:
+    return c in (" ", "\t", "\n", "\r")
+
+
+def prettify(source: str) -> str:
+    """Reformat a compact s-expression string into KiCad's canonical layout.
+
+    Port of KiCad ``Prettify()`` for ``FORMAT_MODE::DEFAULT``.  ``source`` should
+    be a valid single-line (or arbitrarily-spaced) s-expression such as the output
+    of :func:`sexpdata.dumps`.  Returns the pretty-printed text, terminated with a
+    trailing newline (matching KiCad, for clean git diffs).
+    """
+    n = len(source)
+    formatted: list[str] = []
+
+    list_depth = 0
+    last_non_whitespace = ""
+    in_quote = False
+    has_inserted_space = False
+    in_multi_line_list = False
+    in_xy = False
+    column = 0
+    backslash_count = 0
+
+    def next_non_whitespace(i: int) -> str:
+        while i < n and _is_whitespace(source[i]):
+            i += 1
+        return chr(0) if i >= n else source[i]
+
+    def is_xy(i: int) -> bool:
+        # True if source[i:] starts with "(xy " (the point-list special case).
+        return i + 3 < n and source[i + 1] == "x" and source[i + 2] == "y" and source[i + 3] == " "
+
+    cursor = 0
+    while cursor < n:
+        cur = source[cursor]
+
+        if _is_whitespace(cur) and not in_quote:
+            nxt = next_non_whitespace(cursor)
+            if (
+                not has_inserted_space  # only one space between tokens
+                and list_depth > 0  # never touch the outer list
+                and last_non_whitespace != "("  # no space right after "("
+                and nxt != ")"  # no space right before ")"
+                and nxt != "("  # a newline (below) handles this instead
+            ):
+                if in_xy or column < _CONSECUTIVE_TOKEN_WRAP_THRESHOLD:
+                    formatted.append(" ")
+                    column += 1
+                else:
+                    formatted.append("\n" + _INDENT_CHAR * (list_depth * _INDENT_SIZE))
+                    column = list_depth * _INDENT_SIZE
+                    in_multi_line_list = True
+                has_inserted_space = True
+        else:
+            has_inserted_space = False
+
+            if cur == "(" and not in_quote:
+                current_is_xy = is_xy(cursor)
+
+                if not formatted:
+                    formatted.append("(")
+                    column += 1
+                elif in_xy and current_is_xy and column < _XY_SPECIAL_CASE_COLUMN_LIMIT:
+                    # Keep consecutive (xy ...) points on the same line.
+                    formatted.append(" (")
+                    column += 2
+                else:
+                    formatted.append("\n" + _INDENT_CHAR * (list_depth * _INDENT_SIZE) + "(")
+                    column = list_depth * _INDENT_SIZE + 1
+
+                in_xy = current_is_xy
+                list_depth += 1
+            elif cur == ")" and not in_quote:
+                if list_depth > 0:
+                    list_depth -= 1
+
+                if last_non_whitespace == ")" or in_multi_line_list:
+                    formatted.append("\n" + _INDENT_CHAR * (list_depth * _INDENT_SIZE) + ")")
+                    column = list_depth * _INDENT_SIZE + 1
+                    in_multi_line_list = False
+                else:
+                    formatted.append(")")
+                    column += 1
+            else:
+                # Track escaped quotes: a '"' only toggles quote state when
+                # preceded by an even number of backslashes.
+                if cur == "\\":
+                    backslash_count += 1
+                elif cur == _QUOTE_CHAR and (backslash_count & 1) == 0:
+                    in_quote = not in_quote
+
+                if cur != "\\":
+                    backslash_count = 0
+
+                formatted.append(cur)
+                column += 1
+
+            last_non_whitespace = cur
+
+        cursor += 1
+
+    # Trailing newline for POSIX compliance / clean git diffs (matches KiCad).
+    formatted.append("\n")
+    return "".join(formatted)
+
+
+def dumps(data) -> str:
+    """Serialize a sexpdata tree to KiCad's canonical pretty format.
+
+    Drop-in replacement for ``sexpdata.dumps(data)`` at schematic write sites.
+
+    Data-integrity guard: :func:`prettify` only moves whitespace outside quoted
+    strings, so it cannot change the parsed data.  As cheap insurance against a
+    latent formatter bug (or a future KiCad layout change this port doesn't
+    track), the pretty output is re-parsed and compared to the compact form; on
+    any mismatch we log and fall back to the compact string, which is ugly
+    (single line) but guaranteed to preserve the schematic exactly.
+    """
+    compact = sexpdata.dumps(data)
+    pretty = prettify(compact)
+    if sexpdata.dumps(sexpdata.loads(pretty)) != compact:
+        logger.error(
+            "sexpr_format.dumps: pretty output did not round-trip to the same "
+            "data; writing compact form to avoid corruption. Please report this."
+        )
+        return compact
+    return pretty

--- a/scripts/kicad_sch_reformat.py
+++ b/scripts/kicad_sch_reformat.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Re-expand a minified .kicad_sch into KiCad's canonical (eeschema) format.
+
+Interim/migration helper for schematic files that were minified onto a single
+line by older versions of this server's write tools.  Produces byte-for-byte the
+same layout eeschema's "Save" writes, without launching KiCad.  Reuses the same
+formatter the server itself now uses (python/utils/sexpr_format.py), so results
+match tool writes exactly.  Only external dependency: ``sexpdata``.
+
+Usage
+-----
+  # Reformat files in place:
+  python scripts/kicad_sch_reformat.py path/to/*.kicad_sch
+
+  # Check-only (exit 1 if any file would change) — CI / pre-commit:
+  python scripts/kicad_sch_reformat.py --check path/to/*.kicad_sch
+
+  # As a git clean filter (stdin -> stdout). In .gitattributes:
+  #   *.kicad_sch filter=kicadpretty
+  # and:
+  #   git config filter.kicadpretty.clean \
+  #     "python /abs/path/scripts/kicad_sch_reformat.py --stdin"
+  python scripts/kicad_sch_reformat.py --stdin < in.kicad_sch > out.kicad_sch
+"""
+import sys
+from pathlib import Path
+
+# Reuse the server's canonical formatter rather than re-implementing it.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "python"))
+
+import sexpdata  # noqa: E402
+from utils.sexpr_format import prettify  # noqa: E402
+
+
+def reformat_text(text: str) -> str:
+    # Round-trip through sexpdata to normalize any input spacing, then prettify.
+    # sexpdata's round-trip is data-lossless, so no schematic data changes.
+    return prettify(sexpdata.dumps(sexpdata.loads(text)))
+
+
+def main(argv):
+    args = list(argv)
+    check = "--check" in args
+    if check:
+        args.remove("--check")
+    if "--stdin" in args:
+        sys.stdout.write(reformat_text(sys.stdin.read()))
+        return 0
+    if not args:
+        print(__doc__)
+        return 2
+    changed = 0
+    for path in args:
+        orig = Path(path).read_text(encoding="utf-8")
+        new = reformat_text(orig)
+        if new != orig:
+            changed += 1
+            if check:
+                print(f"would reformat: {path}")
+            else:
+                with open(path, "w", encoding="utf-8", newline="\n") as f:
+                    f.write(new)
+                print(f"reformatted: {path}")
+    if check:
+        return 1 if changed else 0
+    print(f"done ({changed} file(s) changed)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/fixtures/canonical_schematic.kicad_sch
+++ b/tests/fixtures/canonical_schematic.kicad_sch
@@ -1,0 +1,323 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "f379cdcf-95e9-40fb-bb22-dbfcc9b050ce")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 138.43 39.37 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0723939a-c521-4710-80fa-43ad6797d5f1")
+		(property "Reference" "C9"
+			(at 142.24 38.0999 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100n"
+			(at 142.24 40.6399 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric"
+			(at 146.05 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 146.05 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Capacitor 100nF 50V X7R, 0603, Basic"
+			(at 138.43 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 138.43 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 138.43 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "LCSC" "C14663"
+			(at 138.43 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Octopart" ""
+			(at 138.43 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor1" "https://www.digikey.com/en/products/detail/yageo/CC0603KRX7R9BB104/2103082"
+			(at 138.43 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor2" ""
+			(at 138.43 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "45458ff8-dc52-4480-95c3-5ee44b4deaf2")
+		)
+		(pin "2"
+			(uuid "a8b2bef2-9f13-4556-aeca-0637dd3eb41b")
+		)
+		(instances
+			(project "sample_project"
+				(path "/4d9632d0-b3ab-4bf3-9e72-b7763bdb4de6/c738ecfb-7198-4a8a-9534-ae0e3e686e37"
+					(reference "C9")
+					(unit 1)
+				)
+			)
+			(project ""
+				(path "/f379cdcf-95e9-40fb-bb22-dbfcc9b050ce"
+					(reference "C9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
+)

--- a/tests/test_sexpr_format.py
+++ b/tests/test_sexpr_format.py
@@ -1,0 +1,202 @@
+"""Tests for utils.sexpr_format — KiCad-canonical schematic serialization.
+
+These guard the fix for the schematic write tools minifying .kicad_sch onto a
+single line.  The formatter must reproduce, byte-for-byte, what eeschema's
+"Save" produces so tool writes create minimal, reviewable diffs.
+"""
+
+import sys
+from pathlib import Path
+
+import sexpdata
+from sexpdata import Symbol as S
+
+PYTHON_DIR = Path(__file__).parent.parent / "python"
+sys.path.insert(0, str(PYTHON_DIR))
+
+from commands.wire_dragger import WireDragger  # noqa: E402
+from utils.sexpr_format import dumps, prettify  # noqa: E402
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+# A genuine canonical schematic produced by `kicad-cli sch upgrade` (KiCad 10).
+# Exercises: (xy ...) inline runs, an escaped quote in a string, nested effects,
+# tab indentation, and the trailing newline.
+CANONICAL_GOLDEN = (
+    "(kicad_sch\n"
+    "\t(version 20260306)\n"
+    '\t(generator "eeschema")\n'
+    '\t(generator_version "10.0")\n'
+    '\t(uuid "11111111-1111-4111-8111-111111111111")\n'
+    '\t(paper "A4")\n'
+    "\t(lib_symbols)\n"
+    "\t(polyline\n"
+    "\t\t(pts\n"
+    "\t\t\t(xy 0 0) (xy 1 0) (xy 2 0) (xy 3 0)\n"
+    "\t\t)\n"
+    "\t\t(stroke\n"
+    "\t\t\t(width 0)\n"
+    "\t\t\t(type default)\n"
+    "\t\t)\n"
+    "\t\t(fill\n"
+    "\t\t\t(type none)\n"
+    "\t\t)\n"
+    '\t\t(uuid "c744d04a-07a6-46fb-a4c5-ff282ffe1664")\n'
+    "\t)\n"
+    '\t(text "quote \\"x\\" end"\n'
+    "\t\t(exclude_from_sim no)\n"
+    "\t\t(at 10 10 0)\n"
+    "\t\t(effects\n"
+    "\t\t\t(font\n"
+    "\t\t\t\t(size 1.27 1.27)\n"
+    "\t\t\t)\n"
+    "\t\t)\n"
+    '\t\t(uuid "08c0d948-c7dc-4db2-9955-79d9d2405d9d")\n'
+    "\t)\n"
+    '\t(label "NET1"\n'
+    "\t\t(at 5 5 0)\n"
+    "\t\t(effects\n"
+    "\t\t\t(font\n"
+    "\t\t\t\t(size 1.27 1.27)\n"
+    "\t\t\t)\n"
+    "\t\t\t(justify left)\n"
+    "\t\t)\n"
+    '\t\t(uuid "91ce1fc6-d449-41ea-a41b-1c11ec3499e7")\n'
+    "\t)\n"
+    ")\n"
+)
+
+
+class TestPrettify:
+    def test_reproduces_canonical_kicad_output(self):
+        """dumps(parsed) is byte-identical to eeschema's canonical format."""
+        assert dumps(sexpdata.loads(CANONICAL_GOLDEN)) == CANONICAL_GOLDEN
+
+    def test_prettify_is_idempotent(self):
+        once = prettify(sexpdata.dumps(sexpdata.loads(CANONICAL_GOLDEN)))
+        assert prettify(once) == once
+
+    def test_not_minified(self):
+        out = dumps(sexpdata.loads(CANONICAL_GOLDEN))
+        assert out.count("\n") > 30  # multi-line, not a single minified line
+
+    def test_uses_tab_indentation(self):
+        out = dumps(sexpdata.loads(CANONICAL_GOLDEN))
+        assert "\n\t(version" in out
+        assert "    (version" not in out  # never space-indented
+
+    def test_trailing_newline(self):
+        assert dumps(sexpdata.loads(CANONICAL_GOLDEN)).endswith(")\n")
+
+    def test_xy_runs_stay_inline(self):
+        out = dumps(sexpdata.loads(CANONICAL_GOLDEN))
+        assert "(xy 0 0) (xy 1 0) (xy 2 0) (xy 3 0)" in out
+
+    def test_xy_wraps_long_runs(self):
+        pts = " ".join(f"(xy {i}.5 {i}.25)" for i in range(20))
+        out = prettify(f"(kicad_sch (polyline (pts {pts})))")
+        xy_lines = [ln for ln in out.splitlines() if "(xy" in ln]
+        # A long run wraps across multiple lines (not all 20 on one line) and no
+        # data is lost (all 20 points survive the wrap).
+        assert len(xy_lines) > 1
+        assert out.count("(xy ") == 20
+        # KiCad appends a new (xy only while column (tabs = 1) < 99, so lines
+        # stay near that bound (at most one extra group of slack).
+        for ln in xy_lines:
+            assert len(ln) < 99 + len("(xy 19.5 19.25)")
+
+    def test_escaped_quote_not_treated_as_list_boundary(self):
+        # A "(" inside a quoted string must not open a new list.
+        src = '(kicad_sch (text "a ( b ) c \\" d"))'
+        out = prettify(src)
+        assert sexpdata.loads(out) == sexpdata.loads(src)
+
+    def test_backslash_before_quote_handled(self):
+        # A literal backslash followed by an escaped quote: the quote still
+        # toggles (odd backslash count before it means it is escaped).
+        src = r'(kicad_sch (text "path C:\\dir\" x ) y"))'
+        out = prettify(src)
+        assert sexpdata.loads(out) == sexpdata.loads(src)
+
+    def test_round_trip_data_stable(self):
+        data = sexpdata.loads(CANONICAL_GOLDEN)
+        assert sexpdata.loads(dumps(data)) == data
+
+    def test_degrades_to_compact_is_never_needed_for_valid_data(self):
+        # dumps() falls back to compact only if a formatting bug would corrupt
+        # data; for well-formed input it must always return the pretty form.
+        out = dumps(sexpdata.loads(CANONICAL_GOLDEN))
+        assert "\n" in out  # not the single-line compact fallback
+
+
+class TestCanonicalFixture:
+    """Round-trip against a real, multi-symbol schematic emitted by kicad-cli.
+
+    Covers the constructs the synthetic golden omits: a full lib_symbols
+    definition, a placed symbol with a (instances (project ...)) block, an
+    empty quoted string, and many wrapped (xy ...) runs.
+    """
+
+    def _golden(self):
+        return (FIXTURES / "canonical_schematic.kicad_sch").read_text(encoding="utf-8")
+
+    def test_byte_identical_round_trip(self):
+        g = self._golden()
+        assert dumps(sexpdata.loads(g)) == g
+
+    def test_idempotent(self):
+        g = self._golden()
+        assert prettify(g) == g
+
+    def test_data_preserved(self):
+        g = self._golden()
+        assert sexpdata.loads(dumps(sexpdata.loads(g))) == sexpdata.loads(g)
+
+
+class TestWriteToolIntegration:
+    """End-to-end: a real write tool must produce canonical output on disk, not a
+    minified single line. WireManager.add_wire is self-contained (no pcbnew), so it
+    exercises the full read -> mutate -> kicad_dumps write path a caller hits."""
+
+    MINIMAL = (
+        '(kicad_sch (version 20250114) (generator "test") (uuid "u") (paper "A4")'
+        ' (lib_symbols) (sheet_instances (path "/" (page "1"))))'
+    )
+
+    def test_add_wire_writes_canonical_format(self, tmp_path):
+        from commands.wire_manager import WireManager  # noqa: E402
+
+        p = tmp_path / "t.kicad_sch"
+        p.write_text(self.MINIMAL, encoding="utf-8")
+
+        assert WireManager.add_wire(p, [10.0, 10.0], [20.0, 10.0]) is True
+
+        out = p.read_text(encoding="utf-8")
+        assert out.count("\n") > 5  # multi-line, not minified
+        assert "\n\t(" in out  # tab-indented like eeschema
+        assert out.endswith(")\n")  # trailing newline
+        assert "(wire" in out  # the edit landed
+        assert sexpdata.loads(out) is not None  # still parses
+        # Writing again is stable (idempotent formatting).
+        assert prettify(out) == out
+
+
+class TestIntegerRotationAngle:
+    """update_symbol_rotation_mirror must write integral angles as ints so the
+    output matches KiCad (e.g. `(at x y 90)`, not `(at x y 90.0)`)."""
+
+    def test_integral_angle_written_as_int(self):
+        at = [S("at"), 36.83, 40.64, 0]
+        sch = [
+            S("kicad_sch"),
+            [
+                S("symbol"),
+                [S("lib_id"), "Device:D"],
+                at,
+                [S("property"), "Reference", "D3"],
+            ],
+        ]
+        WireDragger.update_symbol_rotation_mirror(sch, "D3", 90.0, None)
+        assert at[3] == 90
+        assert isinstance(at[3], int)
+        assert "(at 36.83 40.64 90)" in dumps(sch)


### PR DESCRIPTION
## Summary

Schematic write tools now emit `.kicad_sch` in KiCad's canonical multi-line
("pretty") format instead of a single minified line, so tool edits produce
minimal, reviewable diffs that match what eeschema's **Save** writes byte-for-byte.

## Why

Every schematic write tool parses the file with `sexpdata` and serialized it back
with `sexpdata.dumps()`, which emits the **entire file as one line**. A one-symbol
edit therefore rewrote a whole sub-sheet onto a single line:

- `rotate_schematic_component` on one diode turned an untouched 12,951-line
  sub-sheet into **1 line** — `git diff` showed ~12,951 deletions / 1 insertion,
  impossible to review.
- KiCad's UI always re-expands to the multi-line canonical format on save, so a
  minified file flips back and forth on every manual edit — perpetual whole-file
  churn and merge pain.

Keeping KiCad-pretty (not embracing minification) is the only option that doesn't
fight the editor: you can't stop eeschema from writing multi-line.

## Changes

- **`python/utils/sexpr_format.py`** (new): a port of KiCad's `Prettify()`
  (`FORMAT_MODE::DEFAULT`, the mode eeschema uses for `.kicad_sch`) plus
  `dumps()`, a drop-in for `sexpdata.dumps()`. It re-parses its own output and
  falls back to the compact form on any round-trip mismatch, so a formatter
  change can never corrupt schematic data.
- **`wire_manager.py`, `schematic_handlers.py`, `schematic_snap.py`,
  `schematic_batch.py`**: every `sexpdata.dumps()` write site now calls
  `kicad_dumps`.
- **`schematic.py`**: `save_schematic()` reformats kicad-skip's output through
  `prettify()` (kicad-skip emits a semi-minified layout).
- **`wire_dragger.py`**: normalize integral rotation angles to `int` (`90`, not
  `90.0`) to match KiCad's output exactly.
- **`scripts/kicad_sch_reformat.py`** (new): re-expand files minified by older
  versions — in-place, `--check` (CI/pre-commit), or `--stdin` (git clean
  filter). Reuses the same formatter, so results match tool writes.
- **`tests/`**: `test_sexpr_format.py` covers a synthetic golden, xy-run wrapping,
  escaped quotes/backslashes, idempotency and data round-trip; plus a real
  `kicad-cli`-produced fixture (`canonical_schematic.kicad_sch`) with a full
  `lib_symbols` def and a placed symbol `(instances (project ...))` block.

## Compatibility

Not a breaking change:

- **Data / semantics are unchanged.** The formatter only moves whitespace outside
  quoted strings; the parsed s-expression is identical, and KiCad opens minified
  and pretty files the same way. Unlike `kicad-cli sch upgrade`, it never touches
  `(version ...)` or project names — it is pure whitespace, so no schema/version
  upgrade is triggered.
- **No API change.** No tools or params are renamed/removed.
- **Nothing reformats spontaneously.** A file is only rewritten when a write tool
  actually edits it — exactly when the old code would have minified it anyway.
  There is no repo-wide sweep and no reformat-on-read.

What existing users see on their next tool write:

- Files currently in KiCad's pretty format (the common case): a **minimal** diff
  that matches eeschema, instead of the whole file collapsing to one line — a
  strict improvement, and it ends the UI-expands / tool-minifies churn for anyone
  who edits in both KiCad and these tools.
- Files that were already minified by an older version of this server: a
  **one-time** expansion back to pretty, then stable. That is cosmetic and
  desirable; `scripts/kicad_sch_reformat.py` lets a user do that expansion as a
  deliberate standalone commit rather than have it ride along inside an unrelated
  edit.

Byte-identical output is verified against KiCad 10. `Prettify()` has been
layout-stable across KiCad 7–10, so other versions should match; if a version
ever formats differently the only effect is minor cosmetic churn — never data
changes, since `dumps()` falls back to the compact form on any round-trip
mismatch.

## Test plan

- `pytest tests/test_sexpr_format.py` — 16 passing, including an end-to-end test
  that drives a real write tool (`WireManager.add_wire`) and asserts the file on
  disk is canonical (multi-line, tab-indented, round-trips).
- `dumps(loads(f)) == f` byte-for-byte on the real `kicad-cli` fixture and on
  local project sub-sheets (incl. a 223 KB / 12,951-line one).
- A real `rotate_schematic_component` now yields a ~6-line diff (2 wire endpoints
  + 1 angle) instead of 12,951 deletions / 1 insertion; `kicad-cli sch erc`
  before/after is identical — no connectivity change.
- Existing `test_rotate_schematic_mirror.py`, `test_ipc_rotate_absolute.py` pass.
- flake8 + isort clean. (black must be run via a Python ≥3.10 pre-commit env.)

Independent of the net-label re-netting fix (separate PR); the two branches touch
different regions of `wire_dragger.py` / `schematic_handlers.py` and merge cleanly.
