### PR TITLE
refactor: remove dynamic template injection from legacy add_component (#221 part B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **Legacy `ComponentManager.add_component` no longer silently loses
+  components via dynamic template injection** (#221, part B): when no placed
+  `_TEMPLATE_*` donor existed, the legacy clone path used to call
+  `DynamicSymbolLoader.load_symbol_dynamically`, which wrote a template
+  instance into the *file* mid-call and cloned onto a locally reloaded
+  object — so callers following the normal add-then-save pattern saved
+  their stale in-memory schematic, discarding the new component and
+  leaving `_TEMPLATE_*` clutter behind. That branch is removed: template
+  lookup is now read-only (`find_template`), a schematic without donors
+  gets a clear error pointing at the production `add_schematic_component`
+  path (which works on any file), and the fixture-based clone path is
+  unchanged. `add_component` is deprecated for general use; the
+  remove/update/get/search helpers are unaffected.
+
 - **Pin locations respect the owning unit of multi-unit symbols** (#239):
   `get_schematic_pin_locations` / `get_pin_location` located every pin against
   whichever placed `(symbol)` instance appeared first in file order, so for a

--- a/python/commands/component_schematic.py
+++ b/python/commands/component_schematic.py
@@ -1,35 +1,27 @@
 import logging
-import os
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional
 
 from skip import Schematic
 
 logger = logging.getLogger(__name__)
 
-# Import dynamic symbol loader
-try:
-    from commands.dynamic_symbol_loader import DynamicSymbolLoader
-
-    DYNAMIC_LOADING_AVAILABLE = True
-except ImportError:
-    logger.warning("Dynamic symbol loader not available - falling back to template-only mode")
-    DYNAMIC_LOADING_AVAILABLE = False
-
 
 class ComponentManager:
-    """Manage components in a schematic"""
+    """Manage components in an in-memory (kicad-skip) schematic.
 
-    # Initialize dynamic loader (class variable, shared across instances)
-    _dynamic_loader = None
+    DEPRECATION NOTE (issue #221): ``add_component`` is the legacy,
+    template-clone path. It only works on schematics that already contain
+    placed ``_TEMPLATE_*`` donor symbols (e.g. fixtures copied from
+    ``python/templates/template_with_symbols.kicad_sch``). The production
+    path for adding components is the ``add_schematic_component`` tool,
+    which synthesizes instances via ``DynamicSymbolLoader.add_component``
+    and works on any schematic. New code should use that instead.
 
-    @classmethod
-    def get_dynamic_loader(cls) -> Any:
-        """Get or create dynamic symbol loader instance"""
-        if cls._dynamic_loader is None and DYNAMIC_LOADING_AVAILABLE:
-            cls._dynamic_loader = DynamicSymbolLoader()
-        return cls._dynamic_loader
+    The other methods here (remove/update/get/search) are
+    template-independent and remain fully supported.
+    """
 
     # Template symbol references mapping component type to template reference
     TEMPLATE_MAP = {
@@ -65,29 +57,31 @@ class ComponentManager:
     }
 
     @classmethod
-    def get_or_create_template(
+    def find_template(
         cls,
         schematic: Schematic,
         comp_type: str,
         library: Optional[str] = None,
-        schematic_path: Optional[Path] = None,
-    ) -> tuple:
+    ) -> Optional[str]:
+        """Find a placed ``_TEMPLATE_*`` donor symbol for a component type.
+
+        Looks up the static ``TEMPLATE_MAP`` alias plus the naming patterns
+        used by previously (dynamically) injected templates. Purely a read of
+        the in-memory schematic — never mutates the schematic or the file.
+
+        The old ``get_or_create_template`` variant of this method could fall
+        through to ``DynamicSymbolLoader.load_symbol_dynamically``, which wrote
+        a ``_TEMPLATE_*`` instance into the *file* mid-call and cloned onto a
+        locally reloaded object. Any caller following the normal
+        add-then-save pattern then saved its stale in-memory schematic,
+        silently discarding the new component while leaving the injected
+        template clutter behind (issue #221). That branch is gone; template
+        lookup is now read-only.
+
+        Returns the template reference, or None if no donor symbol exists.
         """
-        Get template reference for a component type, creating it dynamically if needed
 
-        Args:
-            schematic: Schematic object
-            comp_type: Component type (e.g., 'R', 'LED', 'STM32F103C8Tx')
-            library: Optional library name (defaults to 'Device' for common types)
-            schematic_path: Optional path to schematic file (required for dynamic loading)
-
-        Returns:
-            Tuple of (template_ref, needs_reload) where needs_reload indicates if schematic must be reloaded
-        """
-
-        # Helper function to check if template exists in schematic
-        def template_exists(schematic: Any, template_ref: str) -> bool:
-            """Check if template exists by iterating symbols (handles special characters)"""
+        def template_exists(template_ref: str) -> bool:
             for symbol in schematic.symbol:
                 if (
                     hasattr(symbol.property, "Reference")
@@ -96,125 +90,76 @@ class ComponentManager:
                     return True
             return False
 
-        # 1. Check static template map first
+        candidates: List[str] = []
         if comp_type in cls.TEMPLATE_MAP:
-            template_ref = cls.TEMPLATE_MAP[comp_type]
-            # Verify template exists in schematic
-            if template_exists(schematic, template_ref):
-                logger.debug(f"Using static template: {template_ref}")
-                return (template_ref, False)
-
-        # 2. Check if dynamically loaded template already exists
-        # Build potential template reference names
-        potential_refs = []
+            candidates.append(cls.TEMPLATE_MAP[comp_type])
         if library:
-            potential_refs.append(f"_TEMPLATE_{library}_{comp_type}")
-        potential_refs.append(f"_TEMPLATE_{comp_type}")
-        if comp_type in cls.TEMPLATE_MAP:
-            potential_refs.append(cls.TEMPLATE_MAP[comp_type])
+            candidates.append(f"_TEMPLATE_{library}_{comp_type}")
+        candidates.append(f"_TEMPLATE_{comp_type}")
 
-        # Check each potential reference
-        for template_ref in potential_refs:
-            if template_exists(schematic, template_ref):
-                logger.debug(f"Found existing template: {template_ref}")
-                return (template_ref, False)
-
-        # 3. Try dynamic loading
-        if not DYNAMIC_LOADING_AVAILABLE:
-            logger.warning(
-                f"Component type '{comp_type}' not in static templates and dynamic loading unavailable"
-            )
-            # Fall back to basic resistor template
-            return ("_TEMPLATE_R", False)
-
-        loader = cls.get_dynamic_loader()
-        if not loader:
-            logger.warning("Dynamic loader unavailable, using fallback template")
-            return ("_TEMPLATE_R", False)
-
-        # Check if schematic path is available
-        if schematic_path is None:
-            logger.warning("Dynamic loading requires schematic file path but none was provided")
-            fallback = cls.TEMPLATE_MAP.get(comp_type, "_TEMPLATE_R")
-            return (fallback, False)
-
-        # Determine library name
-        if library is None:
-            # Default library for common component types
-            library = "Device"  # Most passives and basic components are in Device library
-
-        try:
-            logger.info(f"Attempting dynamic load: {library}:{comp_type} from {schematic_path}")
-
-            # Use dynamic symbol loader to inject symbol and create template
-            template_ref = loader.load_symbol_dynamically(schematic_path, library, comp_type)
-
-            logger.info(f"Successfully loaded symbol dynamically. Template ref: {template_ref}")
-            # Signal that schematic needs reload to see new template
-            return (template_ref, True)
-
-        except Exception as e:
-            logger.error(f"Dynamic loading failed: {e}")
-            import traceback
-
-            logger.error(traceback.format_exc())
-            # Fall back to static template if available
-            fallback = cls.TEMPLATE_MAP.get(comp_type, "_TEMPLATE_R")
-            return (fallback, False)
+        for template_ref in candidates:
+            if template_exists(template_ref):
+                logger.debug(f"Using template: {template_ref}")
+                return template_ref
+        return None
 
     @staticmethod
     def add_component(
         schematic: Schematic, component_def: dict, schematic_path: Optional[Path] = None
     ) -> Any:
         """
-        Add a component to the schematic by cloning from template
+        Add a component to the in-memory schematic by cloning a placed template.
+
+        DEPRECATED for general use (issue #221): this only works when the
+        schematic already contains a placed ``_TEMPLATE_*`` donor symbol for
+        the component type (fixtures based on template_with_symbols.kicad_sch).
+        For arbitrary schematics use the ``add_schematic_component`` tool /
+        ``DynamicSymbolLoader.add_component``, which injects the library
+        definition and synthesizes the instance directly in the file.
 
         Args:
             schematic: Schematic object to add component to
             component_def: Component definition dictionary
-            schematic_path: Optional path to schematic file (enables dynamic symbol loading)
+            schematic_path: Unused; retained for backward signature compatibility
 
         Returns:
-            Tuple of (new_symbol, needs_reload) where needs_reload indicates if caller should reload schematic
+            The newly added kicad-skip symbol object (part of ``schematic``).
         """
         try:
-            from commands.schematic import SchematicManager
-
             logger.info(
                 f"Adding component: type={component_def.get('type')}, ref={component_def.get('reference')}"
             )
             logger.debug(f"Full component_def: {component_def}")
 
-            # Get component type and determine template
             comp_type = component_def.get("type", "R")
             library = component_def.get("library", None)  # Optional library specification
 
-            # Get template reference (static or dynamic)
-            template_ref, needs_reload = ComponentManager.get_or_create_template(
-                schematic, comp_type, library, schematic_path
-            )
+            template_ref = ComponentManager.find_template(schematic, comp_type, library)
 
-            # If dynamic loading occurred, reload schematic to see new template
-            if needs_reload and schematic_path:
-                logger.info(f"Reloading schematic after dynamic loading: {schematic_path}")
-                schematic = SchematicManager.load_schematic(str(schematic_path))
-
-            # Find template symbol by reference (handles special characters like +)
             template_symbol = None
-            for symbol in schematic.symbol:
-                if (
-                    hasattr(symbol.property, "Reference")
-                    and symbol.property.Reference.value == template_ref
-                ):
-                    template_symbol = symbol
-                    break
+            if template_ref is not None:
+                # Find template symbol by reference (handles special characters like +)
+                for symbol in schematic.symbol:
+                    if (
+                        hasattr(symbol.property, "Reference")
+                        and symbol.property.Reference.value == template_ref
+                    ):
+                        template_symbol = symbol
+                        break
 
             if not template_symbol:
+                available = [str(s.property.Reference.value) for s in schematic.symbol]
                 logger.error(
-                    f"Template symbol {template_ref} not found in schematic. Available symbols: {[str(s.property.Reference.value) for s in schematic.symbol]}"
+                    f"No placed template for type '{comp_type}' in schematic. "
+                    f"Available symbols: {available}"
                 )
                 raise ValueError(
-                    f"Template symbol {template_ref} not found. The schematic must be created from template_with_symbols.kicad_sch"
+                    f"No placed _TEMPLATE_* donor symbol for component type "
+                    f"'{comp_type}' in this schematic. ComponentManager.add_component "
+                    f"is the legacy template-clone path and only works on schematics "
+                    f"seeded with template_with_symbols.kicad_sch. To add components "
+                    f"to an arbitrary schematic, use the add_schematic_component tool "
+                    f"(DynamicSymbolLoader.add_component), which works on any file."
                 )
 
             # Clone the template symbol

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -325,7 +325,6 @@ try:
     logger.info("Importing command handlers...")
     from commands.board import BoardCommands
     from commands.component import ComponentCommands
-    from commands.component_schematic import ComponentManager
     from commands.connection_schematic import ConnectionManager
     from commands.datasheet_manager import DatasheetManager
     from commands.design_rules import DesignRuleCommands

--- a/tests/test_add_schematic_component.py
+++ b/tests/test_add_schematic_component.py
@@ -309,7 +309,12 @@ class TestAddComponentMirrorParam:
     'mirror': 'x' and then asserts something against the resulting schematic
     cannot accidentally pass for the wrong reason (the symbol ends up
     unmirrored). If/when add_component grows real mirror support, update both
-    tests together — the second test then becomes the positive assertion."""
+    tests together — the second test then becomes the positive assertion.
+
+    The schematic is seeded from template_with_symbols.kicad_sch because the
+    legacy clone path requires a placed _TEMPLATE_* donor (issue #221 part B
+    removed the dynamic-injection fallback, which silently lost components
+    for add-then-save callers)."""
 
     def setup_method(self) -> None:
         from commands.component_schematic import ComponentManager
@@ -335,7 +340,7 @@ class TestAddComponentMirrorParam:
 
     def test_mirror_x_arg_is_silently_dropped(self, tmp_path: Any) -> None:
         sch = tmp_path / "mirror_x.kicad_sch"
-        shutil.copy(EMPTY_SCH, sch)
+        shutil.copy(TEMPLATES_DIR / "template_with_symbols.kicad_sch", sch)
         self._add(sch, "x")
         text = sch.read_text()
         assert "(mirror x)" not in text, (
@@ -346,7 +351,7 @@ class TestAddComponentMirrorParam:
 
     def test_mirror_y_arg_is_silently_dropped(self, tmp_path: Any) -> None:
         sch = tmp_path / "mirror_y.kicad_sch"
-        shutil.copy(EMPTY_SCH, sch)
+        shutil.copy(TEMPLATES_DIR / "template_with_symbols.kicad_sch", sch)
         self._add(sch, "y")
         text = sch.read_text()
         assert "(mirror y)" not in text, (

--- a/tests/test_component_manager_legacy.py
+++ b/tests/test_component_manager_legacy.py
@@ -1,0 +1,105 @@
+"""Legacy ComponentManager.add_component contract (issue #221, part B).
+
+The legacy template-clone path must:
+1. keep working on schematics seeded with placed ``_TEMPLATE_*`` donors
+   (the template_with_symbols.kicad_sch fixture),
+2. raise a clear, actionable error on schematics without donors — pointing
+   at the production ``add_schematic_component`` path, and
+3. never mutate the on-disk file. The removed dynamic-injection branch used
+   to write ``_TEMPLATE_*`` symbols into the file mid-call and clone onto a
+   locally reloaded object; callers following the normal add-then-save
+   pattern then saved their stale in-memory schematic, silently losing the
+   component while the injected template clutter stayed in the file.
+"""
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.integration  # needs kicad-skip (real 'skip' package)
+
+_TEMPLATE_SCH = (
+    Path(__file__).parent.parent / "python" / "templates" / "template_with_symbols.kicad_sch"
+)
+
+_BLANK_SCH = """(kicad_sch (version 20260306) (generator "eeschema") (generator_version "10.0")
+  (uuid 3c9f2b6e-1a2b-4c3d-8e4f-5a6b7c8d9e0f)
+  (paper "A4")
+  (lib_symbols)
+  (sheet_instances (path "/" (page "1")))
+)
+"""
+
+
+def _load(sch_path: Path):
+    from commands.schematic import SchematicManager
+
+    return SchematicManager.load_schematic(str(sch_path))
+
+
+class TestTemplateClonePathStillWorks:
+    def test_add_component_clones_from_placed_template(self):
+        from commands.component_schematic import ComponentManager
+
+        with tempfile.TemporaryDirectory() as tmp:
+            sch_path = Path(tmp) / "seeded.kicad_sch"
+            shutil.copy(_TEMPLATE_SCH, sch_path)
+            sch = _load(sch_path)
+
+            new_sym = ComponentManager.add_component(
+                sch,
+                {"type": "R", "reference": "R1", "value": "10k", "x": 100, "y": 100},
+                sch_path,
+            )
+
+            assert new_sym.property.Reference.value == "R1"
+            assert new_sym.property.Value.value == "10k"
+
+
+class TestBlankSchematicFailsClearly:
+    def test_error_names_the_production_path(self):
+        from commands.component_schematic import ComponentManager
+
+        with tempfile.TemporaryDirectory() as tmp:
+            sch_path = Path(tmp) / "blank.kicad_sch"
+            sch_path.write_text(_BLANK_SCH, encoding="utf-8")
+            sch = _load(sch_path)
+
+            with pytest.raises(ValueError) as exc:
+                ComponentManager.add_component(
+                    sch,
+                    {"type": "R", "reference": "R1", "value": "10k", "x": 100, "y": 100},
+                    sch_path,
+                )
+
+            msg = str(exc.value)
+            assert "add_schematic_component" in msg, (
+                "The template-missing error must point users at the production " f"path; got: {msg}"
+            )
+
+    def test_add_component_never_mutates_the_file(self):
+        """The removed dynamic branch wrote _TEMPLATE_* symbols into the file
+        mid-call. The legacy path must now be read-only with respect to disk."""
+        from commands.component_schematic import ComponentManager
+
+        with tempfile.TemporaryDirectory() as tmp:
+            sch_path = Path(tmp) / "blank.kicad_sch"
+            sch_path.write_text(_BLANK_SCH, encoding="utf-8")
+            before = sch_path.read_text(encoding="utf-8")
+            sch = _load(sch_path)
+
+            with pytest.raises(ValueError):
+                ComponentManager.add_component(
+                    sch,
+                    {"type": "R", "reference": "R1", "value": "10k", "x": 100, "y": 100},
+                    sch_path,
+                )
+
+            after = sch_path.read_text(encoding="utf-8")
+            assert after == before, "add_component must not write to the schematic file"
+            assert "_TEMPLATE_" not in after


### PR DESCRIPTION
## Summary

Part B of the #221 split (boovaragan has A+C: blank KiCad 10 templates + keeping `template_with_symbols.kicad_sch` as a test fixture). This removes the placed-template coupling from the legacy `ComponentManager.add_component` path — and in doing so fixes a silent data-loss bug that the coupling was hiding.

## The bug the dynamic branch was hiding

When no placed `_TEMPLATE_*` donor existed, `get_or_create_template` fell through to `DynamicSymbolLoader.load_symbol_dynamically`, which:

1. wrote the lib_symbols definition **and a placed `_TEMPLATE_*` instance into the file** mid-call,
2. reloaded the schematic into a **local** variable, and
3. cloned the new component onto that local object — which is what got returned.

The caller's original in-memory `Schematic` was never touched. Every existing caller follows the `add_component(sch, ...)` then `save_schematic(sch, ...)` pattern, so the subsequent save wrote the **stale** object back: the new component was silently discarded, and the injected `_TEMPLATE_*` clutter stayed behind in the file. This is the same class of clutter reported in #243, plus a lost component.

## What changed

- `get_or_create_template` is replaced by a read-only `find_template` (same lookup: static `TEMPLATE_MAP` alias, previously-injected naming patterns). It never mutates the schematic or the file.
- No donor found now raises a clear error naming the production path (`add_schematic_component` / `DynamicSymbolLoader.add_component`, which synthesizes instances directly in the file and works on any schematic), instead of the misleading "must be created from template_with_symbols.kicad_sch" — or worse, the silent loss above.
- The fixture-based clone path is byte-for-byte unchanged: schematics seeded from `template_with_symbols.kicad_sch` behave exactly as before, which is what keeps the pin-geometry tests and demos green (slice C).
- `add_component` is documented as deprecated for general use; `remove/update/get/search` are template-independent and unaffected.
- Drops the unused `ComponentManager` import from `kicad_interface.py` (production never used it — confirming the trace boovaragan posted on #221).
- The two mirror-canary tests in `test_add_schematic_component.py` are reseeded from the template fixture; they previously relied on the removed dynamic branch to conjure `Device:R` into a blank schematic (verified the fixture contains no `(mirror` tokens, so the canary assertions remain meaningful).

## New tests (`tests/test_component_manager_legacy.py`)

1. Clone path still works on a template-seeded schematic.
2. A blank schematic raises the error naming `add_schematic_component`.
3. `add_component` never writes to the file — the regression test for the silent-loss bug (asserts byte-identical file content and no `_TEMPLATE_` injection after a failed add).

## Verification

Full suite: 1245 passed, 8 failed — the failures are the known Java-environmental set (autoroute/freerouting), identical on main. The legacy-dependent suites (`test_pin_locator_and_component`, `test_add_schematic_component`, new file) pass: 21/21. black, mypy (clean across `python/`), and tsc all green.

## Effect on the #221 plan

With this merged, slice A (pointing `create_project`/`create_schematic` at blank KiCad 10 templates) can land without leaving the legacy path incoherent: new schematics simply get the clear redirect error instead of a template-clone that was never going to survive a save anyway. `template_with_symbols.kicad_sch` stays in-repo as the fixture (slice C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
