### PR TITLE
fix: sheet insertion lands on line boundaries; add_sheet_pin scans by character (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`add_sheet_pin` finds sheets regardless of line formatting; sheet/text
+  insertion no longer splices mid-line** (#298): `add_hierarchical_sheet`
+  and the wire/label/text insert helper located their insertion point with
+  `content.rfind(...)` — a raw character offset — so on files where the
+  marker does not start its own line (sexpdata-written schematics keep
+  several forms on one line) the new block landed mid-line. `add_sheet_pin`
+  then scanned line-by-line for `(sheet` at the start of a line and could
+  never find such a sheet, failing with "sheet not found" on a sheet that
+  plainly existed. Insertions now snap to a line boundary (breaking the
+  line when the marker shares it), and `add_sheet_pin` scans by character
+  with paren matching, so it also works on files already written with
+  mid-line sheets and on fully minified single-line schematics.
+
 - **`export_dsn`/`autoroute` no longer drop `.kicad_pro` net classes — power
   nets keep their width** (#302): net-class definitions live in the project
   file on KiCad 7+, which the headless `pcbnew.LoadBoard()` path never reads,

--- a/python/commands/schematic_hierarchy.py
+++ b/python/commands/schematic_hierarchy.py
@@ -85,7 +85,21 @@ class SchematicHierarchyCommands:
             insert_at = content.rfind("(sheet_instances")
             if insert_at == -1:
                 return {"success": False, "message": "Could not find (sheet_instances in schematic"}
-            content = content[:insert_at] + sheet_block + "  " + content[insert_at:]
+            # rfind returns a raw character offset; on files where
+            # (sheet_instances does not start its own line (sexpdata-written
+            # schematics keep several forms on one line) splicing there lands
+            # the sheet block mid-line, where line-based consumers like
+            # add_sheet_pin can never find it (#298). Snap to a line boundary.
+            line_start = content.rfind("\n", 0, insert_at) + 1
+            if content[line_start:insert_at].strip():
+                # (sheet_instances shares its line with earlier content:
+                # break the line so the sheet block and (sheet_instances each
+                # start a line of their own.
+                content = content[:insert_at] + "\n" + sheet_block + "  " + content[insert_at:]
+            else:
+                # (sheet_instances starts its line: insert the block at the
+                # line start so (sheet_instances keeps its own indentation.
+                content = content[:line_start] + sheet_block + content[line_start:]
 
             si_start = content.rfind("(sheet_instances")
             depth = 0

--- a/python/commands/wire_manager.py
+++ b/python/commands/wire_manager.py
@@ -65,6 +65,16 @@ def _text_insert(file_path: Path, sexp_text: str) -> bool:
         content = f.read()
 
     insert_at = _find_insertion_point(content)
+    # _find_insertion_point returns a raw character offset; on files where
+    # the marker does not start its own line (sexpdata-written schematics
+    # keep several forms on one line) splicing there lands the new element
+    # mid-line, where line-based consumers can never find it (#298). Snap to
+    # a line boundary, or break the line when the marker shares it.
+    line_start = content.rfind("\n", 0, insert_at) + 1
+    if content[line_start:insert_at].strip():
+        sexp_text = "\n" + sexp_text
+    else:
+        insert_at = line_start
     content = content[:insert_at] + sexp_text + content[insert_at:]
 
     with open(file_path, "w", encoding="utf-8") as f:
@@ -1121,47 +1131,49 @@ class WireManager:
     ) -> Tuple[str, bool]:
         """Insert a sheet pin into the named sheet block in the parent schematic.
 
+        Scans by character, not by line: a (sheet block does not always start
+        a line — sexpdata-written schematics keep several forms on one line,
+        and files written by the pre-#298 sheet inserter have (sheet spliced
+        mid-line — so a line-anchored search misses real sheets.
+
         Returns (modified_content, success).
         """
-        lines = content.split("\n")
         # KiCad 7-9 stores the property as "Sheetname"; KiCad 10 renamed it
         # to "Sheet name" (with space). Match either to stay compatible.
         sheetname_pattern = re.compile(
             r'\(property\s+"Sheet\s?name"\s+"' + re.escape(sheet_name) + r'"'
         )
-        # KiCad 7-9 indents top-level blocks with a single tab; KiCad 10
-        # writes 2- or 4-space indentation. Accept any leading whitespace.
-        sheet_block_pattern = re.compile(r"^\s*\(sheet\b")
 
-        # Find the sheet block that contains the target Sheetname property
-        i = 0
-        while i < len(lines):
-            if sheet_block_pattern.match(lines[i]):
-                # Walk forward to find closing paren of this block
-                depth = sum(1 for c in lines[i] if c == "(") - sum(1 for c in lines[i] if c == ")")
-                j = i + 1
-                found_name = False
-                while j < len(lines) and depth > 0:
-                    if sheetname_pattern.search(lines[j]):
-                        found_name = True
-                    depth += sum(1 for c in lines[j] if c == "(") - sum(
-                        1 for c in lines[j] if c == ")"
-                    )
-                    j += 1
-                b_end = j - 1  # index of closing ")" line of the sheet block
-
-                if found_name:
-                    # Insert pin text before the closing paren of the sheet block
-                    pin_text = _make_sheet_pin_text(pin_name, pin_type, position, orientation)
-                    pin_lines = pin_text.rstrip("\n").split("\n")
-                    for offset, line in enumerate(pin_lines):
-                        lines.insert(b_end + offset, line)
-                    logger.info(f"Added sheet pin '{pin_name}' to sheet '{sheet_name}'")
-                    return "\n".join(lines), True
-
-                i = b_end + 1
+        # \b keeps (sheet_instances from matching ("_" is a word character).
+        for match in re.finditer(r"\(sheet\b", content):
+            start = match.start()
+            depth = 0
+            end = -1
+            for i in range(start, len(content)):
+                if content[i] == "(":
+                    depth += 1
+                elif content[i] == ")":
+                    depth -= 1
+                    if depth == 0:
+                        end = i  # index of the block's closing ")"
+                        break
+            if end == -1:
+                break  # unbalanced parens; nothing sane to do
+            if not sheetname_pattern.search(content, start, end):
                 continue
-            i += 1
+
+            pin_text = _make_sheet_pin_text(pin_name, pin_type, position, orientation)
+            # Insert before the block's closing paren so the pin gets lines
+            # of its own even when that paren does not start a line.
+            line_start = content.rfind("\n", 0, end) + 1
+            if content[line_start:end].strip():
+                insertion = "\n" + pin_text.rstrip("\n") + "\n\t"
+                at = end
+            else:
+                insertion = pin_text
+                at = line_start
+            logger.info(f"Added sheet pin '{pin_name}' to sheet '{sheet_name}'")
+            return content[:at] + insertion + content[at:], True
 
         return content, False
 

--- a/tests/test_hierarchy_tools.py
+++ b/tests/test_hierarchy_tools.py
@@ -347,3 +347,106 @@ class TestAddSheetPin:
         content = sch.read_text()
         assert "(at 100 60 180)" in content
         assert "(justify right)" in content
+
+    def test_finds_sheet_that_does_not_start_a_line(self, iface, tmp_path):
+        """#298: files written by the pre-fix sheet inserter have (sheet
+        spliced mid-line; the line-anchored scan never found them."""
+        import sexpdata
+
+        sch = tmp_path / "parent.kicad_sch"
+        sch.write_text(
+            "(kicad_sch\n"
+            '\t(uuid "abcd-1234") (sheet (at 100 50) (size 40 30)\n'
+            '\t\t(property "Sheetname" "Storage" (at 100 49 0))\n'
+            '\t\t(property "Sheetfile" "sheets/storage.kicad_sch" (at 100 82 0))\n'
+            "\t)\n"
+            '\t(sheet_instances (path "/" (page "1")))\n'
+            ")\n"
+        )
+
+        result = iface._handle_add_sheet_pin(
+            {
+                "schematicPath": str(sch),
+                "sheetName": "Storage",
+                "pinName": "SD_CLK",
+                "pinType": "output",
+                "position": [140, 60],
+            }
+        )
+
+        assert result["success"] is True, result
+        content = sch.read_text()
+        assert '(pin "SD_CLK" output' in content
+        sexpdata.loads(content)
+
+    def test_finds_sheet_in_minified_single_line_file(self, iface, tmp_path):
+        """A sexpdata-minified schematic has no line structure at all; the
+        pin must still land inside the right sheet block."""
+        import sexpdata
+
+        sch = tmp_path / "parent.kicad_sch"
+        sch.write_text(
+            "(kicad_sch (uuid abcd-1234)"
+            " (sheet (at 100 50) (size 40 30)"
+            ' (property "Sheetname" "Storage" (at 100 49 0))'
+            ' (property "Sheetfile" "sheets/storage.kicad_sch" (at 100 82 0)))'
+            ' (sheet_instances (path "/" (page "1"))))'
+        )
+
+        result = iface._handle_add_sheet_pin(
+            {
+                "schematicPath": str(sch),
+                "sheetName": "Storage",
+                "pinName": "SD_D0",
+                "pinType": "bidirectional",
+                "position": [140, 60],
+            }
+        )
+
+        assert result["success"] is True, result
+        content = sch.read_text()
+        parsed = sexpdata.loads(content)
+        # The pin must be inside the (sheet ...) block, not appended at top level.
+        from sexpdata import Symbol
+
+        sheet = next(
+            item
+            for item in parsed
+            if isinstance(item, list) and item and item[0] == Symbol("sheet")
+        )
+        assert any(
+            isinstance(sub, list) and sub and sub[0] == Symbol("pin") and sub[1] == "SD_D0"
+            for sub in sheet
+        ), f"pin not inside the sheet block:\n{content}"
+
+    def test_add_sheet_then_pin_on_single_line_parent(self, iface, tmp_path):
+        """End-to-end #298 repro: link a sheet into a sexpdata-style parent
+        (no newline before (sheet_instances), then add a pin to it."""
+        import sexpdata
+
+        from commands.schematic_hierarchy import SchematicHierarchyCommands
+
+        parent = tmp_path / "top.kicad_sch"
+        parent.write_text('(kicad_sch (uuid abcd-1234) (sheet_instances (path "/" (page "1"))))')
+        link = SchematicHierarchyCommands(iface).add_hierarchical_sheet(
+            {
+                "schematicPath": str(parent),
+                "subsheetPath": str(tmp_path / "power.kicad_sch"),
+                "sheetName": "Power",
+            }
+        )
+        assert link["success"] is True
+
+        result = iface._handle_add_sheet_pin(
+            {
+                "schematicPath": str(parent),
+                "sheetName": "Power",
+                "pinName": "VIN",
+                "pinType": "input",
+                "position": [52, 55],
+            }
+        )
+        assert result["success"] is True, result
+        content = parent.read_text()
+        assert '(pin "VIN" input' in content
+        sexpdata.loads(content)

--- a/tests/test_schematic_hierarchy.py
+++ b/tests/test_schematic_hierarchy.py
@@ -44,6 +44,54 @@ class TestAddHierarchicalSheet:
         # a sheet_instances path entry for the new sheet block was added
         assert f'/{ "abcd-1234" }/{ r["sheet_uuid"] }' in content
 
+    def test_sheet_block_starts_its_own_line(self, tmp_path):
+        """#298: rfind gives a raw char offset; when (sheet_instances does not
+        start a line (sexpdata-written files), the sheet block used to be
+        spliced mid-line, where add_sheet_pin's scan could never find it."""
+        import sexpdata
+
+        parent = tmp_path / "top.kicad_sch"
+        # Everything on one line: (sheet_instances shares it with the uuid.
+        parent.write_text('(kicad_sch (uuid abcd-1234) (sheet_instances (path "/" (page "1"))))')
+        r = _cmds().add_hierarchical_sheet(
+            {
+                "schematicPath": str(parent),
+                "subsheetPath": str(tmp_path / "sub.kicad_sch"),
+                "sheetName": "Power",
+            }
+        )
+        assert r["success"] is True
+        content = parent.read_text()
+        # The (sheet block must start its own line (any indentation).
+        sheet_lines = [ln for ln in content.split("\n") if ln.lstrip().startswith("(sheet ")]
+        assert sheet_lines, f"(sheet does not start any line:\n{content}"
+        # The file must still be a single balanced s-expression.
+        sexpdata.loads(content)
+
+    def test_sheet_insertion_keeps_indented_files_intact(self, tmp_path):
+        """The normal KiCad-written shape ((sheet_instances starts a line)
+        must keep working and stay balanced."""
+        import sexpdata
+
+        parent = tmp_path / "top.kicad_sch"
+        parent.write_text(
+            '(kicad_sch (uuid abcd-1234)\n\t(sheet_instances (path "/" (page "1")))\n)'
+        )
+        r = _cmds().add_hierarchical_sheet(
+            {
+                "schematicPath": str(parent),
+                "subsheetPath": str(tmp_path / "sub.kicad_sch"),
+                "sheetName": "IO",
+            }
+        )
+        assert r["success"] is True
+        content = parent.read_text()
+        sheet_lines = [ln for ln in content.split("\n") if ln.lstrip().startswith("(sheet ")]
+        assert sheet_lines
+        # (sheet_instances keeps its own line and indentation
+        assert any(ln.lstrip().startswith("(sheet_instances") for ln in content.split("\n"))
+        sexpdata.loads(content)
+
 
 class TestCreateHierarchicalSubsheet:
     def test_orchestrates(self):


### PR DESCRIPTION
Fixes #298.

## Problem

The reporter's agent diagnosed this precisely, and both halves it described are real:

1. **Insertion side**: `add_hierarchical_sheet` (and the shared wire/label/text insert helper in `wire_manager.py`) find their insertion point with `content.rfind("(sheet_instances")` -- a raw character offset. On files where `(sheet_instances` does not start its own line (sexpdata's `dumps()` keeps several forms on one line), the sheet block was spliced mid-line, e.g. onto the tail of the uuid line.
2. **Search side**: `add_sheet_pin` scanned line-by-line for `^\s*\(sheet\b`. The indentation tolerance from the #260-class fix was already there, but a `(sheet` that landed mid-line (or a fully minified single-line file) can never match a line-anchored pattern, so adding a pin to a sheet that plainly existed failed with "sheet not found".

## Fix

- **Insertions snap to a line boundary.** When the marker's line prefix is whitespace-only (normal KiCad output), the block is inserted at the line start so the marker keeps its own indentation. When something else shares the line (sexpdata-written files), the line is broken so the inserted block and the marker each start a line of their own. Applied to both `add_hierarchical_sheet` and `_text_insert` (which backs `add_wire`/`add_label`/`add_text`/`add_hierarchical_label`), since they share the same raw-offset pattern.
- **`add_sheet_pin` scans by character with paren matching** instead of line-anchored regex: find each `(sheet` occurrence (the `\b` keeps `(sheet_instances` from matching, since `_` is a word character), balance parens to the block end, and check the Sheetname property within that span. This makes the tool work on files already written with mid-line sheets (they exist in the wild -- the reporter has one) and on fully minified schematics, not just on files we write from now on.

## Tests

Five new tests; the four regression tests fail without the fix (verified by stashing the source changes):

- `add_hierarchical_sheet` on a single-line parent: the `(sheet` block starts its own line and the file stays a balanced s-expression
- the normal indented shape keeps working unchanged
- `add_sheet_pin` finds a sheet whose `(sheet` does not start a line
- `add_sheet_pin` on a fully minified single-line file, with an sexpdata-parse assertion that the pin landed *inside* the sheet block
- end-to-end #298 repro: link a sheet into a sexpdata-style parent, then add a pin to it

Full suite: 1306 passed, 4 skipped (baseline plus these five). black and mypy clean on changed files. All 17 pre-existing hierarchy-tool tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)