### PR TITLE
fix: save_project refuses to clobber external file edits (#244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`save_project` no longer silently clobbers external file edits** (#244):
+  the explicit save wrote `pcbnew.SaveBoard` unconditionally, so a direct edit
+  to the `.kicad_pcb` made after the MCP loaded the board (e.g. a manual
+  net-name patch after a Freerouting import) was destroyed without warning —
+  and the dispatcher then re-recorded the disk signature, blessing the
+  clobber. The explicit path now applies the same content-hash divergence
+  check the auto-save path already had: a diverged file refuses the save with
+  `diskChangedExternally: true` and instructions (reload via `open_project`,
+  or pass `force=true` to overwrite). Saving to a different `filename` is an
+  explicit destination choice and is never blocked. `close_project`'s
+  save-before-close routes through the same guard.
+
 - **Legacy `ComponentManager.add_component` no longer silently loses
   components via dynamic template injection** (#221, part B): when no placed
   `_TEMPLATE_*` donor existed, the legacy clone path used to call

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -442,7 +442,7 @@ class KiCADInterface(SchematicHandlersMixin):
             "create_project": self._handle_create_project,
             "open_project": self._handle_open_project,
             "close_project": self._handle_close_project,
-            "save_project": self.project_commands.save_project,
+            "save_project": self._handle_save_project,
             "snapshot_project": self._handle_snapshot_project,
             "get_project_info": self.project_commands.get_project_info,
             # Board commands
@@ -1518,6 +1518,50 @@ class KiCADInterface(SchematicHandlersMixin):
         self.project_filename = None
         self._current_project_path = None
 
+    def _handle_save_project(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Save the project, refusing to clobber external file edits (issue #244).
+
+        The auto-save path has refused divergent overwrites since the disk
+        signature was introduced, but the explicit save_project tool wrote
+        unconditionally: an edit made directly to the .kicad_pcb after the MCP
+        loaded it (e.g. a manual net-name patch after a Freerouting import) was
+        silently destroyed, and the dispatcher then re-recorded the signature,
+        blessing the clobber. Now the same content check guards this path.
+
+        params:
+          filename (str, optional): save to a new location. Saving to a path
+            other than the loaded board file is an explicit destination choice
+            and is never blocked by the divergence guard.
+          force (bool, default False): overwrite the loaded board file even if
+            its on-disk contents changed externally since load.
+        """
+        board_path = self._current_board_path()
+        filename = params.get("filename")
+        saving_to_loaded_file = board_path is not None and (
+            not filename
+            or self._normalize_board_path(os.path.abspath(os.path.expanduser(filename)))
+            == self._normalize_board_path(board_path)
+        )
+
+        if saving_to_loaded_file and not params.get("force", False):
+            dirty = self._dirty_state(board_path)
+            if dirty.get("diskChangedExternally"):
+                return {
+                    "success": False,
+                    "message": (
+                        "Refusing to save: the on-disk board file's contents "
+                        "changed externally since this MCP session loaded it, and "
+                        "saving would overwrite those changes. Reload the project "
+                        "via open_project to pick up the external edits (then "
+                        "re-apply in-memory changes), or pass force=true to "
+                        "overwrite the file anyway."
+                    ),
+                    "boardPath": board_path,
+                    "diskChangedExternally": True,
+                }
+
+        return self.project_commands.save_project(params)
+
     def _handle_close_project(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Close the currently loaded project (issue #225).
 
@@ -1552,7 +1596,10 @@ class KiCADInterface(SchematicHandlersMixin):
 
         if save and self.board is not None:
             try:
-                save_result = self.project_commands.save_project({})
+                # Route through the divergence guard (#244) so a close cannot
+                # clobber external file edits either; force passes through for
+                # callers that explicitly want the overwrite.
+                save_result = self._handle_save_project({"force": params.get("force", False)})
             except Exception as e:  # noqa: BLE001 - surfaced to caller below
                 logger.error("close_project: save failed: %s", e)
                 return {

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -73,14 +73,27 @@ PROJECT_TOOLS = [
     {
         "name": "save_project",
         "title": "Save Current Project",
-        "description": "Saves the current board to disk. Can optionally save to a new location.",
+        "description": (
+            "Saves the current board to disk. Can optionally save to a new location. "
+            "If the board file's contents changed on disk since it was loaded (an "
+            "external edit), the save is refused to avoid clobbering those changes "
+            "unless force=true is passed."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
                 "filename": {
                     "type": "string",
                     "description": "Optional new path to save the board (if not provided, saves to current location)",
-                }
+                },
+                "force": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Overwrite the loaded board file even if its on-disk contents "
+                        "changed externally since this session loaded it"
+                    ),
+                },
             },
         },
     },

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -75,11 +75,18 @@ export function registerProjectTools(server: McpServer, callKicadScript: Functio
   // Save project tool
   server.tool(
     "save_project",
-    "Save the current KiCAD project",
+    "Save the current KiCAD project. Refuses to overwrite the board file if its " +
+      "contents changed on disk since load (external edit) unless force is true.",
     {
       path: z.string().optional().describe("Optional new path to save to"),
+      force: z
+        .boolean()
+        .optional()
+        .describe(
+          "Overwrite the loaded board file even if its on-disk contents changed externally",
+        ),
     },
-    async (args: { path?: string }) => {
+    async (args: { path?: string; force?: boolean }) => {
       const result = await callKicadScript("save_project", args);
       return {
         content: [

--- a/tests/test_save_project_guard.py
+++ b/tests/test_save_project_guard.py
@@ -1,0 +1,121 @@
+"""save_project divergence guard (issue #244).
+
+The explicit save_project tool used to write pcbnew.SaveBoard unconditionally:
+a direct edit to the .kicad_pcb made after the MCP loaded the board (e.g. a
+manual net-name patch after a Freerouting import) was silently overwritten,
+and the dispatcher then re-recorded the disk signature, blessing the clobber.
+
+_handle_save_project now applies the same content-hash check the auto-save
+path has used since the disk signature was introduced:
+  * contents diverged + saving to the loaded file -> refused (success:false,
+    diskChangedExternally:true) and the delegate save never runs;
+  * force=true -> proceeds;
+  * saving to a *different* filename -> never blocked (explicit destination);
+  * no divergence -> proceeds unchanged.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from kicad_interface import KiCADInterface  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeBoard:
+    def __init__(self, filename):
+        self._filename = str(filename)
+
+    def GetFileName(self):
+        return self._filename
+
+
+class _FakeProjectCommands:
+    """Records delegate calls; the real one would pcbnew.SaveBoard."""
+
+    def __init__(self):
+        self.save_calls = []
+
+    def save_project(self, params):
+        self.save_calls.append(params)
+        return {"success": True, "message": "saved", "project": {"path": "x"}}
+
+
+def _make_iface(tmp_path, diverged: bool):
+    board_file = tmp_path / "board.kicad_pcb"
+    board_file.write_text("(kicad_pcb original)", encoding="utf-8")
+
+    iface = KiCADInterface.__new__(KiCADInterface)
+    iface.board = _FakeBoard(board_file)
+    iface.project_commands = _FakeProjectCommands()
+    iface._last_auto_save_status = None
+    iface._is_board_healthy = lambda *a, **k: True
+    # Record the signature of the original content, then optionally simulate
+    # an external edit so the recorded and current signatures diverge.
+    iface._board_disk_signature = iface._disk_signature(str(board_file))
+    if diverged:
+        board_file.write_text("(kicad_pcb externally patched)", encoding="utf-8")
+    return iface, board_file
+
+
+class TestDivergenceRefusal:
+    def test_refuses_when_disk_changed_externally(self, tmp_path):
+        iface, _ = _make_iface(tmp_path, diverged=True)
+
+        result = iface._handle_save_project({})
+
+        assert result["success"] is False
+        assert result["diskChangedExternally"] is True
+        assert "force=true" in result["message"]
+        assert iface.project_commands.save_calls == [], "delegate save must not run"
+
+    def test_external_edit_survives_a_refused_save(self, tmp_path):
+        iface, board_file = _make_iface(tmp_path, diverged=True)
+
+        iface._handle_save_project({})
+
+        assert board_file.read_text(encoding="utf-8") == "(kicad_pcb externally patched)"
+
+
+class TestOverrides:
+    def test_force_true_proceeds(self, tmp_path):
+        iface, _ = _make_iface(tmp_path, diverged=True)
+
+        result = iface._handle_save_project({"force": True})
+
+        assert result["success"] is True
+        assert len(iface.project_commands.save_calls) == 1
+
+    def test_saving_to_a_different_filename_is_never_blocked(self, tmp_path):
+        iface, _ = _make_iface(tmp_path, diverged=True)
+        other = tmp_path / "elsewhere.kicad_pcb"
+
+        result = iface._handle_save_project({"filename": str(other)})
+
+        assert result["success"] is True
+        assert iface.project_commands.save_calls == [{"filename": str(other)}]
+
+
+class TestNoDivergence:
+    def test_clean_save_proceeds_unchanged(self, tmp_path):
+        iface, _ = _make_iface(tmp_path, diverged=False)
+
+        result = iface._handle_save_project({})
+
+        assert result["success"] is True
+        assert len(iface.project_commands.save_calls) == 1
+
+    def test_no_board_loaded_delegates(self, tmp_path):
+        iface, _ = _make_iface(tmp_path, diverged=True)
+        iface.board = None  # nothing loaded -> guard is moot, delegate decides
+
+        result = iface._handle_save_project({})
+
+        # The fake delegate reports success; the real one returns its own
+        # "No board is loaded" failure. Either way the guard must not block.
+        assert len(iface.project_commands.save_calls) == 1
+        assert result["success"] is True


### PR DESCRIPTION
## Summary

Fixes #244. The explicit save_project tool wrote pcbnew.SaveBoard unconditionally: any direct edit to the .kicad_pcb made after the MCP loaded the board (the issue's repro is a manual net-name patch after a Freerouting SES import) was silently destroyed — and the dispatcher then re-recorded the disk signature afterward, so the clobber was even blessed as the new baseline.

The auto-save path has refused divergent overwrites since the disk-signature machinery landed; this brings the explicit path to parity. A new _handle_save_project wrapper checks the recorded content hash before delegating:

- Contents diverged and saving to the loaded file: refused with success:false, diskChangedExternally:true, and instructions (reload via open_project to pick up the external edits, or pass force=true to overwrite).
- force=true: proceeds.
- filename pointing somewhere else: never blocked — an explicit destination choice is not a clobber of the loaded file.
- No divergence: proceeds exactly as before.

close_project's save-before-close routes through the same guard (with force passthrough), so a close cannot clobber external edits either. The refused-save path cannot re-record the signature because the dispatcher's re-record is gated on success.

The force parameter is added to both tool schemas (python/schemas/tool_schemas.py and src/tools/project.ts). Note: mtime-only changes do not trigger the refusal — the check is content-hash based, same rationale as the auto-save guard (touch/backup tools advance mtime without changing content).

## Testing

tests/test_save_project_guard.py — 6 unit tests: refusal on divergence (and the delegate save provably not running), the external edit surviving a refused save, force override, different-filename bypass, clean save unchanged, no-board delegation. Full suite: 1251 passed, 8 failed (the known Java-environmental set). black/mypy/tsc/vitest clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)