### PR TITLE
fix: export .kicad_pro net classes to Specctra DSN (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the KiCAD MCP Server project are documented here.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **`export_dsn`/`autoroute` no longer drop `.kicad_pro` net classes — power
+  nets keep their width** (#302): net-class definitions live in the project
+  file on KiCad 7+, which the headless `pcbnew.LoadBoard()` path never reads,
+  so `ExportSpecctraDSN` exported every net under a single `kicad_default`
+  class at Default width/clearance. The one-call `autoroute` tool re-exports
+  internally, so a 2.0 mm power net was silently handed to Freerouting at
+  0.2 mm signal width. Both tools now rebuild the board's `NET_SETTINGS` from
+  `.kicad_pro` (`net_settings.classes`, `netclass_patterns`, and
+  `netclass_assignments`, via a new `python/utils/project_netclasses.py`)
+  before exporting, so KiCad's own exporter natively emits per-class
+  `(class ...)` blocks, rules, and via padstacks — verified against real
+  KiCad 10 to match a project-loaded GUI export. The tool result now carries
+  a `netClasses` report (`applied` classes, or a `warning` when no project
+  file is found or the classes cannot be applied), so a dropped class is
+  loud instead of silent.
+
 ## [2.3.1] - 2026-07-05
 
 Eight merges since v2.3.0: the entire June scaffolding cluster (#220/#221/

--- a/python/commands/freerouting.py
+++ b/python/commands/freerouting.py
@@ -18,6 +18,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
+from utils.project_netclasses import apply_net_classes_to_board, load_project_net_classes
+
 logger = logging.getLogger("kicad_interface")
 
 # Default Freerouting JAR location
@@ -169,7 +171,7 @@ def _build_freerouting_cmd(
 # SES across attempts.
 # ---------------------------------------------------------------------------
 
-_SES_NET_RE = re.compile(r'\(net\s+(\S+)\s*\n\s*\(wire')
+_SES_NET_RE = re.compile(r"\(net\s+(\S+)\s*\n\s*\(wire")
 
 
 def _score_ses(ses_text: str, target_nets: Iterable[str]) -> Dict[str, Any]:
@@ -188,8 +190,8 @@ def _score_ses(ses_text: str, target_nets: Iterable[str]) -> Dict[str, Any]:
     nets = set(_SES_NET_RE.findall(ses_text))
     # Strip wrapping quotes if Freerouting emits them.
     clean_nets = {n.strip('"') for n in nets}
-    segments = len(re.findall(r'\(wire', ses_text))
-    vias = len(re.findall(r'\(via ', ses_text))
+    segments = len(re.findall(r"\(wire", ses_text))
+    vias = len(re.findall(r"\(via ", ses_text))
 
     targets = set(target_nets) if target_nets else set()
     found = sorted(targets & clean_nets)
@@ -214,6 +216,52 @@ class FreeroutingCommands:
 
     def __init__(self, board: Any = None) -> None:
         self.board = board
+
+    def _apply_project_net_classes(self, board_path: Optional[str]) -> Dict[str, Any]:
+        """Push the project's net classes into the loaded board before DSN
+        export (#302).
+
+        Net-class definitions live in ``.kicad_pro``, which the headless
+        ``LoadBoard()`` path never reads, so without this every net is
+        exported under ``kicad_default`` at Default width — a power net
+        reaches Freerouting at signal width with no warning. Applying the
+        classes to the board's NET_SETTINGS makes ``ExportSpecctraDSN``
+        natively emit per-class rules and via padstacks.
+
+        Best-effort: never raises. The returned report goes into the tool
+        response so a dropped class is loud, not silent.
+        """
+        pro_path = os.path.splitext(board_path)[0] + ".kicad_pro" if board_path else ""
+        try:
+            settings = load_project_net_classes(pro_path)
+        except ValueError as exc:
+            return {
+                "applied": [],
+                "warning": f"{exc}; DSN exported with Default-class rules only",
+            }
+        if settings is None:
+            return {
+                "applied": [],
+                "warning": (
+                    "no .kicad_pro found next to the board; net-class rules are "
+                    "unknown, so every net is exported at Default width/clearance"
+                ),
+            }
+        custom = [c["name"] for c in settings["classes"] if c.get("name") != "Default"]
+        try:
+            report = apply_net_classes_to_board(self.board, settings)
+        except Exception as exc:
+            detail = (
+                f"project defines net classes {custom} but they could not be "
+                f"applied ({exc}); DSN exported with Default-class rules only"
+                if custom
+                else f"could not apply project net settings ({exc})"
+            )
+            return {"applied": [], "warning": detail}
+        report["projectFile"] = pro_path
+        if report["applied"]:
+            logger.info(f"Applied project net classes to board: {report['applied']}")
+        return report
 
     def _resolve_execution_mode(self, jar_path: str) -> Dict[str, Any]:
         """Determine how to run Freerouting: direct or docker.
@@ -353,6 +401,12 @@ class FreeroutingCommands:
         ses_path = os.path.join(board_dir, f"{board_stem}.ses")
         best_ses_path = os.path.join(board_dir, f"{board_stem}_best.ses")
 
+        # Apply the project's net classes so the DSN carries per-class
+        # width/clearance rules instead of routing everything at Default (#302)
+        netclass_report = self._apply_project_net_classes(board_path)
+        if netclass_report.get("warning"):
+            logger.warning(f"Net-class application: {netclass_report['warning']}")
+
         # Step 1: Export DSN (once, regardless of attempt count)
         logger.info(f"Exporting DSN to {dsn_path}")
         try:
@@ -402,7 +456,11 @@ class FreeroutingCommands:
                 single_thread = True
 
             cmd = _build_freerouting_cmd(
-                jar_path, dsn_path, ses_path, attempt_passes, use_docker,
+                jar_path,
+                dsn_path,
+                ses_path,
+                attempt_passes,
+                use_docker,
                 single_thread=single_thread,
             )
             logger.info(
@@ -438,14 +496,16 @@ class FreeroutingCommands:
             if proc.returncode != 0:
                 # Don't abort the whole best-of-N just because one attempt
                 # exits nonzero — record it and move on.
-                attempt_results.append({
-                    "attempt": idx + 1,
-                    "max_passes": attempt_passes,
-                    "elapsed_seconds": attempt_elapsed,
-                    "ok": False,
-                    "exit_code": proc.returncode,
-                    "stderr": (proc.stderr or "")[:200],
-                })
+                attempt_results.append(
+                    {
+                        "attempt": idx + 1,
+                        "max_passes": attempt_passes,
+                        "elapsed_seconds": attempt_elapsed,
+                        "ok": False,
+                        "exit_code": proc.returncode,
+                        "stderr": (proc.stderr or "")[:200],
+                    }
+                )
                 if attempts == 1:
                     return {
                         "success": False,
@@ -457,20 +517,20 @@ class FreeroutingCommands:
                 continue
 
             if not os.path.isfile(ses_path):
-                attempt_results.append({
-                    "attempt": idx + 1,
-                    "max_passes": attempt_passes,
-                    "elapsed_seconds": attempt_elapsed,
-                    "ok": False,
-                    "error": "no SES produced",
-                })
+                attempt_results.append(
+                    {
+                        "attempt": idx + 1,
+                        "max_passes": attempt_passes,
+                        "elapsed_seconds": attempt_elapsed,
+                        "ok": False,
+                        "error": "no SES produced",
+                    }
+                )
                 if attempts == 1:
                     return {
                         "success": False,
                         "message": "Freerouting did not produce SES output",
-                        "errorDetails": (
-                            f"Expected at: {ses_path}. Stdout: {proc.stdout[:500]}"
-                        ),
+                        "errorDetails": (f"Expected at: {ses_path}. Stdout: {proc.stdout[:500]}"),
                         "elapsed_seconds": attempt_elapsed,
                     }
                 continue
@@ -480,13 +540,15 @@ class FreeroutingCommands:
                 ses_text = fh.read()
             score_info = _score_ses(ses_text, target_nets)
             score = score_info["score"]
-            attempt_results.append({
-                "attempt": idx + 1,
-                "max_passes": attempt_passes,
-                "elapsed_seconds": attempt_elapsed,
-                "ok": True,
-                **score_info,
-            })
+            attempt_results.append(
+                {
+                    "attempt": idx + 1,
+                    "max_passes": attempt_passes,
+                    "elapsed_seconds": attempt_elapsed,
+                    "ok": True,
+                    **score_info,
+                }
+            )
             logger.info(
                 f"  attempt {idx + 1}: score={score} "
                 f"({score_info['nets']} nets, {score_info['segments']} segs, "
@@ -570,6 +632,7 @@ class FreeroutingCommands:
                 "tracks": track_count,
                 "vias": via_count,
             },
+            "netClasses": netclass_report,
             "freerouting_stdout": best_proc_stdout[:1000],
         }
         if attempts > 1:
@@ -610,6 +673,12 @@ class FreeroutingCommands:
                     "errorDetails": ("Provide outputPath or have a board open"),
                 }
 
+        # Apply the project's net classes so the DSN carries per-class
+        # width/clearance rules instead of routing everything at Default (#302)
+        netclass_report = self._apply_project_net_classes(board_path)
+        if netclass_report.get("warning"):
+            logger.warning(f"Net-class application: {netclass_report['warning']}")
+
         try:
             result = pcbnew.ExportSpecctraDSN(self.board, output_path)
             if result is not True and result != 0:
@@ -631,6 +700,7 @@ class FreeroutingCommands:
             "message": f"Exported DSN to {output_path}",
             "path": output_path,
             "size_bytes": file_size,
+            "netClasses": netclass_report,
         }
 
     def import_ses(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/python/utils/project_netclasses.py
+++ b/python/utils/project_netclasses.py
@@ -1,0 +1,159 @@
+"""Read ``.kicad_pro`` net-class definitions and apply them to a SWIG board.
+
+KiCad 7+ stores net-class definitions in the project file
+(``net_settings.classes``), not the board. ``pcbnew.LoadBoard()`` reads only
+the ``.kicad_pcb``, so a board loaded headless carries just the stock
+Default class. ``pcbnew.ExportSpecctraDSN()`` then exports every net under a
+single ``kicad_default`` DSN class at Default width/clearance, silently
+dropping the user's class rules — a power net gets handed to Freerouting at
+signal width with no warning (#302).
+
+These helpers rebuild the board's ``NET_SETTINGS`` from the project file so
+KiCad's own exporter sees the same classes the GUI would and natively emits
+per-class ``(class ...)`` blocks, via padstacks, and rules. Verified against
+real KiCad 10: applying a 2.0 mm "Power" class over two nets makes
+``ExportSpecctraDSN`` write ``(class Power PWR PWR2 (circuit (use_via
+"Via[0-1]_1200:600_um")) (rule (width 2000) (clearance 350)))``, register
+the via padstack in the library, and drop the claimed nets from
+``kicad_default`` — byte-identical to a project-loaded GUI export.
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("kicad_interface")
+
+# net_settings.classes numeric fields (millimetres) -> NETCLASS setter names.
+# Same field vocabulary as commands/routing.py's _NETCLASS_NUMERIC_FIELDS.
+_NETCLASS_MM_SETTERS: Tuple[Tuple[str, str], ...] = (
+    ("clearance", "SetClearance"),
+    ("track_width", "SetTrackWidth"),
+    ("via_diameter", "SetViaDiameter"),
+    ("via_drill", "SetViaDrill"),
+    ("microvia_diameter", "SetuViaDiameter"),
+    ("microvia_drill", "SetuViaDrill"),
+    ("diff_pair_width", "SetDiffPairWidth"),
+    ("diff_pair_gap", "SetDiffPairGap"),
+)
+
+
+def load_project_net_classes(pro_path: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Parse ``net_settings`` from a ``.kicad_pro`` into a normalized dict.
+
+    Returns ``None`` when the file does not exist. Raises ``ValueError`` on
+    unreadable/unparseable JSON so the caller can surface the reason instead
+    of silently exporting without classes.
+
+    Result shape::
+
+        {
+          "classes":     [ {name, track_width, clearance, ...}, ... ],
+          "patterns":    [ (pattern, netclass), ... ],
+          "assignments": { net_name: [class_name, ...], ... },
+        }
+    """
+    if not pro_path or not os.path.isfile(pro_path):
+        return None
+    try:
+        with open(pro_path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read project file {pro_path}: {exc}") from exc
+
+    net_settings = data.get("net_settings") or {}
+
+    classes: List[Dict[str, Any]] = [
+        cls
+        for cls in (net_settings.get("classes") or [])
+        if isinstance(cls, dict) and cls.get("name")
+    ]
+
+    patterns: List[Tuple[str, str]] = []
+    for entry in net_settings.get("netclass_patterns") or []:
+        if isinstance(entry, dict) and entry.get("pattern") and entry.get("netclass"):
+            patterns.append((str(entry["pattern"]), str(entry["netclass"])))
+
+    # netclass_assignments maps net name -> list of class names (KiCad 9+
+    # serialization); tolerate a bare string value as well.
+    assignments: Dict[str, List[str]] = {}
+    raw_assignments = net_settings.get("netclass_assignments")
+    if isinstance(raw_assignments, dict):
+        for net, value in raw_assignments.items():
+            if isinstance(value, str):
+                names = [value]
+            elif isinstance(value, (list, tuple)):
+                names = [v for v in value if isinstance(v, str)]
+            else:
+                continue
+            if names:
+                assignments[str(net)] = names
+
+    return {"classes": classes, "patterns": patterns, "assignments": assignments}
+
+
+def _apply_numeric_fields(pcbnew_mod: Any, netclass: Any, cls: Dict[str, Any]) -> bool:
+    """Set the mm-valued fields present in ``cls`` on a NETCLASS. Returns
+    whether any field was applied."""
+    changed = False
+    for key, setter in _NETCLASS_MM_SETTERS:
+        value = cls.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            getattr(netclass, setter)(pcbnew_mod.FromMM(float(value)))
+            changed = True
+    return changed
+
+
+def apply_net_classes_to_board(board: Any, settings: Dict[str, Any]) -> Dict[str, Any]:
+    """Push parsed project net classes into ``board``'s ``NET_SETTINGS``.
+
+    May raise on a SWIG API mismatch (older KiCad builds); callers wrap this
+    and degrade to a warning rather than failing the export.
+    """
+    import pcbnew
+
+    net_settings = board.GetDesignSettings().m_NetSettings
+
+    applied: List[str] = []
+    default_updated = False
+    for cls in settings.get("classes", []):
+        name = str(cls["name"])
+        if name == "Default":
+            # The Default class already exists; update it in place so its
+            # project-configured width/clearance reach the DSN's default rule.
+            default_updated = _apply_numeric_fields(pcbnew, net_settings.GetDefaultNetclass(), cls)
+            continue
+        netclass = pcbnew.NETCLASS(name)
+        _apply_numeric_fields(pcbnew, netclass, cls)
+        priority = cls.get("priority")
+        if isinstance(priority, int) and not isinstance(priority, bool):
+            netclass.SetPriority(priority)
+        net_settings.SetNetclass(name, netclass)
+        applied.append(name)
+
+    assignment_count = 0
+    for pattern, class_name in settings.get("patterns", []):
+        net_settings.SetNetclassPatternAssignment(pattern, class_name)
+        assignment_count += 1
+
+    # Explicit per-net assignments are expressed as exact-name patterns:
+    # SetNetclassLabelAssignment is not callable from Python (its argument is
+    # a C++ std::set<wxString>), and a literal net name is a wildcard pattern
+    # matching exactly itself. Nets assigned multiple classes keep only the
+    # last one (same-pattern assignments replace); composite-class merging is
+    # not modeled here.
+    for net_name, class_names in settings.get("assignments", {}).items():
+        for class_name in class_names:
+            net_settings.SetNetclassPatternAssignment(net_name, class_name)
+            assignment_count += 1
+
+    if hasattr(net_settings, "ClearAllCaches"):
+        net_settings.ClearAllCaches()
+    board.SynchronizeNetsAndNetClasses(False)
+
+    return {
+        "applied": applied,
+        "defaultUpdated": default_updated,
+        "assignments": assignment_count,
+    }

--- a/tests/test_dsn_netclass_export_real.py
+++ b/tests/test_dsn_netclass_export_real.py
@@ -1,0 +1,110 @@
+"""Real-pcbnew end-to-end regression test for #302.
+
+Requires KICAD_USE_REAL_PCBNEW=1 (run under KiCad's bundled Python, e.g.
+``C:\\KiCad\\10.0\\bin\\python.exe -m pytest``). Builds a small board plus a
+``.kicad_pro`` defining a 2.0 mm "Power" class over PWR/PWR2, then asserts
+the production ``export_dsn`` emits the class with its rules and via
+padstack — the exact scenario from the issue, where every net previously
+exported under ``kicad_default`` at 0.2 mm.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+PYTHON_DIR = Path(__file__).parent.parent / "python"
+sys.path.insert(0, str(PYTHON_DIR))
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.real_pcbnew,
+]
+
+
+@pytest.fixture(autouse=True)
+def require_real_pcbnew() -> None:
+    if os.environ.get("KICAD_USE_REAL_PCBNEW") != "1":
+        pytest.skip("real pcbnew DSN test requires KICAD_USE_REAL_PCBNEW=1")
+
+
+def _build_board(pcbnew, pcb_path: Path):
+    def mm(v):
+        return pcbnew.FromMM(v)
+
+    board = pcbnew.BOARD()
+    nets = {}
+    for name in ["PWR", "PWR2", "SIG", "GND"]:
+        item = pcbnew.NETINFO_ITEM(board, name)
+        board.Add(item)
+        nets[name] = item
+
+    for x1, y1, x2, y2 in [(0, 0, 50, 0), (50, 0, 50, 50), (50, 50, 0, 50), (0, 50, 0, 0)]:
+        seg = pcbnew.PCB_SHAPE(board)
+        seg.SetShape(pcbnew.SHAPE_T_SEGMENT)
+        seg.SetStart(pcbnew.VECTOR2I(mm(x1), mm(y1)))
+        seg.SetEnd(pcbnew.VECTOR2I(mm(x2), mm(y2)))
+        seg.SetLayer(pcbnew.Edge_Cuts)
+        seg.SetWidth(mm(0.1))
+        board.Add(seg)
+
+    for ref, y, net_a, net_b in [("R1", 10, "PWR", "GND"), ("R2", 30, "PWR2", "SIG")]:
+        fp = pcbnew.FOOTPRINT(board)
+        fp.SetReference(ref)
+        fp.SetPosition(pcbnew.VECTOR2I(mm(10), mm(y)))
+        for i, net in enumerate([net_a, net_b], start=1):
+            pad = pcbnew.PAD(fp)
+            pad.SetNumber(str(i))
+            pad.SetShape(pcbnew.PAD_SHAPE_CIRCLE)
+            pad.SetAttribute(pcbnew.PAD_ATTRIB_PTH)
+            pad.SetSize(pcbnew.VECTOR2I(mm(1.6), mm(1.6)))
+            pad.SetDrillSize(pcbnew.VECTOR2I(mm(0.8), mm(0.8)))
+            pad.SetLayerSet(pad.PTHMask())
+            pad.SetPosition(pcbnew.VECTOR2I(mm(10 + (i - 1) * 5), mm(y)))
+            pad.SetNet(nets[net])
+            fp.Add(pad)
+        board.Add(fp)
+
+    pcbnew.SaveBoard(str(pcb_path), board)
+
+
+def _write_project(pro_path: Path) -> None:
+    from utils.kicad_project import new_project_settings
+
+    data = new_project_settings(pro_path.stem)
+    classes = data["net_settings"]["classes"]
+    power = dict(classes[0])
+    power.update(name="Power", track_width=2.0, clearance=0.35, via_diameter=1.2, via_drill=0.6)
+    classes.append(power)
+    data["net_settings"]["netclass_patterns"] = [
+        {"netclass": "Power", "pattern": "PWR"},
+        {"netclass": "Power", "pattern": "PWR2"},
+    ]
+    pro_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_export_dsn_emits_project_net_classes(tmp_path: Path) -> None:
+    import pcbnew
+
+    from commands.freerouting import FreeroutingCommands
+
+    pcb_path = tmp_path / "t302.kicad_pcb"
+    _build_board(pcbnew, pcb_path)
+    _write_project(tmp_path / "t302.kicad_pro")
+
+    board = pcbnew.LoadBoard(str(pcb_path))
+    result = FreeroutingCommands(board).export_dsn({"outputPath": str(tmp_path / "t302.dsn")})
+
+    assert result["success"] is True, result
+    assert result["netClasses"]["applied"] == ["Power"]
+    assert "warning" not in result["netClasses"]
+
+    dsn = (tmp_path / "t302.dsn").read_text(encoding="utf-8")
+    assert "(class Power PWR PWR2" in dsn
+    assert "(width 2000)" in dsn
+    assert "(clearance 350)" in dsn
+    assert '"Via[0-1]_1200:600_um"' in dsn
+    # The claimed nets must leave the default class.
+    assert "(class kicad_default GND SIG" in dsn

--- a/tests/test_project_netclasses.py
+++ b/tests/test_project_netclasses.py
@@ -1,0 +1,302 @@
+"""Tests for #302: project net classes reach the Specctra DSN export.
+
+Net-class definitions live in ``.kicad_pro``; the headless ``LoadBoard()``
+path never reads them, so ``ExportSpecctraDSN`` exported every net at the
+Default class width — a silent electrical hazard on the autoroute path.
+These tests cover the ``.kicad_pro`` parser, the NET_SETTINGS application
+step (against a fake pcbnew), and the report/warning surface of
+``FreeroutingCommands._apply_project_net_classes``.
+"""
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from utils.project_netclasses import (  # noqa: E402
+    apply_net_classes_to_board,
+    load_project_net_classes,
+)
+
+
+def _project_json(**net_settings) -> str:
+    return json.dumps({"net_settings": net_settings})
+
+
+# ---------------------------------------------------------------------------
+# Fake pcbnew + board, recording exactly the calls the fix performs.
+# ---------------------------------------------------------------------------
+
+
+class FakeNetclass:
+    def __init__(self, name: str = "Default") -> None:
+        self.name = name
+        self.values: dict = {}
+        self.priority = None
+
+    def __getattr__(self, attr: str):
+        if attr.startswith("Set"):
+
+            def setter(value, _key=attr[3:]):
+                self.values[_key] = value
+
+            return setter
+        raise AttributeError(attr)
+
+    def SetPriority(self, value: int) -> None:
+        self.priority = value
+
+
+class FakeNetSettings:
+    def __init__(self) -> None:
+        self.default = FakeNetclass("Default")
+        self.netclasses: dict = {}
+        self.pattern_assignments: list = []
+        self.caches_cleared = False
+
+    def GetDefaultNetclass(self) -> FakeNetclass:
+        return self.default
+
+    def SetNetclass(self, name: str, netclass: FakeNetclass) -> None:
+        self.netclasses[name] = netclass
+
+    def SetNetclassPatternAssignment(self, pattern: str, name: str) -> None:
+        self.pattern_assignments.append((pattern, name))
+
+    def ClearAllCaches(self) -> None:
+        self.caches_cleared = True
+
+
+class FakeBoard:
+    def __init__(self) -> None:
+        self.net_settings = FakeNetSettings()
+        self.synchronized_with = None
+
+    def GetDesignSettings(self):
+        return types.SimpleNamespace(m_NetSettings=self.net_settings)
+
+    def SynchronizeNetsAndNetClasses(self, reset: bool) -> None:
+        self.synchronized_with = reset
+
+
+def _fake_pcbnew() -> types.ModuleType:
+    module = types.ModuleType("pcbnew")
+    module.FromMM = lambda mm: int(round(mm * 1_000_000))  # type: ignore[attr-defined]
+    module.NETCLASS = FakeNetclass  # type: ignore[attr-defined]
+    return module
+
+
+# ---------------------------------------------------------------------------
+# load_project_net_classes
+# ---------------------------------------------------------------------------
+
+
+def test_load_missing_file_returns_none(tmp_path: Path) -> None:
+    assert load_project_net_classes(str(tmp_path / "absent.kicad_pro")) is None
+    assert load_project_net_classes(None) is None
+    assert load_project_net_classes("") is None
+
+
+def test_load_malformed_json_raises_value_error(tmp_path: Path) -> None:
+    pro = tmp_path / "bad.kicad_pro"
+    pro.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="bad.kicad_pro"):
+        load_project_net_classes(str(pro))
+
+
+def test_load_parses_classes_patterns_and_assignments(tmp_path: Path) -> None:
+    pro = tmp_path / "t.kicad_pro"
+    pro.write_text(
+        _project_json(
+            classes=[
+                {"name": "Default", "track_width": 0.25},
+                {"name": "Power", "track_width": 2.0, "clearance": 0.35},
+            ],
+            netclass_patterns=[
+                {"netclass": "Power", "pattern": "PWR*"},
+            ],
+            netclass_assignments={
+                "GND": ["Power"],
+                "VBUS": "Power",  # bare-string value tolerated
+            },
+        ),
+        encoding="utf-8",
+    )
+    settings = load_project_net_classes(str(pro))
+    assert settings is not None
+    assert [c["name"] for c in settings["classes"]] == ["Default", "Power"]
+    assert settings["patterns"] == [("PWR*", "Power")]
+    assert settings["assignments"] == {"GND": ["Power"], "VBUS": ["Power"]}
+
+
+def test_load_skips_malformed_entries(tmp_path: Path) -> None:
+    pro = tmp_path / "t.kicad_pro"
+    pro.write_text(
+        _project_json(
+            classes=[{"track_width": 1.0}, "junk", {"name": "OK"}],
+            netclass_patterns=[{"pattern": "X"}, {"netclass": "Y"}, "junk"],
+            netclass_assignments={"N1": 42, "N2": [3, "Real"]},
+        ),
+        encoding="utf-8",
+    )
+    settings = load_project_net_classes(str(pro))
+    assert settings is not None
+    assert [c["name"] for c in settings["classes"]] == ["OK"]
+    assert settings["patterns"] == []
+    assert settings["assignments"] == {"N2": ["Real"]}
+
+
+def test_load_handles_null_net_settings(tmp_path: Path) -> None:
+    pro = tmp_path / "t.kicad_pro"
+    pro.write_text(json.dumps({"net_settings": None}), encoding="utf-8")
+    settings = load_project_net_classes(str(pro))
+    assert settings == {"classes": [], "patterns": [], "assignments": {}}
+
+
+# ---------------------------------------------------------------------------
+# apply_net_classes_to_board
+# ---------------------------------------------------------------------------
+
+
+def _apply(settings):
+    board = FakeBoard()
+    with mock.patch.dict(sys.modules, {"pcbnew": _fake_pcbnew()}):
+        report = apply_net_classes_to_board(board, settings)
+    return board, report
+
+
+def test_apply_registers_custom_class_with_mm_conversion() -> None:
+    board, report = _apply(
+        {
+            "classes": [
+                {
+                    "name": "Power",
+                    "track_width": 2.0,
+                    "clearance": 0.35,
+                    "via_diameter": 1.2,
+                    "via_drill": 0.6,
+                    "priority": 0,
+                }
+            ],
+            "patterns": [("PWR", "Power"), ("PWR2", "Power")],
+            "assignments": {},
+        }
+    )
+    ns = board.net_settings
+    assert list(ns.netclasses) == ["Power"]
+    power = ns.netclasses["Power"]
+    assert power.values["TrackWidth"] == 2_000_000
+    assert power.values["Clearance"] == 350_000
+    assert power.values["ViaDiameter"] == 1_200_000
+    assert power.values["ViaDrill"] == 600_000
+    assert power.priority == 0
+    assert ns.pattern_assignments == [("PWR", "Power"), ("PWR2", "Power")]
+    assert ns.caches_cleared is True
+    assert board.synchronized_with is False  # keep current track/via sizes
+    assert report["applied"] == ["Power"]
+    assert report["assignments"] == 2
+
+
+def test_apply_updates_default_class_in_place() -> None:
+    board, report = _apply(
+        {
+            "classes": [{"name": "Default", "track_width": 0.3}],
+            "patterns": [],
+            "assignments": {},
+        }
+    )
+    ns = board.net_settings
+    assert ns.netclasses == {}  # Default is never re-registered
+    assert ns.default.values["TrackWidth"] == 300_000
+    assert report["applied"] == []
+    assert report["defaultUpdated"] is True
+
+
+def test_apply_expresses_explicit_assignments_as_exact_patterns() -> None:
+    board, report = _apply(
+        {
+            "classes": [{"name": "HV", "clearance": 1.0}],
+            "patterns": [],
+            "assignments": {"Net-(D1-Pad2)": ["HV"]},
+        }
+    )
+    assert board.net_settings.pattern_assignments == [("Net-(D1-Pad2)", "HV")]
+    assert report["assignments"] == 1
+
+
+def test_apply_skips_non_numeric_values() -> None:
+    board, _ = _apply(
+        {
+            "classes": [
+                {"name": "Odd", "track_width": "wide", "clearance": True, "via_drill": 0.4}
+            ],
+            "patterns": [],
+            "assignments": {},
+        }
+    )
+    odd = board.net_settings.netclasses["Odd"]
+    assert odd.values == {"ViaDrill": 400_000}
+
+
+# ---------------------------------------------------------------------------
+# FreeroutingCommands._apply_project_net_classes (report/warning surface)
+# ---------------------------------------------------------------------------
+
+
+from commands.freerouting import FreeroutingCommands  # noqa: E402
+
+
+def test_report_warns_when_project_file_missing(tmp_path: Path) -> None:
+    fc = FreeroutingCommands(FakeBoard())
+    report = fc._apply_project_net_classes(str(tmp_path / "board.kicad_pcb"))
+    assert report["applied"] == []
+    assert ".kicad_pro" in report["warning"]
+
+
+def test_report_warns_on_unreadable_project(tmp_path: Path) -> None:
+    (tmp_path / "board.kicad_pro").write_text("{broken", encoding="utf-8")
+    fc = FreeroutingCommands(FakeBoard())
+    report = fc._apply_project_net_classes(str(tmp_path / "board.kicad_pcb"))
+    assert report["applied"] == []
+    assert "Default-class rules only" in report["warning"]
+
+
+def test_report_names_dropped_classes_when_apply_fails(tmp_path: Path) -> None:
+    (tmp_path / "board.kicad_pro").write_text(
+        _project_json(classes=[{"name": "Power", "track_width": 2.0}]),
+        encoding="utf-8",
+    )
+
+    class ExplodingBoard:
+        def GetDesignSettings(self):
+            raise RuntimeError("no m_NetSettings on this build")
+
+    fc = FreeroutingCommands(ExplodingBoard())
+    with mock.patch.dict(sys.modules, {"pcbnew": _fake_pcbnew()}):
+        report = fc._apply_project_net_classes(str(tmp_path / "board.kicad_pcb"))
+    assert report["applied"] == []
+    assert "Power" in report["warning"]
+    assert "Default-class rules only" in report["warning"]
+
+
+def test_report_success_includes_project_file(tmp_path: Path) -> None:
+    (tmp_path / "board.kicad_pro").write_text(
+        _project_json(
+            classes=[{"name": "Power", "track_width": 2.0}],
+            netclass_patterns=[{"netclass": "Power", "pattern": "PWR"}],
+        ),
+        encoding="utf-8",
+    )
+    board = FakeBoard()
+    fc = FreeroutingCommands(board)
+    with mock.patch.dict(sys.modules, {"pcbnew": _fake_pcbnew()}):
+        report = fc._apply_project_net_classes(str(tmp_path / "board.kicad_pcb"))
+    assert report["applied"] == ["Power"]
+    assert report["projectFile"] == str(tmp_path / "board.kicad_pro")
+    assert "warning" not in report
+    assert board.net_settings.pattern_assignments == [("PWR", "Power")]


### PR DESCRIPTION
Fixes #302.

## Problem

Net-class definitions live in `.kicad_pro` on KiCad 7+, which the headless `pcbnew.LoadBoard()` path never reads. `ExportSpecctraDSN` therefore exported every net under a single `kicad_default` class at Default width/clearance. The one-call `autoroute` tool re-exports internally, so a 2.0 mm power net was silently handed to Freerouting at 0.2 mm signal width -- routed too thin with no error or warning. This is the read-side analog of the write-side gap documented in #185/#232.

## Approach

Rather than post-processing the DSN text (the reporter's validated workaround), the fix populates the board's `NET_SETTINGS` from the project file **before** export and lets KiCad's own exporter do the writing. Empirically verified on real KiCad 10 that the SWIG surface supports this end to end: `pcbnew.NETCLASS` construction, `m_NetSettings.SetNetclass`, `SetNetclassPatternAssignment`, and `BOARD.SynchronizeNetsAndNetClasses`. With the classes applied, `ExportSpecctraDSN` natively emits:

- the per-class block: `(class Power PWR PWR2 (circuit (use_via "Via[0-1]_1200:600_um")) (rule (width 2000) (clearance 350)))`
- the class's via padstack in the `(library ...)` section (name encodes diameter:drill, which the SES importer parses back into correctly sized vias)
- the padstack name appended to the structure's `(via ...)` list
- the claimed nets removed from `kicad_default`

This is byte-identical to what a project-loaded GUI export writes, so there is no format guessing, and pattern matching uses KiCad's own wildcard semantics.

One SWIG limitation worked around: `SetNetclassLabelAssignment` takes a C++ `std::set<wxString>` and is not callable from Python, so explicit per-net `netclass_assignments` are expressed as exact-name pattern assignments (a literal net name is a wildcard pattern matching exactly itself). Nets assigned multiple classes keep the last one; composite-class merging is not modeled.

## Loud, not silent

The tool result now carries a `netClasses` report:

- success: `{"applied": ["Power"], "defaultUpdated": true, "assignments": 2, "projectFile": "..."}`
- no `.kicad_pro` next to the board: a warning that class rules are unknown and everything exports at Default
- project defines classes but they cannot be applied (older SWIG API): a warning naming the dropped classes

Application is best-effort and never fails the export -- the previous behavior was silent data loss, so the floor is now "same DSN as before, plus a warning saying exactly what was dropped."

## Validation

- End-to-end on real KiCad 10 (`C:\KiCad\10.0`): built the issue's minimal repro (4 nets, a 2.0 mm Power class over PWR/PWR2 via `netclass_patterns`), ran the production `export_dsn` -- all six content checks pass (class block, members, width 2000, clearance 350, 1200:600 padstack, shrunken default class), and the orphan-board path produces the warning.
- 13 new unit tests (`tests/test_project_netclasses.py`): the `.kicad_pro` parser (missing file, malformed JSON, malformed entries, bare-string assignments, null net_settings), the NET_SETTINGS application step against a fake pcbnew (mm conversion, Default updated in place, explicit assignments as exact patterns, non-numeric values skipped), and the report/warning surface of `_apply_project_net_classes`.
- 1 gated end-to-end regression test (`tests/test_dsn_netclass_export_real.py`, `KICAD_USE_REAL_PCBNEW=1`) reproducing the issue's scenario against real pcbnew.
- Full suite: 1301 passed, 4 skipped. The Java-gated freerouting tests show exactly the baseline 8 environmental failures ("Java executable not found"), unchanged.
- black and mypy clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)