### PR TITLE
fix: filter pins by unit in _find_pins_on_net for multi-unit symbols (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`get_wire_connections` no longer reports phantom cross-unit pins** (#293):
+  `_find_pins_on_net` transformed every unit's pins against every placed
+  instance of a multi-unit component, so a sibling unit's pin whose library
+  offset matched could land on this instance's wire and be reported as a
+  false member of the net (e.g. an LM358's pin 7 appearing on unit A's
+  output net alongside pin 1). `_parse_symbol_instances_sexp` now records
+  each instance's `(unit N)`, and `_find_pins_on_net` filters the pin
+  definitions to that unit (plus unit 0, common to all units) before
+  transforming them. Complements #272, which fixed the query-coordinate side
+  of the same multi-unit gap; the pin `unit` tags it added are what this fix
+  consumes. Single-unit parts are unaffected.
+
 - **`create_project` writes a conformant KiCad 10 `.kicad_pro`** (#220): the
   project file was a hand-rolled 122-byte stub containing only
   `board.filename` and a `sheets` entry with the literal id `"root"`, so

--- a/python/commands/wire_connectivity.py
+++ b/python/commands/wire_connectivity.py
@@ -365,6 +365,7 @@ def _parse_symbol_instances_sexp(
             "rotation": 0.0,
             "mirror_x": False,
             "mirror_y": False,
+            "unit": 0,
         }
 
         for sub in item[1:]:
@@ -385,6 +386,8 @@ def _parse_symbol_instances_sexp(
                         inst["mirror_x"] = True
                     elif mv == "y":
                         inst["mirror_y"] = True
+            elif tag == Symbol("unit") and len(sub) >= 2:
+                inst["unit"] = int(sub[1])
             elif tag == Symbol("property") and len(sub) >= 3:
                 prop_name = str(sub[1]).strip('"')
                 if prop_name == "Reference":
@@ -445,6 +448,22 @@ def _find_pins_on_net(
             if not pin_defs:
                 logger.debug(f"  {ref}: no pin definitions for lib_id={lib_id}")
                 continue
+
+            # For a multi-unit component, each placed instance carries a single
+            # (unit N) and only owns the pins defined in that unit's sub-symbol
+            # (plus unit 0, which is common to every unit). Without this filter,
+            # every unit's pins are transformed against every instance's
+            # position, so a sibling unit's pin can land on this instance's wire
+            # and be reported as a phantom member of the net (#293).
+            inst_unit = inst["unit"]
+            if inst_unit:
+                pin_defs = {
+                    num: pdata
+                    for num, pdata in pin_defs.items()
+                    if pdata.get("unit", 0) in (0, inst_unit)
+                }
+                if not pin_defs:
+                    continue
 
             sym_x = inst["x"]
             sym_y = inst["y"]

--- a/tests/test_wire_connectivity_multi_unit.py
+++ b/tests/test_wire_connectivity_multi_unit.py
@@ -1,0 +1,144 @@
+"""
+Regression tests for issue #293:
+
+    get_wire_connections reports phantom cross-unit pins in net membership
+
+A multi-unit part is placed as several ``(symbol ...)`` instances that share
+one reference designator but each carry their own ``(unit N)``, position and
+rotation. Each instance only owns the pins defined in its unit's sub-symbol
+(plus unit 0, common to all units).
+
+The bug: ``_find_pins_on_net`` transformed *every* unit's pins against *every*
+instance's position. When two units share an x-coordinate and their pins have
+identical library offsets (the normal case for a dual op-amp), a sibling unit's
+pin lands exactly on this instance's wire and is reported as a phantom member
+of the net.
+
+These tests place a 2-unit symbol whose two units share x and differ only in y,
+wire each unit's output pin to a distinct passive, and assert that each net
+contains only the pin from its own unit -- never the sibling unit's pin.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+PYTHON_DIR = Path(__file__).parent.parent / "python"
+sys.path.insert(0, str(PYTHON_DIR))
+
+
+# Two-unit symbol "TEST:DualAmp":
+#   unit 1 output = pin 3, unit 2 output = pin 7, both at lib offset (7.62, 0).
+# Placed:
+#   unit 1 at (100, 100) -> output pin 3 at (107.62, 100)
+#   unit 2 at (100, 150) -> output pin 7 at (107.62, 150)
+# A wire + resistor hangs off each output. Because both units share x=100 and
+# both outputs are at lib-x +7.62, the pre-fix code transforms unit 2's pin 7
+# against unit 1's instance -> (107.62, 100), landing on unit 1's wire, and
+# vice versa. The fix must keep pin 7 off unit 1's net and pin 3 off unit 2's.
+MULTI_UNIT_SCH = """\
+(kicad_sch (version 20250114) (generator "test")
+  (uuid 00000000-0000-0000-0000-0000000000aa)
+  (paper "A4")
+  (lib_symbols
+    (symbol "TEST:DualAmp" (pin_names (offset 0)) (in_bom yes) (on_board yes)
+      (property "Reference" "U" (at 0 0 0))
+      (property "Value" "DualAmp" (at 0 0 0))
+      (symbol "DualAmp_1_1"
+        (pin output line (at 7.62 0 180) (length 2.54)
+          (name "~" (effects (font (size 1.27 1.27))))
+          (number "3" (effects (font (size 1.27 1.27))))
+        )
+      )
+      (symbol "DualAmp_2_1"
+        (pin output line (at 7.62 0 180) (length 2.54)
+          (name "~" (effects (font (size 1.27 1.27))))
+          (number "7" (effects (font (size 1.27 1.27))))
+        )
+      )
+    )
+    (symbol "Device:R" (pin_numbers (hide yes)) (pin_names (offset 0))
+      (property "Reference" "R" (at 0 0 0))
+      (property "Value" "R" (at 0 0 0))
+      (symbol "R_0_1")
+      (symbol "R_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27)
+          (name "~" (effects (font (size 1.27 1.27))))
+          (number "1" (effects (font (size 1.27 1.27))))
+        )
+        (pin passive line (at 0 -3.81 90) (length 1.27)
+          (name "~" (effects (font (size 1.27 1.27))))
+          (number "2" (effects (font (size 1.27 1.27))))
+        )
+      )
+    )
+  )
+  (symbol (lib_id "TEST:DualAmp") (at 100 100 0) (unit 1)
+    (uuid 00000000-0000-0000-0000-000000000001)
+    (property "Reference" "U1" (at 100 90 0))
+    (property "Value" "DualAmp" (at 100 110 0))
+  )
+  (symbol (lib_id "TEST:DualAmp") (at 100 150 0) (unit 2)
+    (uuid 00000000-0000-0000-0000-000000000002)
+    (property "Reference" "U1" (at 100 140 0))
+    (property "Value" "DualAmp" (at 100 160 0))
+  )
+  (symbol (lib_id "Device:R") (at 120 100 90) (unit 1)
+    (uuid 00000000-0000-0000-0000-000000000101)
+    (property "Reference" "R1" (at 120 95 0))
+    (property "Value" "1k" (at 120 105 0))
+  )
+  (symbol (lib_id "Device:R") (at 120 150 90) (unit 1)
+    (uuid 00000000-0000-0000-0000-000000000102)
+    (property "Reference" "R2" (at 120 145 0))
+    (property "Value" "1k" (at 120 155 0))
+  )
+  (wire (pts (xy 107.62 100) (xy 116.19 100))
+    (stroke (width 0) (type default)) (uuid 00000000-0000-0000-0000-000000000201))
+  (wire (pts (xy 107.62 150) (xy 116.19 150))
+    (stroke (width 0) (type default)) (uuid 00000000-0000-0000-0000-000000000202))
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+@pytest.fixture()
+def multi_unit_sch():
+    with tempfile.TemporaryDirectory() as tmp:
+        sch_path = Path(tmp) / "multi_unit.kicad_sch"
+        sch_path.write_text(MULTI_UNIT_SCH, encoding="utf-8")
+        yield sch_path
+
+
+def _pins_on_net_at(sch_path, x_mm, y_mm):
+    """Return the set of "REF/PIN" strings on the net reachable from a point."""
+    from commands.wire_connectivity import get_wire_connections
+    from skip import Schematic
+
+    sch = Schematic(str(sch_path))
+    result = get_wire_connections(sch, str(sch_path), x_mm, y_mm)
+    assert result is not None
+    return {f"{p['component']}/{p['pin']}" for p in result["pins"]}
+
+
+@pytest.mark.integration
+class TestNoPhantomCrossUnitPins:
+    """Each unit's output net must contain only that unit's pin (#293)."""
+
+    def test_unit1_net_excludes_unit2_pin(self, multi_unit_sch):
+        # Unit 1 output wire runs from (107.62, 100).
+        pins = _pins_on_net_at(multi_unit_sch, 107.62, 100.0)
+        assert "U1/3" in pins  # unit 1's own output
+        assert "R1/2" in pins  # the passive wired to it
+        assert "U1/7" not in pins  # phantom sibling-unit pin must be gone
+
+    def test_unit2_net_excludes_unit1_pin(self, multi_unit_sch):
+        # Unit 2 output wire runs from (107.62, 150).
+        pins = _pins_on_net_at(multi_unit_sch, 107.62, 150.0)
+        assert "U1/7" in pins  # unit 2's own output
+        assert "R2/2" in pins  # the passive wired to it
+        assert "U1/3" not in pins  # phantom sibling-unit pin must be gone


### PR DESCRIPTION
## Summary

Fixes #293 — `get_wire_connections` reported phantom cross-unit pins in its net-membership list for multi-unit components.

`_find_pins_on_net` transformed **every** unit's pins against **every** placed instance of a multi-unit component. When two units share an x-coordinate and their pins have identical library offsets (the normal case for a dual op-amp), a sibling unit's pin lands exactly on this instance's wire and is reported as a false member of the net — e.g. an LM358's pin 7 (unit B output) appearing on unit A's output net alongside pin 1.

This is the net-membership counterpart to #272, which fixed the query-**coordinate** side of the same multi-unit gap. #272 added a per-pin `unit` tag in `parse_symbol_definition`; this PR consumes that tag in `wire_connectivity.py`.

## Root cause

`_parse_symbol_instances_sexp` (in `wire_connectivity.py`) parsed placed symbol instances but did not extract the `(unit N)` field. Downstream, `_find_pins_on_net` fetched all of a symbol's pins via `get_symbol_pins` and transformed them against each instance's position with no unit filtering, so pins from sibling units produced phantom net associations.

## Fix

Two changes, both in `python/commands/wire_connectivity.py`:

1. `_parse_symbol_instances_sexp` now records each instance's `(unit N)` (defaulting to `0`).
2. `_find_pins_on_net` filters the pin definitions to the instance's own unit plus unit 0 (the shared/common body) before transforming them.

Single-unit parts are unaffected: their instances carry no `unit` (or unit 0), which skips the filter entirely and preserves the original behaviour.

## Example (LM358, 3 units)

Real schematic, reference IC-1. Verified against `kicad-cli sch export netlist`:

| Pin | Before (phantom) | After |
|-----|------------------|-------|
| 1 | C1, IC-1/1, **IC-1/7**, R23 | C1, IC-1/1, R23 |
| 7 | **IC-1/1**, IC-1/7, R28, C2, R29 | IC-1/7, R28, C2, R29 |
| 3 | R22, IC-1/3, **IC-1/5**, D2, D1 | R22, IC-1/3, D2, D1 |
| 5 | **IC-1/3**, IC-1/5, D4, R26, D3 | IC-1/5, D4, R26, D3 |
| 8 | (clean) | (clean) |
| 4 | (clean) | (clean) |

Power pins 4/8 (unit 3) were already clean because unit 3 is placed far from units 1/2, so its mis-transformed pins didn't land on their wires.

## Tests

New `tests/test_wire_connectivity_multi_unit.py`: places a 2-unit symbol whose units share x and differ only in y, wires each unit's output to a distinct passive, and asserts each net contains only its own unit's pin — never the sibling's. Both tests **fail without the fix** (verified by stashing the change) and pass with it.

```
pytest tests/test_wire_connectivity_multi_unit.py                    # 2 passed
pytest tests/test_wire_connectivity.py \
       tests/test_pin_locator_multi_unit.py \
       tests/test_pin_locator_and_component.py \
       tests/test_net_connectivity.py \
       tests/test_label_at_pin_net_connections.py                    # 83 passed, no regressions
```

Black, isort, flake8, and mypy all pass on the changed files.

## PR Checklist

- [x] Code follows style guidelines
- [x] All tests pass locally
- [x] New tests added for new behavior
- [x] Documentation updated (CHANGELOG.md under [Unreleased])
- [x] Commit messages follow convention
- [x] No merge conflicts