### PR TITLE
fix: start new projects/schematics blank instead of seeding _TEMPLATE_ symbols (#221 A+C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,21 @@ All notable changes to the KiCAD MCP Server project are documented here.
   `add_schematic_component` tool synthesizes its own `lib_symbols` via the
   dynamic loader (and the legacy fallback was removed in #288), so the seeds only
   leaked into user files. Both tools now copy a new blank KiCad 10 template
-  (`python/templates/blank.kicad_sch`: `(version 20260306) (generator
-"eeschema")`, empty `lib_symbols`, no placed symbols).
+  (`python/templates/blank.kicad_sch`: `(version 20260101) (generator
+  "eeschema")`, empty `lib_symbols`, no placed symbols).
   `template_with_symbols.kicad_sch` is kept unchanged in-repo as a test fixture.
   A regression test asserts a created schematic contains no `_TEMPLATE_`
   references and no seeded `lib_symbols` entries.
+
+- **Generated schematics use format version `20260101`, not `20260306`, so
+  every KiCad 10.0.x can open them**: KiCad refuses to load files that claim
+  a format version newer than the running build, and `20260306` is a later
+  10.0.x token — KiCad 10.0.0 (whose `kicad-cli sch upgrade` writes
+  `20260101`) reported "Failed to load schematic" on our output. All
+  templates, fallback writers, and test fixtures now use `20260101`, which
+  loads on every 10.0.x (newer builds silently upgrade on save). This also
+  makes `tests/fixtures/canonical_schematic.kicad_sch` loadable by
+  `kicad-cli`, which it previously was not.
 
 - **`create_project` writes a conformant KiCad 10 `.kicad_pro`** (#220): the
   project file was a hand-rolled 122-byte stub containing only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **New projects and schematics start blank instead of seeding `_TEMPLATE_*`
+  symbols** (#221, #243): `create_project` and `create_schematic` copied
+  `template_with_symbols_expanded.kicad_sch` / `template_with_symbols.kicad_sch`,
+  which pre-seeded `Device:R/C/LED` `lib_symbols` and placed `_TEMPLATE_*`
+  instances into every new file. Those symbols existed only as clone sources for
+  the legacy `ComponentManager.add_component` path; the live
+  `add_schematic_component` tool synthesizes its own `lib_symbols` via the
+  dynamic loader (and the legacy fallback was removed in #288), so the seeds only
+  leaked into user files. Both tools now copy a new blank KiCad 10 template
+  (`python/templates/blank.kicad_sch`: `(version 20260306) (generator
+"eeschema")`, empty `lib_symbols`, no placed symbols).
+  `template_with_symbols.kicad_sch` is kept unchanged in-repo as a test fixture.
+  A regression test asserts a created schematic contains no `_TEMPLATE_`
+  references and no seeded `lib_symbols` entries.
+
 - **`create_project` writes a conformant KiCad 10 `.kicad_pro`** (#220): the
   project file was a hand-rolled 122-byte stub containing only
   `board.filename` and a `sheets` entry with the literal id `"root"`, so
@@ -145,7 +160,7 @@ the KiCad GUI connects later (reopen the project to adopt IPC).
   components via dynamic template injection** (#221, part B): when no placed
   `_TEMPLATE_*` donor existed, the legacy clone path used to call
   `DynamicSymbolLoader.load_symbol_dynamically`, which wrote a template
-  instance into the *file* mid-call and cloned onto a locally reloaded
+  instance into the _file_ mid-call and cloned onto a locally reloaded
   object — so callers following the normal add-then-save pattern saved
   their stale in-memory schematic, discarding the new component and
   leaving `_TEMPLATE_*` clutter behind. That branch is removed: template

--- a/python/commands/project.py
+++ b/python/commands/project.py
@@ -110,7 +110,7 @@ class ProjectCommands:
                     # new file). The older 20250114 token is the KiCad 9 format and
                     # is stale under KiCad 10 (issue #221).
                     f.write(
-                        '(kicad_sch (version 20260306) (generator "eeschema")'
+                        '(kicad_sch (version 20260101) (generator "eeschema")'
                         ' (generator_version "10.0")\n\n'
                     )
                     f.write(f"  (uuid {schematic_root_uuid})\n\n")

--- a/python/commands/project.py
+++ b/python/commands/project.py
@@ -63,13 +63,17 @@ class ProjectCommands:
             board.SetFileName(board_path)
             pcbnew.SaveBoard(board_path, board)
 
-            # Create schematic from template (use expanded template with symbol definitions)
+            # Create schematic from a blank KiCad 10 template (empty lib_symbols,
+            # no placed symbols). The old template_with_symbols_expanded.kicad_sch
+            # pre-seeded _TEMPLATE_* symbols that leaked into every new project;
+            # the live add tool synthesizes its own lib_symbols via the dynamic
+            # loader, so a blank start is correct (issue #221, also closes #243).
             schematic_path = project_path.replace(".kicad_pro", ".kicad_sch")
             template_sch_path = os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),
                 "..",
                 "templates",
-                "template_with_symbols_expanded.kicad_sch",
+                "blank.kicad_sch",
             )
 
             if os.path.exists(template_sch_path):

--- a/python/commands/schematic.py
+++ b/python/commands/schematic.py
@@ -19,12 +19,17 @@ class SchematicManager:
     ) -> Any:
         """Create a new empty schematic from template"""
         try:
-            # Determine template path (use template_with_symbols for component cloning support)
+            # Determine template path. New schematics start from a blank KiCad 10
+            # file (empty lib_symbols, no placed symbols) rather than the seeded
+            # template_with_symbols.kicad_sch — the live add tool synthesizes its
+            # own lib_symbols via the dynamic loader, so the pre-seeded
+            # _TEMPLATE_* symbols are not needed and only leaked into user files
+            # (issue #221, also closes #243).
             template_path = os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),
                 "..",
                 "templates",
-                "template_with_symbols.kicad_sch",
+                "blank.kicad_sch",
             )
 
             # Determine output path. A caller may pass `path` as either a

--- a/python/commands/schematic.py
+++ b/python/commands/schematic.py
@@ -75,7 +75,7 @@ class SchematicManager:
                     # new file). The older 20250114 token is the KiCad 9 format and
                     # is stale under KiCad 10 (issue #221).
                     f.write(
-                        '(kicad_sch (version 20260306) (generator "eeschema")'
+                        '(kicad_sch (version 20260101) (generator "eeschema")'
                         ' (generator_version "10.0")\n\n'
                     )
                     f.write(f"  (uuid {schematic_uuid})\n\n")

--- a/python/templates/blank.kicad_sch
+++ b/python/templates/blank.kicad_sch
@@ -1,4 +1,4 @@
-(kicad_sch (version 20260306) (generator "eeschema") (generator_version "10.0")
+(kicad_sch (version 20260101) (generator "eeschema") (generator_version "10.0")
 
   (uuid 00000000-0000-0000-0000-000000000000)
 

--- a/python/templates/blank.kicad_sch
+++ b/python/templates/blank.kicad_sch
@@ -1,0 +1,13 @@
+(kicad_sch (version 20260306) (generator "eeschema") (generator_version "10.0")
+
+  (uuid 00000000-0000-0000-0000-000000000000)
+
+  (paper "A4")
+
+  (lib_symbols
+  )
+
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)

--- a/tests/fixtures/canonical_schematic.kicad_sch
+++ b/tests/fixtures/canonical_schematic.kicad_sch
@@ -1,5 +1,5 @@
 (kicad_sch
-	(version 20260306)
+	(version 20260101)
 	(generator "eeschema")
 	(generator_version "10.0")
 	(uuid "f379cdcf-95e9-40fb-bb22-dbfcc9b050ce")

--- a/tests/test_add_schematic_component.py
+++ b/tests/test_add_schematic_component.py
@@ -208,7 +208,7 @@ class TestHandlerAddSchematicComponent:
 # instances before the closing paren of (kicad_sch ...) when the marker is
 # missing.
 SUB_SHEET_NO_SHEET_INSTANCES = """(kicad_sch
-\t(version 20260306)
+\t(version 20260101)
 \t(generator "eeschema")
 \t(generator_version "10.0")
 \t(uuid "bbbb2222-2222-2222-2222-bbbbbbbbbbbb")

--- a/tests/test_add_wire_sub_sheet.py
+++ b/tests/test_add_wire_sub_sheet.py
@@ -21,7 +21,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
 # Minimal sub-sheet content: same outer (kicad_sch ...) form as a root sheet
 # but WITHOUT (sheet_instances ...).
 SUB_SHEET_NO_SHEET_INSTANCES = """(kicad_sch
-\t(version 20260306)
+\t(version 20260101)
 \t(generator "eeschema")
 \t(generator_version "10.0")
 \t(uuid "bbbb2222-2222-2222-2222-bbbbbbbbbbbb")

--- a/tests/test_blank_template_no_seed.py
+++ b/tests/test_blank_template_no_seed.py
@@ -1,0 +1,90 @@
+"""
+Regression tests for issue #221 (and #243):
+
+    create_project / create_schematic seeded new files with _TEMPLATE_* symbols
+
+New projects and schematics must start from a *blank* KiCad 10 file: an empty
+``lib_symbols`` block and no placed ``_TEMPLATE_*`` symbol instances. The live
+``add_schematic_component`` tool synthesizes its own ``lib_symbols`` via the
+dynamic loader, so the previously pre-seeded template symbols only leaked into
+user files.
+
+These tests run the real ``shutil.copy`` + file writing against a temp dir
+(only stubbing the heavy ``Schematic`` / ``pcbnew`` dependencies), then read the
+produced ``.kicad_sch`` back and assert it is genuinely blank.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# pcbnew and skip are only available inside KiCAD — stub them so the command
+# modules can be imported in a plain Python environment.
+sys.modules.setdefault("pcbnew", MagicMock())
+sys.modules.setdefault("skip", MagicMock())
+
+# project.py imports `from utils.kicad_project import ...`, which needs the
+# python/ package root on sys.path.
+_PYTHON_DIR = Path(__file__).parent.parent / "python"
+sys.path.insert(0, str(_PYTHON_DIR))
+
+_COMMANDS_DIR = _PYTHON_DIR / "commands"
+
+
+def _load(module_name: str, filename: str):
+    """Import a command module directly, bypassing python/commands/__init__.py."""
+    spec = importlib.util.spec_from_file_location(
+        module_name, os.path.join(_COMMANDS_DIR, filename)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_sch_mod = _load("schematic_module", "schematic.py")
+_proj_mod = _load("project_module", "project.py")
+SchematicManager = _sch_mod.SchematicManager
+ProjectCommands = _proj_mod.ProjectCommands
+
+
+def _assert_blank(sch_text: str) -> None:
+    assert "_TEMPLATE_" not in sch_text, "new schematic must not seed _TEMPLATE_* symbols"
+    # No placed symbol instances at all in a blank schematic.
+    assert "(symbol (lib_id" not in sch_text, "new schematic must not place any symbols"
+    # lib_symbols must be present but empty (no seeded Device:R/C/LED etc.).
+    assert "(lib_symbols" in sch_text
+    assert "Device:R" not in sch_text
+    assert '(symbol "' not in sch_text, "lib_symbols must be empty"
+    # And it must carry the current KiCad 10 header.
+    assert "(version 20260306)" in sch_text
+    assert "20250114" not in sch_text
+
+
+def test_blank_template_file_is_blank():
+    """The bundled blank.kicad_sch template itself is empty and KiCad 10."""
+    blank = Path(__file__).parent.parent / "python" / "templates" / "blank.kicad_sch"
+    _assert_blank(blank.read_text(encoding="utf-8"))
+
+
+def test_create_schematic_produces_blank_file(tmp_path):
+    """create_schematic copies the blank template; result has no seeded symbols."""
+    with patch.object(_sch_mod, "Schematic", MagicMock()):
+        SchematicManager.create_schematic("fresh", path=str(tmp_path))
+
+    produced = tmp_path / "fresh.kicad_sch"
+    assert produced.exists(), "schematic file was not written"
+    _assert_blank(produced.read_text(encoding="utf-8"))
+
+
+def test_create_project_produces_blank_schematic(tmp_path):
+    """create_project writes a blank schematic alongside the project."""
+    cmds = ProjectCommands()
+    with patch.object(_proj_mod, "pcbnew", MagicMock()):
+        result = cmds.create_project({"name": "Fresh", "path": str(tmp_path)})
+
+    assert result["success"] is True, result
+    produced = tmp_path / "Fresh.kicad_sch"
+    assert produced.exists(), f"schematic not found at {produced}"
+    _assert_blank(produced.read_text(encoding="utf-8"))

--- a/tests/test_blank_template_no_seed.py
+++ b/tests/test_blank_template_no_seed.py
@@ -58,7 +58,7 @@ def _assert_blank(sch_text: str) -> None:
     assert "Device:R" not in sch_text
     assert '(symbol "' not in sch_text, "lib_symbols must be empty"
     # And it must carry the current KiCad 10 header.
-    assert "(version 20260306)" in sch_text
+    assert "(version 20260101)" in sch_text
     assert "20250114" not in sch_text
 
 

--- a/tests/test_component_manager_legacy.py
+++ b/tests/test_component_manager_legacy.py
@@ -27,7 +27,7 @@ _TEMPLATE_SCH = (
     Path(__file__).parent.parent / "python" / "templates" / "template_with_symbols.kicad_sch"
 )
 
-_BLANK_SCH = """(kicad_sch (version 20260306) (generator "eeschema") (generator_version "10.0")
+_BLANK_SCH = """(kicad_sch (version 20260101) (generator "eeschema") (generator_version "10.0")
   (uuid 3c9f2b6e-1a2b-4c3d-8e4f-5a6b7c8d9e0f)
   (paper "A4")
   (lib_symbols)

--- a/tests/test_create_project_paths.py
+++ b/tests/test_create_project_paths.py
@@ -74,6 +74,6 @@ def test_create_project_fallback_schematic_uses_kicad10_header():
 
     assert result["success"] is True, result
     written = "".join(call.args[0] for call in m().write.call_args_list)
-    assert "(version 20260306)" in written, written
+    assert "(version 20260101)" in written, written
     assert 'generator "eeschema"' in written
     assert "20250114" not in written

--- a/tests/test_create_schematic_path.py
+++ b/tests/test_create_schematic_path.py
@@ -125,6 +125,6 @@ def test_create_schematic_fallback_writes_kicad10_header():
         SchematicManager.create_schematic("myschematic")
 
     written = "".join(call.args[0] for call in m().write.call_args_list)
-    assert "(version 20260306)" in written, written
+    assert "(version 20260101)" in written, written
     assert 'generator "eeschema"' in written
     assert "20250114" not in written

--- a/tests/test_edit_schematic_component_instances.py
+++ b/tests/test_edit_schematic_component_instances.py
@@ -130,7 +130,7 @@ def _write_schematic(tmp_path: Path, placed_block: str) -> Path:
     sch = tmp_path / "test.kicad_sch"
     sch.write_text(
         "(kicad_sch\n"
-        '  (version 20260306)\n'
+        '  (version 20260101)\n'
         '  (generator "eeschema")\n'
         '  (uuid "abcdef12-3456-7890-abcd-ef1234567890")\n'
         '  (paper "A4")\n'

--- a/tests/test_sexpr_format.py
+++ b/tests/test_sexpr_format.py
@@ -24,7 +24,7 @@ FIXTURES = Path(__file__).parent / "fixtures"
 # tab indentation, and the trailing newline.
 CANONICAL_GOLDEN = (
     "(kicad_sch\n"
-    "\t(version 20260306)\n"
+    "\t(version 20260101)\n"
     '\t(generator "eeschema")\n'
     '\t(generator_version "10.0")\n'
     '\t(uuid "11111111-1111-4111-8111-111111111111")\n'


### PR DESCRIPTION
## Summary

Fixes #221 and closes #243 — this is **Part A + C** of the plan agreed in
#221, following the maintainer's merge of Part B (#288).

`create_project` and `create_schematic` copied seeded templates
(`template_with_symbols_expanded.kicad_sch` / `template_with_symbols.kicad_sch`)
that pre-loaded `Device:R/C/LED` `lib_symbols` **and** placed `_TEMPLATE_*`
symbol instances into every new file. Those seeds existed only as clone sources
for the legacy `ComponentManager.add_component` path — the live
`add_schematic_component` tool synthesizes its own `lib_symbols` via the dynamic
loader, and the legacy template fallback was removed in #288 — so the seeds only
leaked stale KiCad 9 content into user projects.

## Changes

**A — repoint both creation paths to a blank KiCad 10 template**

- New `python/templates/blank.kicad_sch`: header
  `(version 20260306) (generator "eeschema") (generator_version "10.0")`,
  empty `lib_symbols`, no placed symbols.
- `create_schematic` (`python/commands/schematic.py`) now copies
  `blank.kicad_sch` instead of `template_with_symbols.kicad_sch`.
- `create_project` (`python/commands/project.py`) now copies `blank.kicad_sch`
  instead of `template_with_symbols_expanded.kicad_sch` (both call sites
  repointed, as requested).

**C — keep the seeded template as a test fixture**

- `template_with_symbols.kicad_sch` is left **unchanged** in-repo; the
  pin-geometry oracle tests load it directly and stay green.

Left in place intentionally (per your guidance): the `_TEMPLATE_`-prefix filters
in the ERC/analysis/layout modules — removing them now would change behavior for
schematics created from the old template.

## Tests

New `tests/test_blank_template_no_seed.py` (3 tests):

- the bundled `blank.kicad_sch` is blank + KiCad 10;
- `create_schematic` produces a file with **no `_TEMPLATE_` references and no
  seeded `lib_symbols`**;
- `create_project` produces a blank schematic likewise.

The assertions run the real `shutil.copy` + file writes against a temp dir
(only the heavy `Schematic` / `pcbnew` deps are stubbed), so they exercise the
actual bytes written to disk. This is the direct regression test for #221 and
#243.

Existing `create_schematic` / `create_project` path + fallback-header tests
still pass, as do the fixture-based add/pin tests (including the #288
mirror-canary tests that seed from `template_with_symbols.kicad_sch`).

## Note

`template_with_symbols_expanded.kicad_sch` now has no runtime consumer (it was
only referenced by the `create_project` call site repointed here). I left it in
the repo rather than delete it in this PR — happy to remove it in a follow-up if
you'd prefer, since it's no longer wired to anything.
