### PR TITLE
fix: use pin_world_xy in _find_pins_on_net for rotated symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`get_wire_connections` locates pins correctly on rotated symbols**:
+  `_find_pins_on_net` computed pin world coordinates with a local transform
+  that applied mirror before rotation, diverging from `WireDragger.pin_world_xy`
+  (the shared transform corrected in #259) for 90 and 270 degree rotations. Pins
+  on rotated symbols were placed at the wrong coordinate and dropped from their
+  own net's pin list (observed on an LM324 whose gates are placed rotated 90:
+  eight of its pins went missing from their nets). `_find_pins_on_net` now calls
+  `pin_world_xy` so pin geometry matches eeschema everywhere. Single-unit and
+  unrotated parts are unaffected.
+
 - **`get_wire_connections` no longer reports phantom cross-unit pins** (#293):
   `_find_pins_on_net` transformed every unit's pins against every placed
   instance of a multi-unit component, so a sibling unit's pin whose library

--- a/python/commands/wire_connectivity.py
+++ b/python/commands/wire_connectivity.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 import sexpdata
 from commands.pin_locator import PinLocator
+from commands.wire_dragger import WireDragger
 from sexpdata import Symbol
 
 logger = logging.getLogger("kicad_interface")
@@ -472,17 +473,20 @@ def _find_pins_on_net(
             mirror_y = inst["mirror_y"]
 
             for pin_num, pdata in pin_defs.items():
-                px, py = pdata["x"], pdata["y"]
-                # y-negate: lib_symbols y-up → schematic y-down
-                py = -py
-                if mirror_x:
-                    py = -py
-                if mirror_y:
-                    px = -px
-                if sym_rot != 0:
-                    px, py = locator.rotate_point(px, py, sym_rot)
-                abs_x = sym_x + px
-                abs_y = sym_y + py
+                # Use the shared symbol->world transform so pin geometry matches
+                # eeschema (Y-flip -> rotate -> mirror -> translate). A local copy
+                # of this math applied mirror before rotation, which disagrees with
+                # pin_world_xy for 90/270 rotations and mislocated pins on rotated
+                # symbols, dropping them from their own net's pin list.
+                abs_x, abs_y = WireDragger.pin_world_xy(
+                    pdata["x"],
+                    pdata["y"],
+                    sym_x,
+                    sym_y,
+                    sym_rot,
+                    mirror_x,
+                    mirror_y,
+                )
                 if _on_net(abs_x, abs_y):
                     key = (ref, pin_num)
                     if key not in seen:

--- a/tests/test_wire_connectivity_multi_unit.py
+++ b/tests/test_wire_connectivity_multi_unit.py
@@ -133,12 +133,89 @@ class TestNoPhantomCrossUnitPins:
         # Unit 1 output wire runs from (107.62, 100).
         pins = _pins_on_net_at(multi_unit_sch, 107.62, 100.0)
         assert "U1/3" in pins  # unit 1's own output
-        assert "R1/2" in pins  # the passive wired to it
+        assert "R1/1" in pins  # the passive wired to it (rot90: pin 1 at wire end)
         assert "U1/7" not in pins  # phantom sibling-unit pin must be gone
 
     def test_unit2_net_excludes_unit1_pin(self, multi_unit_sch):
         # Unit 2 output wire runs from (107.62, 150).
         pins = _pins_on_net_at(multi_unit_sch, 107.62, 150.0)
         assert "U1/7" in pins  # unit 2's own output
-        assert "R2/2" in pins  # the passive wired to it
+        assert "R2/1" in pins  # the passive wired to it (rot90: pin 1 at wire end)
         assert "U1/3" not in pins  # phantom sibling-unit pin must be gone
+
+
+# Rotated single-unit symbol regression (#294 follow-up / inline-transform bug):
+#   A symbol placed at rotation 90 with an output pin at lib offset (7.62, 0).
+#   pin_world_xy (post-#259) puts that pin at (100, 92.38). The pre-fix inline
+#   transform in _find_pins_on_net applied mirror-before-rotate and diverged
+#   from pin_world_xy for 90/270 rotations, computing a wrong location so the
+#   pin failed to land on its own wire and was dropped from the net's pin list.
+ROTATED_SCH = """\
+(kicad_sch (version 20250114) (generator "test")
+  (uuid 00000000-0000-0000-0000-0000000000bb)
+  (paper "A4")
+  (lib_symbols
+    (symbol "TEST:Amp" (pin_names (offset 0)) (in_bom yes) (on_board yes)
+      (property "Reference" "U" (at 0 0 0))
+      (property "Value" "Amp" (at 0 0 0))
+      (symbol "Amp_1_1"
+        (pin output line (at 7.62 0 180) (length 2.54)
+          (name "~" (effects (font (size 1.27 1.27))))
+          (number "1" (effects (font (size 1.27 1.27))))
+        )
+      )
+    )
+    (symbol "Device:R" (pin_numbers (hide yes)) (pin_names (offset 0))
+      (property "Reference" "R" (at 0 0 0))
+      (property "Value" "R" (at 0 0 0))
+      (symbol "R_0_1")
+      (symbol "R_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27)
+          (name "~" (effects (font (size 1.27 1.27))))
+          (number "1" (effects (font (size 1.27 1.27))))
+        )
+        (pin passive line (at 0 -3.81 90) (length 1.27)
+          (name "~" (effects (font (size 1.27 1.27))))
+          (number "2" (effects (font (size 1.27 1.27))))
+        )
+      )
+    )
+  )
+  (symbol (lib_id "TEST:Amp") (at 100 100 90) (unit 1)
+    (uuid 00000000-0000-0000-0000-000000000010)
+    (property "Reference" "U1" (at 90 100 0))
+    (property "Value" "Amp" (at 110 100 0))
+  )
+  (symbol (lib_id "Device:R") (at 100 85 0) (unit 1)
+    (uuid 00000000-0000-0000-0000-000000000110)
+    (property "Reference" "R1" (at 105 85 0))
+    (property "Value" "1k" (at 105 88 0))
+  )
+  (wire (pts (xy 100 92.38) (xy 100 88.81))
+    (stroke (width 0) (type default)) (uuid 00000000-0000-0000-0000-000000000210))
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+@pytest.fixture()
+def rotated_sch():
+    with tempfile.TemporaryDirectory() as tmp:
+        sch_path = Path(tmp) / "rotated.kicad_sch"
+        sch_path.write_text(ROTATED_SCH, encoding="utf-8")
+        yield sch_path
+
+
+@pytest.mark.integration
+class TestRotatedSymbolPinLocation:
+    """A 90-rotated symbol's pin must land on its own net (#294 follow-up)."""
+
+    def test_rotated_output_pin_on_its_net(self, rotated_sch):
+        # U1 is rotated 90; its output pin 1 (lib 7.62,0) lands at (100, 92.38),
+        # wired down to R1 pin 1. Pre-fix, the inline transform mislocated pin 1
+        # so it was dropped from this net.
+        pins = _pins_on_net_at(rotated_sch, 100.0, 92.38)
+        assert "U1/1" in pins  # rotated symbol's own pin must be present
+        assert "R1/2" in pins  # the passive it is wired to


### PR DESCRIPTION
## Summary

Fixes #303.

Fixes the rotated-symbol pin mislocation in `_find_pins_on_net`.

`_find_pins_on_net` computed each pin's world coordinate with a local transform that applied mirror before rotation. That ordering diverges from `WireDragger.pin_world_xy` (the shared transform corrected in #259) for 90 and 270 degree rotations, so pins on rotated symbols were placed at the wrong coordinate, failed to land on their own wires, and were silently dropped from the pin list `get_wire_connections` returns.

## Root cause

`WireManager._collect_pin_positions` was already routed through `pin_world_xy` by #259, but `_find_pins_on_net` carried a second, divergent copy of the transform math. For an asymmetric pin point the two disagree in exactly four of sixteen orientation combos: 90 and 270 rotation, each with zero or two mirror axes.

## Evidence

LM324 (`Amplifier_Operational:LM324`), gates placed rotated 90, reference IC-6. Ground truth from `kicad-cli sch export netlist`:

```
Net-(IC-6-Pad7): IC-6/7, R10/1, R5/2, R6/2
```

Before: `_find_pins_on_net` places IC-6 pin 7 at (294.64, 134.62) instead of (294.64, 119.38), so `get_wire_connections` returns `['R10/1', 'R5/1', 'R6/2']` - IC-6/7 missing. Eight IC-6 pins (units 2/3/4) were affected. After: all resolve onto their own nets and match the netlist.

## Change

Replaces the inline transform block with a `WireDragger.pin_world_xy` call, so pin geometry matches eeschema (Y-flip -> rotate -> mirror -> translate) everywhere.

## Tests

New `TestRotatedSymbolPinLocation` in `tests/test_wire_connectivity_multi_unit.py`: places a symbol rotated 90 degrees and asserts its output pin lands on its own net. Fails without the fix (verified by stashing the change).

Also corrects two assertions in the existing #293 tests. That fixture places its sense resistors rotated 90 degrees; with the transform fixed, the wire-end resistor pin is pin 1, not pin 2. The pre-fix `R*/2` values reflected the same rotation bug acting on those resistors, so this is the expected corrected geometry, not a behavior regression.

```
pytest tests/test_wire_connectivity_multi_unit.py           # 3 passed
pytest tests/                                                # 1322 passed
    (4 pre-existing failures on main, unrelated: Windows path
     tests on Linux + a SymbolLibraryManager._cache_lock bug)
```

Black, isort, flake8, mypy clean on the changed Python files.

## Relationship to #293/#294

Independent but adjacent. #294 fixed which pins each instance owns (unit filtering); this fixes where each owned pin is computed to be. Both touch `_find_pins_on_net`.

## Checklist

- [x] Code follows style guidelines (black, isort, flake8, mypy)
- [x] All tests pass locally (new test fails without the fix)
- [x] New tests added for new behavior
- [x] CHANGELOG.md updated under [Unreleased]
- [x] Commit message follows convention