### PR TITLE
fix: resolve user-defined env vars from kicad_common.json

### DIFF
--- a/python/commands/library.py
+++ b/python/commands/library.py
@@ -12,6 +12,8 @@ import re
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from utils.platform_helper import PlatformHelper
+
 logger = logging.getLogger("kicad_interface")
 
 
@@ -152,6 +154,9 @@ class LibraryManager:
             "KICAD8_3RD_PARTY": self._find_kicad_3rdparty_dir(),
             "KICAD_3RD_PARTY": self._find_kicad_3rdparty_dir(),
         }
+
+        # Merge user-defined env vars from kicad_common.json
+        env_vars.update(PlatformHelper.load_kicad_env_vars())
 
         # Project directory
         if self.project_path:

--- a/python/commands/library_symbol.py
+++ b/python/commands/library_symbol.py
@@ -13,6 +13,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from utils.platform_helper import PlatformHelper
+
 logger = logging.getLogger("kicad_interface")
 
 
@@ -201,6 +203,9 @@ class SymbolLibraryManager:
             "KICAD_3RD_PARTY": self._find_3rd_party_dir(),
             "KISYSSYM": self._find_kicad_symbol_dir(),
         }
+
+        # Merge user-defined env vars from kicad_common.json
+        env_vars.update(PlatformHelper.load_kicad_env_vars())
 
         # Project directory
         if self.project_path:

--- a/python/utils/platform_helper.py
+++ b/python/utils/platform_helper.py
@@ -5,12 +5,13 @@ This module provides helpers for detecting the current platform and
 getting appropriate paths for KiCAD, configuration, logs, etc.
 """
 
+import json
 import logging
 import os
 import platform
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -348,6 +349,46 @@ class PlatformHelper:
                 paths_added = True
 
         return paths_added
+
+
+    @staticmethod
+    def load_kicad_env_vars() -> Dict[str, str]:
+        """
+        Load user-defined environment variables from kicad_common.json.
+
+        KiCad stores custom path variables (Preferences > Configure Paths) in
+        kicad_common.json under environment.vars. These are referenced in
+        sym-lib-table / fp-lib-table URIs, e.g. ``${SEEK}/mylib.kicad_sym``.
+
+        Returns:
+            Dict of variable name -> value (empty if not found or unreadable)
+        """
+        import json
+
+        env_vars = {}
+        kicad_common_paths = [
+            Path.home() / "Library" / "Preferences" / "kicad" / "10.0" / "kicad_common.json",
+            Path.home() / "Library" / "Preferences" / "kicad" / "9.0" / "kicad_common.json",
+            Path.home() / "Library" / "Preferences" / "kicad" / "8.0" / "kicad_common.json",
+            Path.home() / ".config" / "kicad" / "10.0" / "kicad_common.json",
+            Path.home() / ".config" / "kicad" / "9.0" / "kicad_common.json",
+            Path.home() / ".config" / "kicad" / "8.0" / "kicad_common.json",
+            Path.home() / "AppData" / "Roaming" / "kicad" / "10.0" / "kicad_common.json",
+            Path.home() / "AppData" / "Roaming" / "kicad" / "9.0" / "kicad_common.json",
+            Path.home() / "AppData" / "Roaming" / "kicad" / "8.0" / "kicad_common.json",
+        ]
+        for config_path in kicad_common_paths:
+            if config_path.exists():
+                try:
+                    with open(config_path, "r") as f:
+                        config = json.load(f)
+                    vars_ = config.get("environment", {}).get("vars", {})
+                    if isinstance(vars_, dict):
+                        env_vars.update({k: str(v) for k, v in vars_.items()})
+                    break
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    pass
+        return env_vars
 
 
 # Convenience function for quick platform detection

--- a/python/utils/platform_helper.py
+++ b/python/utils/platform_helper.py
@@ -351,7 +351,6 @@ class PlatformHelper:
 
         return paths_added
 
-
     @staticmethod
     def load_kicad_env_vars() -> Dict[str, str]:
         """

