### PR TITLE
fix: unify KiCad install-root discovery (registry + custom roots) (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ All notable changes to the KiCAD MCP Server project are documented here.
   newest-version first from the Windows registry uninstall keys
   (`InstallLocation`, authoritative for wherever the user installed), the
   `C:\Program Files\KiCad\*` / `(x86)` globs, and common custom roots
-  (`C:\KiCad\*`), de-duplicated. `utils/kicad_cli.py`, `utils/platform_helper.py`,
-  and `commands/library.py` now build their Windows paths from it, so discovery
+  (`C:\KiCad\*`), de-duplicated and cached per-process. `utils/kicad_cli.py`,
+  `utils/platform_helper.py`, `commands/library.py` (footprints), and
+  `commands/library_symbol.py` (symbols) now build their Windows paths from it, so
+  discovery
   can no longer drift apart (the same unification #267 did for the three
   `kicad-cli` resolvers). macOS/Linux behavior is unchanged.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **KiCad install discovery is unified and finds relocated Windows installs**
+  (#286): `kicad-cli` resolution, symbol/python-path discovery, and footprint-dir
+  lookup each independently assumed KiCad lived under `C:\Program Files\KiCad`, so
+  a custom install root (the installer allows any; short roots like
+  `C:\KiCad\10.0` are common) got degraded discovery in three different ways. A
+  new shared helper `python/utils/kicad_roots.py` yields KiCad install roots
+  newest-version first from the Windows registry uninstall keys
+  (`InstallLocation`, authoritative for wherever the user installed), the
+  `C:\Program Files\KiCad\*` / `(x86)` globs, and common custom roots
+  (`C:\KiCad\*`), de-duplicated. `utils/kicad_cli.py`, `utils/platform_helper.py`,
+  and `commands/library.py` now build their Windows paths from it, so discovery
+  can no longer drift apart (the same unification #267 did for the three
+  `kicad-cli` resolvers). macOS/Linux behavior is unchanged.
+
 - **`create_project` writes a conformant KiCad 10 `.kicad_pro`** (#220): the
   project file was a hand-rolled 122-byte stub containing only
   `board.filename` and a `sheets` entry with the literal id `"root"`, so
@@ -145,7 +159,7 @@ the KiCad GUI connects later (reopen the project to adopt IPC).
   components via dynamic template injection** (#221, part B): when no placed
   `_TEMPLATE_*` donor existed, the legacy clone path used to call
   `DynamicSymbolLoader.load_symbol_dynamically`, which wrote a template
-  instance into the *file* mid-call and cloned onto a locally reloaded
+  instance into the _file_ mid-call and cloned onto a locally reloaded
   object — so callers following the normal add-then-save pattern saved
   their stale in-memory schematic, discarding the new component and
   leaving `_TEMPLATE_*` clutter behind. That branch is removed: template

--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -35,7 +35,19 @@ class DynamicSymbolLoader:
 
     def find_kicad_symbol_libraries(self) -> List[Path]:
         """Find all KiCad symbol library directories"""
-        possible_paths = [
+        # Discovered install roots first (registry + Program Files globs +
+        # custom roots like C:\KiCad, newest version first) — the same shared
+        # helper the cli/footprint/symbol-search paths use (#286), so the
+        # production component-placement path cannot drift from the rest of
+        # discovery again. Env-var overrides below still take precedence.
+        try:
+            from utils.kicad_roots import kicad_install_roots
+
+            root_symbol_dirs = [r / "share" / "kicad" / "symbols" for r in kicad_install_roots()]
+        except Exception:  # pragma: no cover - defensive; helper is stdlib-only
+            root_symbol_dirs = []
+
+        possible_paths = root_symbol_dirs + [
             Path("C:/Program Files/KiCad/10.0/share/kicad/symbols"),
             Path("/usr/share/kicad/symbols"),
             Path("/usr/local/share/kicad/symbols"),

--- a/python/commands/library.py
+++ b/python/commands/library.py
@@ -12,6 +12,8 @@ import re
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from utils.kicad_roots import kicad_install_roots
+
 logger = logging.getLogger("kicad_interface")
 
 
@@ -188,8 +190,6 @@ class LibraryManager:
         # Prepend Windows install roots from the shared discovery helper (registry
         # + Program Files + custom C:\KiCad roots, newest first) so a relocated
         # install's footprints are found, not just Program Files ones (#286).
-        from utils.kicad_roots import kicad_install_roots
-
         for root in reversed(kicad_install_roots()):
             possible_paths.insert(0, str(root / "share" / "kicad" / "footprints"))
 

--- a/python/commands/library.py
+++ b/python/commands/library.py
@@ -182,11 +182,16 @@ class LibraryManager:
         possible_paths = [
             "/usr/share/kicad/footprints",
             "/usr/local/share/kicad/footprints",
-            "C:/Program Files/KiCad/10.0/share/kicad/footprints",
-            "C:/Program Files/KiCad/9.0/share/kicad/footprints",
-            "C:/Program Files/KiCad/8.0/share/kicad/footprints",
             "/Applications/KiCad/KiCad.app/Contents/SharedSupport/footprints",
         ]
+
+        # Prepend Windows install roots from the shared discovery helper (registry
+        # + Program Files + custom C:\KiCad roots, newest first) so a relocated
+        # install's footprints are found, not just Program Files ones (#286).
+        from utils.kicad_roots import kicad_install_roots
+
+        for root in reversed(kicad_install_roots()):
+            possible_paths.insert(0, str(root / "share" / "kicad" / "footprints"))
 
         # Also check environment variable
         if "KICAD10_FOOTPRINT_DIR" in os.environ:

--- a/python/commands/library_symbol.py
+++ b/python/commands/library_symbol.py
@@ -13,6 +13,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from utils.kicad_roots import kicad_install_roots
+
 logger = logging.getLogger("kicad_interface")
 
 
@@ -228,13 +230,17 @@ class SymbolLibraryManager:
     def _find_kicad_symbol_dir(self) -> Optional[str]:
         """Find KiCAD symbol directory"""
         possible_paths = [
-            "C:/Program Files/KiCad/10.0/share/kicad/symbols",
             "/usr/share/kicad/symbols",
             "/usr/local/share/kicad/symbols",
-            "C:/Program Files/KiCad/9.0/share/kicad/symbols",
-            "C:/Program Files/KiCad/8.0/share/kicad/symbols",
             "/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols",
         ]
+
+        # Prepend Windows install roots from the shared discovery helper (registry
+        # + Program Files + custom C:\KiCad roots, newest first) so a relocated
+        # install's symbols are found the same as its footprints (#286) — this
+        # closes the gap where symbols stayed hardcoded to Program Files.
+        for root in reversed(kicad_install_roots()):
+            possible_paths.insert(0, str(root / "share" / "kicad" / "symbols"))
 
         # Check environment variable
         if "KICAD10_SYMBOL_DIR" in os.environ:

--- a/python/utils/kicad_cli.py
+++ b/python/utils/kicad_cli.py
@@ -57,17 +57,11 @@ def _candidate_paths() -> List[Path]:
     candidates: List[Path] = []
 
     if system == "Windows":
-        for base in (r"C:\Program Files\KiCad", r"C:\Program Files (x86)\KiCad"):
-            base_dir = Path(base)
-            if base_dir.is_dir():
-                versions = sorted(
-                    (p for p in base_dir.iterdir() if p.is_dir()),
-                    key=lambda p: p.name,
-                    reverse=True,
-                )
-                candidates.extend(v / "bin" / name for v in versions)
-            # Some installs drop straight into <base>\bin without a version dir.
-            candidates.append(base_dir / "bin" / name)
+        # Shared root discovery (registry + Program Files + custom C:\KiCad roots,
+        # newest first) so cli/symbol/footprint lookups can't drift apart (#286).
+        from utils.kicad_roots import windows_kicad_roots
+
+        candidates.extend(root / "bin" / name for root in windows_kicad_roots())
     elif system == "Darwin":
         candidates.extend(
             [

--- a/python/utils/kicad_roots.py
+++ b/python/utils/kicad_roots.py
@@ -30,13 +30,18 @@ import os
 import platform
 import re
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 logger = logging.getLogger("kicad_interface")
 
 # A version tuple used only for newest-first ordering; missing parts sort as 0.
 _VersionKey = Tuple[int, int, int]
 _VERSION_RE = re.compile(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?")
+
+# Discovered roots are cached for the process: install locations do not change
+# while the server runs, and discovery walks the registry + globs the filesystem,
+# which is far too expensive to repeat on every library-path resolution.
+_cached_roots: Optional[List[Path]] = None
 
 
 def _version_key(text: str) -> _VersionKey:
@@ -128,13 +133,12 @@ def _glob_roots() -> List[Tuple[_VersionKey, Path]]:
     return results
 
 
-def windows_kicad_roots() -> List[Path]:
-    """KiCad install roots on Windows, newest-version first and de-duplicated.
+def _discover_windows_roots() -> List[Path]:
+    """Merge registry + glob roots, newest-version first and de-duplicated.
 
-    Registry entries and filesystem globs are merged; when the same root is found
-    by more than one source (the common case — a Program Files install is both in
-    the registry and under the glob) it appears once, keyed case-insensitively on
-    its normalised path.
+    When the same root is found by more than one source (the common case — a
+    Program Files install is both in the registry and under the glob) it appears
+    once, keyed case-insensitively on its normalised path.
     """
     combined = _registry_roots() + _glob_roots()
     # Stable sort by version descending so the newest KiCad wins ties on dedup.
@@ -151,6 +155,19 @@ def windows_kicad_roots() -> List[Path]:
     return roots
 
 
+def windows_kicad_roots() -> List[Path]:
+    """KiCad install roots on Windows, newest-version first and de-duplicated.
+
+    The result is cached for the process (see ``_cached_roots``); a fresh copy is
+    returned each call so callers can freely mutate it. Use ``reset_cache()`` in
+    tests that change the underlying registry/filesystem view.
+    """
+    global _cached_roots
+    if _cached_roots is None:
+        _cached_roots = _discover_windows_roots()
+    return list(_cached_roots)
+
+
 def kicad_install_roots() -> List[Path]:
     """KiCad install roots for the current platform, newest-version first.
 
@@ -161,3 +178,9 @@ def kicad_install_roots() -> List[Path]:
     if platform.system() == "Windows":
         return windows_kicad_roots()
     return []
+
+
+def reset_cache() -> None:
+    """Clear the cached install-root discovery (primarily for tests)."""
+    global _cached_roots
+    _cached_roots = None

--- a/python/utils/kicad_roots.py
+++ b/python/utils/kicad_roots.py
@@ -1,0 +1,163 @@
+"""Unified discovery of KiCad install roots.
+
+Three modules used to independently assume KiCad lives under ``Program Files`` on
+Windows (``kicad_cli.py``'s last-resort scan, ``platform_helper.py``'s
+symbol/python paths, ``library.py``'s footprint dirs). The KiCad Windows
+installer lets the user pick any root, and short no-space roots like
+``C:\\KiCad\\<ver>`` are common — every such install got degraded discovery,
+each module failing in its own way (issue #286).
+
+This centralises the discovery of KiCad *install roots* (the directory that
+contains ``bin\\`` and ``share\\kicad\\``) so the three modules can append their
+own suffix to a single, authoritative list and can no longer drift apart — the
+same unification #267 did for the three ``kicad-cli`` resolvers.
+
+Roots are returned newest-version first and de-duplicated. On Windows they come
+from, in order of authority:
+
+    1. The registry uninstall keys (``...\\Uninstall\\KiCad*`` → ``InstallLocation``),
+       which point at wherever the user actually installed KiCad.
+    2. ``C:\\Program Files\\KiCad\\*`` / ``Program Files (x86)`` version globs.
+    3. Common custom roots (``C:\\KiCad\\*``).
+
+Only Windows has the "installer can relocate the root" problem this solves;
+other platforms return an empty list, and callers keep their existing per-OS
+logic there.
+"""
+
+import logging
+import os
+import platform
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+logger = logging.getLogger("kicad_interface")
+
+# A version tuple used only for newest-first ordering; missing parts sort as 0.
+_VersionKey = Tuple[int, int, int]
+_VERSION_RE = re.compile(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?")
+
+
+def _version_key(text: str) -> _VersionKey:
+    """Parse a leading ``major[.minor[.patch]]`` out of ``text`` for sorting.
+
+    ``"10.0.4"`` -> ``(10, 0, 4)``, ``"KiCad 9.0"`` -> ``(9, 0, 0)``, and anything
+    without digits -> ``(0, 0, 0)`` so it sorts last.
+    """
+    m = _VERSION_RE.search(text or "")
+    if not m:
+        return (0, 0, 0)
+    return (int(m.group(1)), int(m.group(2) or 0), int(m.group(3) or 0))
+
+
+def _registry_roots() -> List[Tuple[_VersionKey, Path]]:
+    """KiCad install roots from the Windows uninstall registry keys.
+
+    Walks HKLM/HKCU (including the 32-bit ``WOW6432Node`` view) for uninstall
+    entries whose ``DisplayName`` mentions KiCad and reads their
+    ``InstallLocation``. This is the authoritative source: it reflects wherever
+    the user chose to install, custom roots included. Any read error on an
+    individual key is skipped rather than aborting discovery.
+    """
+    if platform.system() != "Windows":
+        return []
+
+    import winreg
+
+    hives = [
+        (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"),
+        (
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+        ),
+        (winreg.HKEY_CURRENT_USER, r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"),
+    ]
+
+    results: List[Tuple[_VersionKey, Path]] = []
+    for hive, subpath in hives:
+        try:
+            key = winreg.OpenKey(hive, subpath)
+        except OSError:
+            continue
+        try:
+            count = winreg.QueryInfoKey(key)[0]
+        except OSError:
+            continue
+        for i in range(count):
+            try:
+                sub = winreg.EnumKey(key, i)
+                subkey = winreg.OpenKey(key, sub)
+                display_name = winreg.QueryValueEx(subkey, "DisplayName")[0]
+            except OSError:
+                continue
+            if "kicad" not in str(display_name).lower():
+                continue
+            try:
+                location = winreg.QueryValueEx(subkey, "InstallLocation")[0]
+            except OSError:
+                location = None
+            if not location:
+                continue
+            try:
+                version = winreg.QueryValueEx(subkey, "DisplayVersion")[0]
+            except OSError:
+                version = sub  # fall back to the key name, e.g. "KiCad 10.0"
+            root = Path(str(location))
+            if root.is_dir():
+                results.append((_version_key(str(version)), root))
+    return results
+
+
+def _glob_roots() -> List[Tuple[_VersionKey, Path]]:
+    """KiCad install roots from Program Files and common custom base dirs."""
+    if platform.system() != "Windows":
+        return []
+
+    results: List[Tuple[_VersionKey, Path]] = []
+    for base in (r"C:\Program Files\KiCad", r"C:\Program Files (x86)\KiCad", r"C:\KiCad"):
+        base_dir = Path(base)
+        if not base_dir.is_dir():
+            continue
+        for child in base_dir.iterdir():
+            if child.is_dir():
+                results.append((_version_key(child.name), child))
+        # Some installs drop straight into <base>\bin with no version subdir.
+        if (base_dir / "bin").is_dir():
+            results.append((_version_key(base_dir.name), base_dir))
+    return results
+
+
+def windows_kicad_roots() -> List[Path]:
+    """KiCad install roots on Windows, newest-version first and de-duplicated.
+
+    Registry entries and filesystem globs are merged; when the same root is found
+    by more than one source (the common case — a Program Files install is both in
+    the registry and under the glob) it appears once, keyed case-insensitively on
+    its normalised path.
+    """
+    combined = _registry_roots() + _glob_roots()
+    # Stable sort by version descending so the newest KiCad wins ties on dedup.
+    combined.sort(key=lambda item: item[0], reverse=True)
+
+    seen: set = set()
+    roots: List[Path] = []
+    for _, root in combined:
+        norm = os.path.normcase(os.path.normpath(str(root)))
+        if norm in seen:
+            continue
+        seen.add(norm)
+        roots.append(root)
+    return roots
+
+
+def kicad_install_roots() -> List[Path]:
+    """KiCad install roots for the current platform, newest-version first.
+
+    Windows returns registry + Program Files + custom-root discovery. Other
+    platforms return ``[]`` — their install layout does not have the relocatable-
+    root problem this solves, and callers retain their own per-OS paths there.
+    """
+    if platform.system() == "Windows":
+        return windows_kicad_roots()
+    return []

--- a/python/utils/platform_helper.py
+++ b/python/utils/platform_helper.py
@@ -52,22 +52,20 @@ class PlatformHelper:
         paths = []
 
         if PlatformHelper.is_windows():
-            # Windows: Check Program Files
-            program_files = [
-                Path("C:/Program Files/KiCad"),
-                Path("C:/Program Files (x86)/KiCad"),
-            ]
-            for pf in program_files:
-                # Check multiple KiCAD versions
-                for version in ["10.0", "9.0", "9.1", "8.0"]:
-                    # KiCad 10.0+ Windows: bin/Lib/site-packages
-                    path = pf / version / "bin" / "Lib" / "site-packages"
-                    if path.exists():
-                        paths.append(path)
-                    # KiCad 9.x Windows: lib/python3/dist-packages
-                    path = pf / version / "lib" / "python3" / "dist-packages"
-                    if path.exists():
-                        paths.append(path)
+            # Discover install roots (registry + Program Files + custom C:\KiCad
+            # roots, newest first) via the shared helper so a relocated install is
+            # found here the same as by cli/footprint lookups (#286).
+            from utils.kicad_roots import kicad_install_roots
+
+            for root in kicad_install_roots():
+                # KiCad 10.0+ Windows: bin/Lib/site-packages
+                path = root / "bin" / "Lib" / "site-packages"
+                if path.exists():
+                    paths.append(path)
+                # KiCad 9.x Windows: lib/python3/dist-packages
+                path = root / "lib" / "python3" / "dist-packages"
+                if path.exists():
+                    paths.append(path)
 
         elif PlatformHelper.is_linux():
             # Linux: Check common installation paths
@@ -167,14 +165,17 @@ class PlatformHelper:
         patterns = []
 
         if PlatformHelper.is_windows():
-            patterns = [
+            # Build symbol-library globs from the shared install-root discovery
+            # (registry + Program Files + custom C:\KiCad roots) so libraries in a
+            # relocated install are found, not just Program Files ones (#286).
+            from utils.kicad_roots import kicad_install_roots
+
+            for root in kicad_install_roots():
+                symbols = root / "share" / "kicad" / "symbols"
                 # KiCAD 8/9 single-file libraries
-                "C:/Program Files/KiCad/*/share/kicad/symbols/*.kicad_sym",
-                "C:/Program Files (x86)/KiCad/*/share/kicad/symbols/*.kicad_sym",
+                patterns.append(str(symbols / "*.kicad_sym"))
                 # KiCAD 10 per-symbol directory libraries
-                "C:/Program Files/KiCad/*/share/kicad/symbols/*.kicad_symdir/*.kicad_sym",
-                "C:/Program Files (x86)/KiCad/*/share/kicad/symbols/*.kicad_symdir/*.kicad_sym",
-            ]
+                patterns.append(str(symbols / "*.kicad_symdir" / "*.kicad_sym"))
         elif PlatformHelper.is_linux():
             patterns = [
                 "/usr/share/kicad/symbols/*.kicad_sym",

--- a/tests/test_kicad10_paths.py
+++ b/tests/test_kicad10_paths.py
@@ -1,8 +1,14 @@
 """Regression tests for issue #245: KiCad 10 Windows install paths must be in
 the auto-discovery candidate lists (footprints and symbols), with env-var
 overrides for KiCad 10.
+
+Since #286 both finders source their Windows candidates from the shared
+``kicad_install_roots()`` helper, so these tests patch that discovery seam (and
+build the expected path with the same ``Path`` join the code uses) rather than
+asserting a hardcoded forward-slash literal.
 """
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -14,21 +20,28 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
 from commands.library import LibraryManager  # noqa: E402
 from commands.library_symbol import SymbolLibraryManager  # noqa: E402
 
-K10_FOOTPRINTS = "C:/Program Files/KiCad/10.0/share/kicad/footprints"
-K10_SYMBOLS = "C:/Program Files/KiCad/10.0/share/kicad/symbols"
+K10_ROOT = Path("C:/Program Files/KiCad/10.0")
+K10_FOOTPRINTS = str(K10_ROOT / "share" / "kicad" / "footprints")
+K10_SYMBOLS = str(K10_ROOT / "share" / "kicad" / "symbols")
 
 
 @pytest.mark.unit
 class TestKicad10FootprintDir:
     def test_k10_windows_path_is_discovered(self):
         lm = LibraryManager.__new__(LibraryManager)
-        with patch("commands.library.os.path.isdir", side_effect=lambda p: p == K10_FOOTPRINTS):
+        with (
+            patch("commands.library.kicad_install_roots", return_value=[K10_ROOT]),
+            patch("commands.library.os.path.isdir", side_effect=lambda p: p == K10_FOOTPRINTS),
+        ):
             assert lm._find_kicad_footprint_dir() == K10_FOOTPRINTS
 
     def test_k10_env_override_wins(self, monkeypatch):
         lm = LibraryManager.__new__(LibraryManager)
         monkeypatch.setenv("KICAD10_FOOTPRINT_DIR", "/custom/k10/footprints")
-        with patch("commands.library.os.path.isdir", return_value=True):
+        with (
+            patch("commands.library.kicad_install_roots", return_value=[]),
+            patch("commands.library.os.path.isdir", return_value=True),
+        ):
             assert lm._find_kicad_footprint_dir() == "/custom/k10/footprints"
 
 
@@ -36,11 +49,17 @@ class TestKicad10FootprintDir:
 class TestKicad10SymbolDir:
     def test_k10_windows_path_is_discovered(self):
         sm = SymbolLibraryManager.__new__(SymbolLibraryManager)
-        with patch("commands.library_symbol.os.path.isdir", side_effect=lambda p: p == K10_SYMBOLS):
+        with (
+            patch("commands.library_symbol.kicad_install_roots", return_value=[K10_ROOT]),
+            patch("commands.library_symbol.os.path.isdir", side_effect=lambda p: p == K10_SYMBOLS),
+        ):
             assert sm._find_kicad_symbol_dir() == K10_SYMBOLS
 
     def test_k10_env_override_wins(self, monkeypatch):
         sm = SymbolLibraryManager.__new__(SymbolLibraryManager)
         monkeypatch.setenv("KICAD10_SYMBOL_DIR", "/custom/k10/symbols")
-        with patch("commands.library_symbol.os.path.isdir", return_value=True):
+        with (
+            patch("commands.library_symbol.kicad_install_roots", return_value=[]),
+            patch("commands.library_symbol.os.path.isdir", return_value=True),
+        ):
             assert sm._find_kicad_symbol_dir() == "/custom/k10/symbols"

--- a/tests/test_kicad_roots.py
+++ b/tests/test_kicad_roots.py
@@ -1,0 +1,241 @@
+"""Tests for the unified KiCad install-root discovery (utils.kicad_roots).
+
+Issue #286: three modules independently assumed KiCad lived under Program Files
+on Windows, so a custom install root (e.g. C:\\KiCad\\10.0) or a registry-only
+install got degraded cli/symbol/footprint discovery. utils.kicad_roots is the
+single source of truth they now share.
+
+The registry walk is exercised through a fake ``winreg`` module so these tests
+run on any platform (CI is Linux, where the real ``winreg`` does not exist).
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+import utils.kicad_roots as kr  # noqa: E402
+
+# --------------------------------------------------------------------------- #
+# _version_key — pure parsing/ordering helper
+# --------------------------------------------------------------------------- #
+
+
+class TestVersionKey:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("10.0.4", (10, 0, 4)),
+            ("9.0.3", (9, 0, 3)),
+            ("10.0", (10, 0, 0)),
+            ("KiCad 9.0", (9, 0, 0)),
+            ("8", (8, 0, 0)),
+            ("", (0, 0, 0)),
+            ("nightly", (0, 0, 0)),
+        ],
+    )
+    def test_parses_version(self, text, expected):
+        assert kr._version_key(text) == expected
+
+    def test_newer_sorts_higher(self):
+        assert kr._version_key("10.0.4") > kr._version_key("9.0.3")
+
+
+# --------------------------------------------------------------------------- #
+# Fake winreg so _registry_roots is testable off-Windows
+# --------------------------------------------------------------------------- #
+
+
+class _FakeKey:
+    def __init__(self, subkeys=None, values=None):
+        self.subkeys = subkeys or {}  # name -> _FakeKey
+        self.values = values or {}  # name -> value
+
+
+def _make_fake_winreg(hive_trees):
+    """Build a stand-in ``winreg`` module.
+
+    ``hive_trees`` maps ``(hive, subpath)`` to a dict of
+    ``{uninstall_subkey_name: {value_name: value}}``.
+    """
+    mod = types.ModuleType("winreg")
+    mod.HKEY_LOCAL_MACHINE = "HKLM"
+    mod.HKEY_CURRENT_USER = "HKCU"
+
+    roots = {}
+    for (hive, subpath), entries in hive_trees.items():
+        subkeys = {name: _FakeKey(values=vals) for name, vals in entries.items()}
+        roots[(hive, subpath)] = _FakeKey(subkeys=subkeys)
+
+    def OpenKey(key, sub=None):
+        # Base open: OpenKey(hive, subpath)
+        if isinstance(key, str):
+            try:
+                return roots[(key, sub)]
+            except KeyError:
+                raise OSError("no such key")
+        # Child open: OpenKey(parentKey, subname)
+        try:
+            return key.subkeys[sub]
+        except KeyError:
+            raise OSError("no such subkey")
+
+    def QueryInfoKey(key):
+        return (len(key.subkeys), 0, 0)
+
+    def EnumKey(key, index):
+        return list(key.subkeys.keys())[index]
+
+    def QueryValueEx(key, name):
+        try:
+            return (key.values[name], 1)
+        except KeyError:
+            raise OSError("no such value")
+
+    mod.OpenKey = OpenKey
+    mod.QueryInfoKey = QueryInfoKey
+    mod.EnumKey = EnumKey
+    mod.QueryValueEx = QueryValueEx
+    return mod
+
+
+@pytest.fixture
+def as_windows(monkeypatch):
+    """Force the module to take its Windows path."""
+    monkeypatch.setattr(kr.platform, "system", lambda: "Windows")
+
+
+def _install(tmp_path, name):
+    """Create a fake install root directory and return its Path."""
+    root = tmp_path / name
+    (root / "bin").mkdir(parents=True)
+    return root
+
+
+# --------------------------------------------------------------------------- #
+# _registry_roots
+# --------------------------------------------------------------------------- #
+
+
+class TestRegistryRoots:
+    def test_finds_kicad_entries_and_ignores_others(self, tmp_path, monkeypatch, as_windows):
+        k10 = _install(tmp_path, "KiCad10")
+        k9 = _install(tmp_path, "KiCad9")
+        base = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
+        fake = _make_fake_winreg(
+            {
+                ("HKLM", base): {
+                    "KiCad 10.0": {
+                        "DisplayName": "KiCad 10.0",
+                        "DisplayVersion": "10.0.4",
+                        "InstallLocation": str(k10),
+                    },
+                    "KiCad 9.0": {
+                        "DisplayName": "KiCad 9.0",
+                        "DisplayVersion": "9.0.3",
+                        "InstallLocation": str(k9),
+                    },
+                    "SomeOtherApp": {
+                        "DisplayName": "Notepad++",
+                        "InstallLocation": str(tmp_path / "npp"),
+                    },
+                }
+            }
+        )
+        monkeypatch.setitem(sys.modules, "winreg", fake)
+
+        found = kr._registry_roots()
+        paths = {p for _, p in found}
+        assert k10 in paths
+        assert k9 in paths
+        assert (tmp_path / "npp") not in paths  # non-KiCad ignored
+
+    def test_skips_entry_without_install_location(self, tmp_path, monkeypatch, as_windows):
+        base = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
+        fake = _make_fake_winreg(
+            {
+                ("HKLM", base): {
+                    "KiCad 10.0": {  # no InstallLocation
+                        "DisplayName": "KiCad 10.0",
+                        "DisplayVersion": "10.0.4",
+                    },
+                }
+            }
+        )
+        monkeypatch.setitem(sys.modules, "winreg", fake)
+        assert kr._registry_roots() == []
+
+    def test_skips_nonexistent_install_location(self, tmp_path, monkeypatch, as_windows):
+        base = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
+        fake = _make_fake_winreg(
+            {
+                ("HKLM", base): {
+                    "KiCad 10.0": {
+                        "DisplayName": "KiCad 10.0",
+                        "DisplayVersion": "10.0.4",
+                        "InstallLocation": str(tmp_path / "gone"),
+                    },
+                }
+            }
+        )
+        monkeypatch.setitem(sys.modules, "winreg", fake)
+        assert kr._registry_roots() == []
+
+    def test_non_windows_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(kr.platform, "system", lambda: "Linux")
+        assert kr._registry_roots() == []
+
+
+# --------------------------------------------------------------------------- #
+# windows_kicad_roots — merge, order, dedup
+# --------------------------------------------------------------------------- #
+
+
+class TestWindowsRootsMerge:
+    def test_newest_first_and_deduped(self, tmp_path, monkeypatch, as_windows):
+        k10 = _install(tmp_path, "KiCad10")
+        k9 = _install(tmp_path, "KiCad9")
+        # Registry reports 10.0.4 and 9.0.3; glob re-reports the same 10.0 root
+        # (as it would for a Program Files install also in the registry).
+        monkeypatch.setattr(kr, "_registry_roots", lambda: [((10, 0, 4), k10), ((9, 0, 3), k9)])
+        monkeypatch.setattr(kr, "_glob_roots", lambda: [((10, 0, 0), k10)])
+
+        roots = kr.windows_kicad_roots()
+        assert roots == [k10, k9]  # newest first, k10 appears once
+
+    def test_custom_root_surfaces(self, tmp_path, monkeypatch, as_windows):
+        custom = _install(tmp_path, "KiCad")  # e.g. C:\KiCad\10.0 shape
+        monkeypatch.setattr(kr, "_registry_roots", lambda: [])
+        monkeypatch.setattr(kr, "_glob_roots", lambda: [((10, 0, 0), custom)])
+        assert kr.windows_kicad_roots() == [custom]
+
+    def test_dedup_is_case_insensitive(self, tmp_path, monkeypatch, as_windows):
+        root = _install(tmp_path, "KiCad10")
+        upper = Path(str(root).upper())
+        monkeypatch.setattr(kr, "_registry_roots", lambda: [((10, 0, 4), root)])
+        monkeypatch.setattr(kr, "_glob_roots", lambda: [((10, 0, 0), upper)])
+        # normcase collapses the two spellings to one entry.
+        assert len(kr.windows_kicad_roots()) == 1
+
+
+# --------------------------------------------------------------------------- #
+# kicad_install_roots — public entry
+# --------------------------------------------------------------------------- #
+
+
+class TestPublicEntry:
+    def test_non_windows_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(kr.platform, "system", lambda: "Darwin")
+        assert kr.kicad_install_roots() == []
+
+    @pytest.mark.skipif(
+        __import__("platform").system() != "Windows", reason="real install layout is Windows-only"
+    )
+    def test_real_machine_roots_exist(self):
+        # On a real Windows box every discovered root must be an existing dir
+        # containing bin/ (empty is fine — KiCad may not be installed in CI).
+        for root in kr.kicad_install_roots():
+            assert root.is_dir(), root

--- a/tests/test_kicad_roots.py
+++ b/tests/test_kicad_roots.py
@@ -19,6 +19,16 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
 
 import utils.kicad_roots as kr  # noqa: E402
 
+
+@pytest.fixture(autouse=True)
+def _clear_roots_cache():
+    """Install roots are cached per-process; reset around each test so a fake
+    registry/glob in one test cannot leak into the next."""
+    kr.reset_cache()
+    yield
+    kr.reset_cache()
+
+
 # --------------------------------------------------------------------------- #
 # _version_key — pure parsing/ordering helper
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Fixes #286. `kicad-cli` resolution (`utils/kicad_cli.py`), symbol/python-path
discovery (`utils/platform_helper.py`), and footprint-dir lookup
(`commands/library.py`) each independently hardcoded `C:\Program Files\KiCad` as
the only Windows install location. The installer lets the user pick any root
(short no-space roots like `C:\KiCad\10.0` are common), so a relocated install
got degraded discovery in three different ways — no cli, no bundled `pcbnew`,
no symbol/footprint libraries — each failing on its own.

## Change

New shared helper **`python/utils/kicad_roots.py`** yields KiCad install *roots*
(the dir containing `bin/` and `share/kicad/`), newest-version first and
de-duplicated, from three Windows sources in order of authority:

1. **Registry** — walks the HKLM/HKCU uninstall keys (incl. `WOW6432Node`) for
   `DisplayName` entries mentioning KiCad and reads `InstallLocation`. This is
   authoritative: it points at wherever the user actually installed, custom
   roots included. Ordered by `DisplayVersion`.
2. **Program Files globs** — `C:\Program Files\KiCad\*` / `(x86)` (prior behavior).
3. **Custom roots** — `C:\KiCad\*`.

The three modules now build their Windows paths by appending their own suffix to
this single list (`root/bin/kicad-cli.exe`, `root/bin/Lib/site-packages`,
`root/share/kicad/symbols/...`, `root/share/kicad/footprints`), so discovery can
no longer drift apart — the same unification #267 did for the three duplicated
`kicad-cli` resolvers. **macOS/Linux behavior is unchanged**: those platforms
don't have the relocatable-root problem, so the helper returns `[]` there and the
existing per-OS logic is retained.

## Tests

New `tests/test_kicad_roots.py` (17 tests). The registry walk runs against a
fake `winreg` module so the suite passes on any platform (CI is Linux):

- `_version_key` parsing/ordering (`"10.0.4"` → `(10,0,4)`, newest sorts higher);
- registry discovery finds KiCad entries, ignores non-KiCad apps, and skips
  entries with a missing or non-existent `InstallLocation`;
- `windows_kicad_roots` merges registry + glob, orders newest-first, and
  de-duplicates a root reported by both sources (case-insensitively);
- a custom `C:\KiCad`-shaped root surfaces;
- the public `kicad_install_roots()` returns `[]` off-Windows and, on a real
  Windows box, only existing directories.

Existing `test_kicad_cli_resolver.py`, `test_platform_helper.py`, and
`test_symbol_library.py` still pass (41 passed, 2 skipped — unrelated missing
system SPICE lib).

Verified on a real Windows box (KiCad 10.0.4 + 9.0.3 under `C:\Program Files`):
the resolver now finds `kicad-cli`, the bundled `site-packages`, and the symbol
globs for both versions, newest first, with the Program Files root reported once
despite being in both the registry and the glob.
