### PR TITLE
fix: resolve symdir (extends) parent from sibling shard (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **Derived symbols in KiCad 10 `.kicad_symdir` libraries now inline their parent**
+  (#282): in the sharded directory format each symbol is its own
+  `<Symbol>.kicad_sym` file, so a symbol using `(extends "Parent")` has its parent
+  in a _sibling_ shard. `extract_symbol_from_library` handed only the child's shard
+  to the inliner, so the parent was never found and the `(extends)` clause was
+  stripped — producing a symbol shell with no parent pins/graphics (e.g.
+  `Device:Filter_EMI_C`, which extends `C_Feedthrough`). A new
+  `_resolve_symdir_extends` reads the parent shard, resolves it recursively (a
+  parent may itself extend a grandparent in another shard), and merges it via the
+  existing single-level inliner; a missing parent shard still degrades gracefully
+  (strips + warns, keeping the file loadable). Single-file `.kicad_sym` libraries
+  are unaffected.
+
 - **`create_project` writes a conformant KiCad 10 `.kicad_pro`** (#220): the
   project file was a hand-rolled 122-byte stub containing only
   `board.filename` and a `sheets` entry with the literal id `"root"`, so
@@ -145,7 +158,7 @@ the KiCad GUI connects later (reopen the project to adopt IPC).
   components via dynamic template injection** (#221, part B): when no placed
   `_TEMPLATE_*` donor existed, the legacy clone path used to call
   `DynamicSymbolLoader.load_symbol_dynamically`, which wrote a template
-  instance into the *file* mid-call and cloned onto a locally reloaded
+  instance into the _file_ mid-call and cloned onto a locally reloaded
   object — so callers following the normal add-then-save pattern saved
   their stale in-memory schematic, discarding the new component and
   leaving `_TEMPLATE_*` clutter behind. That branch is removed: template

--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -330,6 +330,53 @@ class DynamicSymbolLoader:
 
         return first_line + "\n" + "\n".join(body_lines) + "\n" + last_line
 
+    def _read_symdir_shard(self, lib_dir: Path, symbol_name: str) -> Optional[str]:
+        """Read the per-symbol shard ``<symbol>.kicad_sym`` from a ``.kicad_symdir``."""
+        shard = lib_dir / f"{symbol_name}.kicad_sym"
+        if not shard.exists():
+            return None
+        try:
+            with open(shard, "r", encoding="utf-8") as f:
+                return f.read()
+        except OSError as e:
+            logger.warning(f"Could not read symdir shard {shard}: {e}")
+            return None
+
+    def _resolve_symdir_extends(
+        self, lib_dir: Path, symbol_name: str, block: str, _seen: Optional[set] = None
+    ) -> str:
+        """Inline ``(extends "Parent")`` for a sharded (``.kicad_symdir``) library.
+
+        Unlike a single-file library, a derived symbol's parent lives in its own
+        sibling shard ``<Parent>.kicad_sym`` and is therefore absent from this
+        symbol's file (issue #282). Read the parent shard, resolve it recursively
+        (a parent may itself extend a grandparent in yet another shard), then merge
+        the fully-resolved parent into the child with the shared single-level
+        inliner. When the parent shard is missing or the chain is cyclic, hand the
+        inliner an empty library so it falls back to its graceful strip-and-warn.
+        """
+        extends_match = re.search(r'\(extends "([^"]+)"\)', block)
+        if not extends_match:
+            return block
+
+        parent_name = extends_match.group(1)
+        seen = set() if _seen is None else _seen
+
+        parent_content = ""
+        if parent_name not in seen:
+            seen.add(parent_name)
+            shard = self._read_symdir_shard(lib_dir, parent_name)
+            if shard is not None:
+                parent_block = self._extract_symbol_block(shard, parent_name)
+                if parent_block is not None:
+                    # Fully resolve the parent (extends-free) before merging so
+                    # multi-level chains inline completely.
+                    parent_content = self._resolve_symdir_extends(
+                        lib_dir, parent_name, parent_block, seen
+                    )
+
+        return self._inline_extends_symbol(parent_content, symbol_name, block)
+
     def extract_symbol_from_library(self, library_name: str, symbol_name: str) -> Optional[str]:
         """
         Extract a symbol definition from a KiCad .kicad_sym library file.
@@ -371,7 +418,12 @@ class DynamicSymbolLoader:
         if re.search(r'\(extends "([^"]+)"\)', block):
             parent_name = re.search(r'\(extends "([^"]+)"\)', block).group(1)
             logger.info(f"Symbol {symbol_name} extends {parent_name}, inlining parent content")
-            block = self._inline_extends_symbol(lib_content, symbol_name, block)
+            if lib_path.is_dir():
+                # Sharded (.kicad_symdir) library: the parent is in a sibling
+                # shard, not in this symbol's file, so resolve across shards (#282).
+                block = self._resolve_symdir_extends(lib_path, symbol_name, block)
+            else:
+                block = self._inline_extends_symbol(lib_content, symbol_name, block)
 
         # Prefix top-level symbol name with library
         full_name = f"{library_name}:{symbol_name}"

--- a/tests/test_symdir_extends.py
+++ b/tests/test_symdir_extends.py
@@ -1,0 +1,137 @@
+"""Regression tests for issue #282:
+
+    symdir libraries: (extends) parent in a sibling shard is not resolved
+
+In KiCad 10's sharded ``.kicad_symdir`` format each symbol is its own
+``<Symbol>.kicad_sym`` file. A derived symbol that uses ``(extends "Parent")``
+therefore has its parent in a *sibling* shard, not in its own file.
+``extract_symbol_from_library`` used to hand the child's shard alone to the
+inliner, so the parent was never found and the ``(extends)`` clause was stripped,
+yielding an incomplete symbol (no parent pins/graphics).
+
+These tests build a fake ``.kicad_symdir`` directory of shards and assert the
+parent is now resolved across shards — including a multi-level chain — and that a
+genuinely missing parent still degrades gracefully.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.dynamic_symbol_loader import DynamicSymbolLoader
+
+
+def _parent_shard(name: str) -> str:
+    """A complete base symbol with two pins in its unit sub-symbol."""
+    return (
+        f"(kicad_symbol_lib (version 20241209) (generator test)\n"
+        f'  (symbol "{name}" (pin_numbers (hide yes)) (pin_names (offset 0.254))'
+        f" (exclude_from_sim no) (in_bom yes) (on_board yes)\n"
+        f'    (property "Reference" "C" (at 0 0 0))\n'
+        f'    (property "Value" "{name}" (at 0 0 0))\n'
+        f'    (property "Datasheet" "~" (at 0 0 0))\n'
+        f'    (symbol "{name}_0_1"\n'
+        f"      (polyline (pts (xy -2 0) (xy 2 0)) (stroke (width 0)) (fill (type none)))\n"
+        f"    )\n"
+        f'    (symbol "{name}_1_1"\n'
+        f"      (pin passive line (at 0 3.81 270) (length 2.54)"
+        f' (name "~" (effects (font (size 1.27 1.27))))'
+        f' (number "1" (effects (font (size 1.27 1.27)))))\n'
+        f"      (pin passive line (at 0 -3.81 90) (length 2.54)"
+        f' (name "~" (effects (font (size 1.27 1.27))))'
+        f' (number "2" (effects (font (size 1.27 1.27)))))\n'
+        f"    )\n"
+        f"  )\n"
+        f")\n"
+    )
+
+
+def _derived_shard(name: str, parent: str, extra_property: str = "") -> str:
+    """A derived symbol that extends ``parent`` and overrides its Value."""
+    return (
+        f"(kicad_symbol_lib (version 20241209) (generator test)\n"
+        f'  (symbol "{name}" (extends "{parent}")\n'
+        f'    (property "Value" "{name}" (at 0 0 0))\n'
+        f"{extra_property}"
+        f"  )\n"
+        f")\n"
+    )
+
+
+def _make_symdir(tmp_path: Path, lib: str, shards: dict) -> DynamicSymbolLoader:
+    """Create ``<lib>.kicad_symdir`` with the given ``{symbol: content}`` shards and
+    return a loader whose bundled-library search points at the containing dir."""
+    symdir = tmp_path / f"{lib}.kicad_symdir"
+    symdir.mkdir()
+    for sym, content in shards.items():
+        (symdir / f"{sym}.kicad_sym").write_text(content, encoding="utf-8")
+
+    loader = DynamicSymbolLoader()
+    loader.find_kicad_symbol_libraries = lambda: [tmp_path]  # type: ignore[method-assign]
+    return loader
+
+
+def test_derived_symbol_inlines_parent_from_sibling_shard(tmp_path):
+    loader = _make_symdir(
+        tmp_path,
+        "TestLib",
+        {
+            "C_Feedthrough": _parent_shard("C_Feedthrough"),
+            "Filter_EMI_C": _derived_shard("Filter_EMI_C", "C_Feedthrough"),
+        },
+    )
+
+    block = loader.extract_symbol_from_library("TestLib", "Filter_EMI_C")
+
+    assert block is not None
+    # Parent content is inlined: both pins are present...
+    assert '(number "1"' in block
+    assert '(number "2"' in block
+    # ...the parent's unit sub-symbol was renamed to the child...
+    assert '(symbol "Filter_EMI_C_1_1"' in block
+    assert "C_Feedthrough_1_1" not in block
+    # ...no (extends) survives (KiCad refuses it inside a schematic)...
+    assert "(extends" not in block
+    # ...the top-level symbol is library-qualified, and the child's Value wins.
+    assert '(symbol "TestLib:Filter_EMI_C"' in block
+    assert '(property "Value" "Filter_EMI_C"' in block
+
+
+def test_multi_level_extends_chain_resolves(tmp_path):
+    loader = _make_symdir(
+        tmp_path,
+        "TestLib",
+        {
+            "Base": _parent_shard("Base"),
+            "Mid": _derived_shard("Mid", "Base"),
+            "Top": _derived_shard("Top", "Mid"),
+        },
+    )
+
+    block = loader.extract_symbol_from_library("TestLib", "Top")
+
+    assert block is not None
+    # Grandparent pins reach the grandchild, renamed all the way down.
+    assert '(number "1"' in block
+    assert '(number "2"' in block
+    assert '(symbol "Top_1_1"' in block
+    assert "(extends" not in block
+    assert '(symbol "TestLib:Top"' in block
+
+
+def test_missing_parent_shard_degrades_gracefully(tmp_path):
+    loader = _make_symdir(
+        tmp_path,
+        "TestLib",
+        {"Orphan": _derived_shard("Orphan", "Ghost")},  # no Ghost.kicad_sym
+    )
+
+    block = loader.extract_symbol_from_library("TestLib", "Orphan")
+
+    # No crash; the unresolved (extends) is stripped so the file stays loadable.
+    assert block is not None
+    assert "(extends" not in block
+    assert '(symbol "TestLib:Orphan"' in block


### PR DESCRIPTION
## Summary

Fixes #282. In KiCad 10's sharded `.kicad_symdir` libraries each symbol is its
own `<Symbol>.kicad_sym` file, so a derived symbol that uses `(extends "Parent")`
has its parent in a **sibling shard**, not in its own file.
`extract_symbol_from_library` read only the child's shard and handed that to
`_inline_extends_symbol`, which therefore never found the parent, stripped the
`(extends)` clause, and returned a symbol shell with no parent pins/graphics
(the issue's example: `Device:Filter_EMI_C`, which extends `C_Feedthrough`).

## Fix (`python/commands/dynamic_symbol_loader.py`)

- New `_resolve_symdir_extends(lib_dir, symbol_name, block)`: reads the parent
  shard `lib_dir/<Parent>.kicad_sym`, resolves it **recursively** (a parent may
  itself extend a grandparent in yet another shard), then merges the
  fully-resolved parent into the child via the existing single-level
  `_inline_extends_symbol`. A `_seen` set guards against cyclic `(extends)`
  chains, and a missing/unreadable parent shard falls back to the inliner's
  existing graceful strip-and-warn (the file stays loadable — KiCad refuses
  `(extends)` inside a schematic's `lib_symbols`).
- Small `_read_symdir_shard` helper for reading a shard.
- `extract_symbol_from_library` now branches the extends handling: **directory
  library → `_resolve_symdir_extends`**; single-file `.kicad_sym` library → the
  existing `_inline_extends_symbol` path, unchanged.

## Tests

New `tests/test_symdir_extends.py` builds a fake `.kicad_symdir` of shards
(pointing the loader's bundled-library search at a tmp dir) and asserts:

- a derived symbol inlines its parent's pins from the sibling shard, renames the
  parent's unit sub-symbols to the child, keeps the child's property overrides,
  and emits **no** `(extends)`;
- a three-shard `Base → Mid → Top` chain resolves end-to-end (grandparent pins
  reach the grandchild);
- a genuinely missing parent shard degrades gracefully (strips + no crash).

The fixture uses a non-installed library name so the test can't accidentally
resolve against a real KiCad `Device` library on the dev machine. Single-file
libraries are unaffected; existing `test_symbol_pins` /
`test_symbol_instance_completeness` / `test_loader_global_sym_lib_table` pass.