--- a/tests/test_kicad_common_env_resolution.py
+++ b/tests/test_kicad_common_env_resolution.py
@@ -1,0 +1,132 @@
+"""
+Regression tests for user-defined environment variables from kicad_common.json.
+
+KiCad stores custom path variables (Preferences > Configure Paths) in
+kicad_common.json under ``environment.vars``.  Users reference these in
+sym-lib-table / fp-lib-table URIs, e.g. ``${SEEK}/seex.kicad_sym``.
+
+Prior to this fix ``_resolve_uri`` only knew about built-in KiCad variables
+(``KICAD9_SYMBOL_DIR``, ``KICAD_3RD_PARTY``, ``KIPRJMOD``, ...) and never read
+kicad_common.json, so libraries registered with custom variables silently
+failed to resolve.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.library import LibraryManager
+from commands.library_symbol import SymbolLibraryManager
+from commands import library, library_symbol
+
+
+def _make_footprint_manager() -> LibraryManager:
+    manager = LibraryManager.__new__(LibraryManager)
+    manager.project_path = None
+    manager.libraries = {}
+    manager.footprint_cache = {}
+    return manager
+
+
+def _make_symbol_manager() -> SymbolLibraryManager:
+    manager = SymbolLibraryManager.__new__(SymbolLibraryManager)
+    manager.project_path = None
+    manager.libraries = {}
+    manager.symbol_cache = {}
+    return manager
+
+
+@pytest.mark.unit
+def test_symbol_manager_resolves_user_defined_env_var(monkeypatch, tmp_path):
+    """A user-defined var from kicad_common.json must resolve in _resolve_uri."""
+    monkeypatch.setattr(
+        library_symbol.PlatformHelper,
+        "load_kicad_env_vars",
+        staticmethod(lambda: {"MY_CUSTOM_LIB": str(tmp_path / "libs")}),
+    )
+
+    target = tmp_path / "libs" / "mylib.kicad_sym"
+    target.parent.mkdir(parents=True)
+    target.touch()
+
+    manager = _make_symbol_manager()
+
+    resolved = manager._resolve_uri("${MY_CUSTOM_LIB}/mylib.kicad_sym")
+    assert resolved == str(target)
+
+
+@pytest.mark.unit
+def test_library_manager_resolves_user_defined_env_var(monkeypatch, tmp_path):
+    """User-defined vars must also work for footprint library URIs."""
+    monkeypatch.setattr(
+        library.PlatformHelper,
+        "load_kicad_env_vars",
+        staticmethod(lambda: {"MY_CUSTOM_LIB": str(tmp_path / "libs")}),
+    )
+
+    target_dir = tmp_path / "libs" / "mylib.pretty"
+    target_dir.mkdir(parents=True)
+
+    manager = _make_footprint_manager()
+
+    resolved = manager._resolve_uri("${MY_CUSTOM_LIB}/mylib.pretty")
+    assert resolved == str(target_dir)
+
+
+@pytest.mark.unit
+def test_sym_lib_table_entry_with_user_var_is_loaded(monkeypatch, tmp_path):
+    """End-to-end: a sym-lib-table row using a user-defined var must end up
+    in ``manager.libraries`` after parsing."""
+    monkeypatch.setattr(
+        library_symbol.PlatformHelper,
+        "load_kicad_env_vars",
+        staticmethod(lambda: {"MY_CUSTOM_LIB": str(tmp_path / "libs")}),
+    )
+
+    lib_file = tmp_path / "libs" / "mylib.kicad_sym"
+    lib_file.parent.mkdir(parents=True)
+    lib_file.write_text("(kicad_symbol_lib (version 20231120))", encoding="utf-8")
+
+    table_path = tmp_path / "sym-lib-table"
+    table_path.write_text(
+        "\n".join(
+            [
+                "(sym_lib_table",
+                '  (lib (name "mylib")(type "KiCad")'
+                f'(uri "${{MY_CUSTOM_LIB}}/mylib.kicad_sym")(options "")(descr ""))',
+                ")",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    manager = _make_symbol_manager()
+    manager._parse_sym_lib_table(table_path)
+
+    assert manager.libraries.get("mylib") == str(lib_file)
+
+
+@pytest.mark.unit
+def test_user_defined_and_builtin_vars_coexist(monkeypatch, tmp_path):
+    """User-defined vars and built-in vars (KIPRJMOD) must both resolve
+    without interfering with each other."""
+    monkeypatch.setattr(
+        library_symbol.PlatformHelper,
+        "load_kicad_env_vars",
+        staticmethod(lambda: {"MY_CUSTOM_LIB": str(tmp_path / "libs")}),
+    )
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    lib_file = tmp_path / "libs" / "lib.kicad_sym"
+    lib_file.parent.mkdir(parents=True)
+    lib_file.write_text("(kicad_symbol_lib (version 20231120))", encoding="utf-8")
+
+    manager = _make_symbol_manager()
+    manager.project_path = project_dir
+
+    assert manager._resolve_uri("${MY_CUSTOM_LIB}/lib.kicad_sym") == str(lib_file)
+    assert manager._resolve_uri("${KIPRJMOD}") == str(project_dir)


### PR DESCRIPTION
## Problem

KiCad allows users to define custom path variables in Preferences > Configure Paths, stored in kicad_common.json under environment.vars. Users reference these variables in sym-lib-table / fp-lib-table, for example:

```
(lib (name "seex") (uri "${SEEK}/seex.kicad_sym") ...)
```

The MCP server's `_resolve_uri` method only recognizes built-in KiCad variables (KICAD9_SYMBOL_DIR, KICAD_3RD_PARTY, KIPRJMOD, etc.) and never reads kicad_common.json, causing libraries with custom variables to fail resolution and silently disappear from MCP listings.

## Solution

- Added `load_kicad_env_vars()` static method to `PlatformHelper` to read environment.vars from kicad_common.json
- Called this method in `_resolve_uri` of both `library.py` and `library_symbol.py` to merge user-defined variables
- Cross-platform support: macOS, Linux, Windows KiCad configuration paths

## Tests

Added `tests/test_kicad_common_env_resolution.py` with 4 regression tests:

1. `test_symbol_manager_resolves_user_defined_env_var` - Verifies symbol library manager resolves custom variables
2. `test_library_manager_resolves_user_defined_env_var` - Verifies footprint library manager resolves custom variables
3. `test_sym_lib_table_entry_with_user_var_is_loaded` - End-to-end test for sym-lib-table parsing
4. `test_user_defined_and_builtin_vars_coexist` - Verifies custom and built-in variables coexist

All tests pass with no regressions.

## Related Files

- `python/utils/platform_helper.py` - Added `load_kicad_env_vars()`
- `python/commands/library.py` - Calls `load_kicad_env_vars()`
- `python/commands/library_symbol.py` - Calls `load_kicad_env_vars()`
- `tests/test_kicad_common_env_resolution.py` - New test file