### PR TITLE
feat: add_symbol_property + add_library_symbol_property MCP tools

### DIFF
--- a/python/commands/add_library_symbol_property.py
+++ b/python/commands/add_library_symbol_property.py
@@ -1,0 +1,106 @@
+"""Add or update a property on a symbol definition in the lib_symbols section."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from utils.sexpr_format import prettify
+
+
+def _find_symbol_in_lib_symbols(
+    content: str, library_name: str, symbol_name: str
+) -> tuple[int, int, str] | None:
+    """Return (start, end, block_text) for a symbol in lib_symbols, or None."""
+    full = f"{library_name}:{symbol_name}"
+    lib_start = content.find("(lib_symbols")
+    if lib_start == -1:
+        return None
+
+    marker = f'(symbol "{full}"'
+    sym_start = content.find(marker, lib_start)
+    if sym_start == -1:
+        return None
+
+    depth = 0
+    for i in range(sym_start, len(content)):
+        if content[i] == "(":
+            depth += 1
+        elif content[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return sym_start, i, content[sym_start : i + 1]
+
+    return None
+
+
+def _has_property(symbol_block: str, prop_name: str) -> bool:
+    """Check if a property already exists in a symbol block."""
+    return bool(re.search(rf'\(property\s+"{re.escape(prop_name)}"', symbol_block))
+
+
+def _property_s_expr(
+    name: str, value: str, pos: dict[str, float] | None = None, hide: bool = False
+) -> str:
+    """Build a (property ...) s-expression string."""
+    x = pos.get("x", 0) if pos else 0
+    y = pos.get("y", 0) if pos else 0
+    parts = [f'(property "{name}" "{value}" (at {x} {y} 0)']
+    if hide:
+        parts.append("(hide yes)")
+    parts.append("(effects (font (size 1.27 1.27)))")
+    parts.append(")")
+    return "\n\t\t\t".join(parts)
+
+
+def add_library_symbol_property(params: dict[str, Any]) -> dict[str, Any]:
+    schematic_path = Path(params["schematicPath"])
+    library_name = params["libraryName"]
+    symbol_name = params["symbolName"]
+    prop_name = params["propertyName"]
+    prop_value = params["propertyValue"]
+    pos = params.get("position")
+    hide = bool(params.get("hide", False))
+
+    if not schematic_path.exists():
+        return {"success": False, "message": f"Schematic not found: {schematic_path}"}
+
+    content = schematic_path.read_text(encoding="utf-8")
+    found = _find_symbol_in_lib_symbols(content, library_name, symbol_name)
+    if not found:
+        return {
+            "success": False,
+            "message": f"Symbol {library_name}:{symbol_name} not found in lib_symbols",
+        }
+
+    sym_start, sym_end, block = found
+    new_prop = _property_s_expr(prop_name, prop_value, pos, hide)
+
+    if _has_property(block, prop_name):
+        old = re.search(
+            rf'(\(property\s+"{re.escape(prop_name)}"[^)]*(?:\([^)]*\))*[^)]*\s*\n?\s*(?:\(hide[^)]*\)\s*\n?\s*)?(?:\(effects[^)]*(?:\([^)]*\))*[^)]*\))?\s*\))',
+            block,
+            re.DOTALL,
+        )
+        if old:
+            block = block[: old.start()] + new_prop + block[old.end() :]
+        else:
+            block = block.rstrip()[:-1] + "\n\t\t\t" + new_prop + "\n\t\t)"
+    else:
+        sub = re.search(r'\n\t\t\t\(symbol "', block)
+        if sub:
+            insert_at = sub.start()
+            block = block[:insert_at] + "\n\t\t\t" + new_prop + block[insert_at:]
+        else:
+            block = block.rstrip()[:-1] + "\n\t\t\t" + new_prop + "\n\t\t)"
+
+    content = content[:sym_start] + block + content[sym_end + 1 :]
+    schematic_path.write_text(prettify(content), encoding="utf-8")
+
+    return {
+        "success": True,
+        "message": f"Property '{prop_name}' set to '{prop_value}' in {library_name}:{symbol_name}",
+        "propertyAdded": prop_name,
+        "propertyValue": prop_value,
+    }

--- a/python/commands/add_symbol_property.py
+++ b/python/commands/add_symbol_property.py
@@ -1,0 +1,98 @@
+"""Add or update a property on a symbol in a .kicad_sym library file."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+
+def _find_symbol_in_lib(content: str, symbol_name: str) -> tuple[int, int, str] | None:
+    """Return (start, end, block) for a symbol in .kicad_sym, or None."""
+    marker = f'(symbol "{symbol_name}"'
+    sym_start = content.find(marker)
+    if sym_start == -1:
+        return None
+
+    depth = 0
+    for i in range(sym_start, len(content)):
+        if content[i] == "(":
+            depth += 1
+        elif content[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return sym_start, i, content[sym_start : i + 1]
+
+    return None
+
+
+def _has_property(symbol_block: str, prop_name: str) -> bool:
+    return bool(re.search(rf'\(property\s+"{re.escape(prop_name)}"', symbol_block))
+
+
+def _build_property(
+    name: str, value: str, pos: dict[str, float] | None = None, hide: bool = False
+) -> str:
+    x = pos.get("x", 0) if pos else 0
+    y = pos.get("y", 0) if pos else 0
+    lines = [f'(property "{name}" "{value}" (at {x} {y} 0)']
+    if hide:
+        lines.append("(hide yes)")
+    lines.append("(effects (font (size 1.27 1.27)))")
+    lines.append(")")
+    return "\n\t\t\t".join(lines)
+
+
+def add_symbol_property(params: dict[str, Any]) -> dict[str, Any]:
+    lib_path = Path(params["libraryPath"])
+    symbol_name = params["symbolName"]
+    prop_name = params["propertyName"]
+    prop_value = params["propertyValue"]
+    pos = params.get("position")
+    hide = bool(params.get("hide", False))
+
+    if not lib_path.exists():
+        return {"success": False, "message": f"Library not found: {lib_path}"}
+
+    content = lib_path.read_text(encoding="utf-8")
+    found = _find_symbol_in_lib(content, symbol_name)
+    if not found:
+        return {
+            "success": False,
+            "message": f"Symbol '{symbol_name}' not found in library",
+        }
+
+    sym_start, sym_end, block = found
+    new_prop = _build_property(prop_name, prop_value, pos, hide)
+
+    updated = False
+    block = content[sym_start:sym_end]
+    if _has_property(block, prop_name):
+        updated = True
+        # Remove old property
+        old = re.search(
+            rf'\(property "{re.escape(prop_name)}"\s+"[^"]*".*?\)',
+            block, re.DOTALL
+        )
+        if old:
+            block = block[: old.start()] + new_prop + block[old.end() :]
+        else:
+            block = block.rstrip()[:-1] + "\n\t\t\t" + new_prop + "\n\t\t)"
+    else:
+        sub = re.search(r'\n\t\t\t\(symbol "', block)
+        if sub:
+            insert_at = sub.start()
+            block = block[:insert_at] + "\n\t\t\t" + new_prop + block[insert_at:]
+        else:
+            block = block.rstrip()[:-1] + "\n\t\t\t" + new_prop + "\n\t\t)"
+
+    content = content[:sym_start] + block + content[sym_end + 1 :]
+    lib_path.write_text(content, encoding="utf-8")
+
+    action = "Updated" if updated else "Added"
+    return {
+        "success": True,
+        "message": f"Property '{prop_name}' = '{prop_value}' {action.lower()} to '{symbol_name}'",
+        "propertyAdded": prop_name,
+        "propertyValue": prop_value,
+    }

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -349,6 +349,8 @@ try:
     from commands.schematic_hierarchy import SchematicHierarchyCommands
     from commands.symbol_creator import SymbolCreator
     from commands.symbol_pins import SymbolPinCommands
+    from commands.add_library_symbol_property import add_library_symbol_property
+    from commands.add_symbol_property import add_symbol_property
 
     logger.info("Successfully imported all command handlers")
 except ImportError as e:
@@ -532,6 +534,7 @@ class KiCADInterface(SchematicHandlersMixin):
             "batch_add_no_connects": self.batch_commands.batch_add_no_connects,
             "batch_connect": self.batch_commands.batch_connect,
             "batch_add_and_connect": self.batch_commands.batch_add_and_connect,
+            "add_library_symbol_property": add_schematic_symbol_property,
             # JLCPCB API commands (complete parts catalog via API)
             "download_jlcpcb_database": self._handle_download_jlcpcb_database,
             "search_jlcpcb_parts": self._handle_search_jlcpcb_parts,
@@ -637,6 +640,7 @@ class KiCADInterface(SchematicHandlersMixin):
             "delete_symbol": self._handle_delete_symbol,
             "list_symbols_in_library": self._handle_list_symbols_in_library,
             "register_symbol_library": self._handle_register_symbol_library,
+            "add_symbol_property": add_symbol_property,
             # Freerouting autoroute commands
             "autoroute": self.freerouting_commands.autoroute,
             "export_dsn": self.freerouting_commands.export_dsn,

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -2439,6 +2439,57 @@ SCHEMATIC_TOOLS = [
             "required": ["schematicPath"],
         },
     },
+    {
+        "name": "add_library_symbol_property",
+        "title": "Add Property to Schematic Lib Symbol",
+        "description": (
+            "Add or update a custom property (Manufacturer, MPN, LCSC, etc.) on a "
+            "symbol definition in the schematic's lib_symbols section (.kicad_sch). "
+            "Note: changes live in the schematic cache only — they are overwritten by "
+            "update_symbol_from_library. For permanent library-wide changes, use "
+            "add_symbol_property on the .kicad_sym file first, then refresh."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "schematicPath": {"type": "string", "description": "Path to .kicad_sch file"},
+                "libraryName": {"type": "string", "description": "Symbol library nickname"},
+                "symbolName": {"type": "string", "description": "Symbol name"},
+                "propertyName": {"type": "string", "description": "Property name"},
+                "propertyValue": {"type": "string", "description": "Property value"},
+                "position": {
+                    "type": "object",
+                    "properties": {"x": {"type": "number"}, "y": {"type": "number"}},
+                },
+                "hide": {"type": "boolean", "default": False},
+            },
+            "required": ["schematicPath", "libraryName", "symbolName", "propertyName", "propertyValue"],
+        },
+    },
+    {
+        "name": "add_symbol_property",
+        "title": "Add Property to Library Symbol",
+        "description": (
+            "Add or update a custom property on a symbol in a .kicad_sym library file. "
+            "This makes permanent library-wide changes. After adding properties, use "
+            "update_symbol_from_library to refresh schematics that reference the updated symbol."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "libraryPath": {"type": "string", "description": "Path to .kicad_sym file"},
+                "symbolName": {"type": "string", "description": "Symbol name"},
+                "propertyName": {"type": "string", "description": "Property name"},
+                "propertyValue": {"type": "string", "description": "Property value"},
+                "position": {
+                    "type": "object",
+                    "properties": {"x": {"type": "number"}, "y": {"type": "number"}},
+                },
+                "hide": {"type": "boolean", "default": False},
+            },
+            "required": ["libraryPath", "symbolName", "propertyName", "propertyValue"],
+        },
+    },
 ]
 
 # =============================================================================

--- a/src/tools/schematic-batch.ts
+++ b/src/tools/schematic-batch.ts
@@ -64,6 +64,30 @@ export function registerSchematicBatchTools(server: McpServer, callKicadScript: 
     },
   );
 
+  // Add/update a custom property on a lib_symbols definition
+  server.tool(
+    "add_library_symbol_property",
+    "Add or update a custom property (Manufacturer, MPN, LCSC, etc.) on a symbol definition in the lib_symbols section. This makes the property available to all instances of that symbol in the schematic.",
+    {
+      schematicPath: z.string().describe("Path to the .kicad_sch file"),
+      libraryName: z.string().describe("Symbol library nickname (e.g. Device, power)"),
+      symbolName: z.string().describe("Symbol name (e.g. R, C, GND)"),
+      propertyName: z.string().describe("Property name (e.g. Manufacturer, MPN)"),
+      propertyValue: z.string().describe("Property value"),
+      position: z
+        .object({ x: z.number(), y: z.number() })
+        .optional()
+        .describe("Position {x, y} in mm (default: 0, 0)"),
+      hide: z.boolean().optional().describe("Hide the property (default false)"),
+    },
+    async (args: any) => {
+      const r = await callKicadScript("add_library_symbol_property", args);
+      if (r.success === false)
+        return { content: [{ type: "text", text: `Failed: ${r.message || "Unknown error"}` }] };
+      return { content: [{ type: "text", text: r.message }] };
+    },
+  );
+
   // Swap a symbol, preserving position/fields
   server.tool(
     "replace_schematic_component",

--- a/src/tools/symbol-creator.ts
+++ b/src/tools/symbol-creator.ts
@@ -211,4 +211,27 @@ export function registerSymbolCreatorTools(server: McpServer, callKicadScript: F
       };
     },
   );
+
+  // ── add_symbol_property ───────────────────────────────────────────────── //
+  server.tool(
+    "add_symbol_property",
+    "Add or update a custom property (Manufacturer, MPN, LCSC, etc.) on a symbol in a .kicad_sym library file.",
+    {
+      libraryPath: z.string().describe("Path to the .kicad_sym file"),
+      symbolName: z.string().describe("Symbol name"),
+      propertyName: z.string().describe("Property name (e.g. Manufacturer, MPN)"),
+      propertyValue: z.string().describe("Property value"),
+      position: z
+        .object({ x: z.number(), y: z.number() })
+        .optional()
+        .describe("Position {x, y} in mm (default: 0, 0)"),
+      hide: z.boolean().optional().describe("Hide the property (default false)"),
+    },
+    async (args: any) => {
+      const r = await callKicadScript("add_symbol_property", args);
+      if (r.success === false)
+        return { content: [{ type: "text", text: `Failed: ${r.message || "Unknown error"}` }] };
+      return { content: [{ type: "text", text: r.message }] };
+    },
+  );
 }

--- a/tests/test_add_library_symbol_property.py
+++ b/tests/test_add_library_symbol_property.py
@@ -1,0 +1,217 @@
+"""
+Tests for add_library_symbol_property — add custom properties to lib_symbols entries.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.add_library_symbol_property import (  # noqa: E402
+    add_library_symbol_property,
+    _find_symbol_in_lib_symbols,
+    _has_property,
+)
+
+_MINIMAL_SCH = """(kicad_sch
+\t(version 20260306)
+\t(generator "eeschema")
+\t(uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+\t(paper "A4")
+\t(lib_symbols
+\t\t(symbol "Device:R"
+\t\t\t(pin_numbers (hide yes))
+\t\t\t(pin_names (offset 0.254))
+\t\t\t(exclude_from_sim no)
+\t\t\t(in_bom yes)
+\t\t\t(on_board yes)
+\t\t\t(property "Reference" "R" (at 0 2.54 0)
+\t\t\t\t(effects (font (size 1.27 1.27)))
+\t\t\t)
+\t\t\t(property "Value" "R" (at 0 -2.54 0)
+\t\t\t\t(effects (font (size 1.27 1.27)))
+\t\t\t)
+\t\t\t(property "Footprint" "" (at 0 -5.08 0)
+\t\t\t\t(hide yes)
+\t\t\t\t(effects (font (size 1.27 1.27)))
+\t\t\t)
+\t\t\t(symbol "R_1_1"
+\t\t\t\t(pin passive line (at 0 3.81 270) (length 1.27)
+\t\t\t\t\t(name "~" (effects (font (size 1.27 1.27))))
+\t\t\t\t\t(number "1" (effects (font (size 1.27 1.27))))
+\t\t\t\t)
+\t\t\t\t(pin passive line (at 0 -3.81 90) (length 1.27)
+\t\t\t\t\t(name "~" (effects (font (size 1.27 1.27))))
+\t\t\t\t\t(number "2" (effects (font (size 1.27 1.27))))
+\t\t\t\t)
+\t\t\t)
+\t\t\t(embedded_fonts no)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 50.8 50.8 0)
+\t\t(unit 1)
+\t\t(uuid "11111111-2222-3333-4444-555555555555")
+\t\t(property "Reference" "R1" (at 50.8 48.26 0)
+\t\t\t(effects (font (size 1.27 1.27)) (justify left))
+\t\t)
+\t\t(property "Value" "10k" (at 50.8 53.34 0)
+\t\t\t(effects (font (size 1.27 1.27)) (justify left))
+\t\t)
+\t\t(pin "1" (uuid "bbbbbbbb-1111-2222-3333-444444444444"))
+\t\t(pin "2" (uuid "bbbbbbbb-5555-6666-7777-888888888888"))
+\t\t(instances
+\t\t\t(project "test" (path "/aaa" (reference "R1") (unit 1)))
+\t\t)
+\t)
+\t(sheet_instances (path "/" (page "1")))
+)
+"""
+
+
+class TestFindSymbolInLibSymbols:
+    def test_finds_existing_symbol(self):
+        start, end, block = _find_symbol_in_lib_symbols(_MINIMAL_SCH, "Device", "R")
+        assert start >= 0
+        assert end > start
+        assert '(symbol "Device:R"' in block
+
+    def test_returns_none_for_missing_symbol(self):
+        assert _find_symbol_in_lib_symbols(_MINIMAL_SCH, "Device", "C") is None
+
+    def test_returns_none_for_wrong_library(self):
+        assert _find_symbol_in_lib_symbols(_MINIMAL_SCH, "power", "GND") is None
+
+
+class TestHasProperty:
+    def test_detects_existing_property(self):
+        _, _, block = _find_symbol_in_lib_symbols(_MINIMAL_SCH, "Device", "R")
+        assert _has_property(block, "Reference") is True
+        assert _has_property(block, "Footprint") is True
+
+    def test_detects_missing_property(self):
+        _, _, block = _find_symbol_in_lib_symbols(_MINIMAL_SCH, "Device", "R")
+        assert _has_property(block, "Manufacturer") is False
+
+
+class TestAddLibrarySymbolProperty:
+    def test_adds_new_property(self, tmp_path):
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text(_MINIMAL_SCH, encoding="utf-8")
+
+        result = add_library_symbol_property({
+            "schematicPath": str(sch),
+            "libraryName": "Device",
+            "symbolName": "R",
+            "propertyName": "Manufacturer",
+            "propertyValue": "YAGEO",
+        })
+
+        assert result["success"] is True
+        assert "Manufacturer" in result["message"]
+
+        updated = sch.read_text(encoding="utf-8")
+        assert 'property "Manufacturer" "YAGEO"' in updated
+        assert '(reference "R1")' in updated
+
+    def test_adds_property_at_position(self, tmp_path):
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text(_MINIMAL_SCH, encoding="utf-8")
+
+        result = add_library_symbol_property({
+            "schematicPath": str(sch),
+            "libraryName": "Device",
+            "symbolName": "R",
+            "propertyName": "MPN",
+            "propertyValue": "CRCW040210K0",
+            "position": {"x": 0, "y": -7.62},
+        })
+
+        assert result["success"] is True
+        updated = sch.read_text(encoding="utf-8")
+        assert '(at 0 -7.62 0)' in updated
+
+    def test_updates_existing_property(self, tmp_path):
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text(_MINIMAL_SCH, encoding="utf-8")
+
+        result = add_library_symbol_property({
+            "schematicPath": str(sch),
+            "libraryName": "Device",
+            "symbolName": "R",
+            "propertyName": "Reference",
+            "propertyValue": "RR",
+        })
+
+        assert result["success"] is True
+        updated = sch.read_text(encoding="utf-8")
+        assert 'property "Reference" "RR"' in updated
+
+    def test_adds_hidden_property(self, tmp_path):
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text(_MINIMAL_SCH, encoding="utf-8")
+
+        result = add_library_symbol_property({
+            "schematicPath": str(sch),
+            "libraryName": "Device",
+            "symbolName": "R",
+            "propertyName": "ki_description",
+            "propertyValue": "Test resistor",
+            "hide": True,
+        })
+
+        assert result["success"] is True
+        updated = sch.read_text(encoding="utf-8")
+        assert 'property "ki_description" "Test resistor"' in updated
+        assert "(hide yes)" in updated
+
+    def test_fails_for_missing_symbol(self, tmp_path):
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text(_MINIMAL_SCH, encoding="utf-8")
+
+        result = add_library_symbol_property({
+            "schematicPath": str(sch),
+            "libraryName": "Device",
+            "symbolName": "C",
+            "propertyName": "Foo",
+            "propertyValue": "Bar",
+        })
+
+        assert result["success"] is False
+        assert "not found" in result["message"].lower()
+
+    def test_fails_for_missing_lib_symbols(self, tmp_path):
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text("(kicad_sch (version 20260306))", encoding="utf-8")
+
+        result = add_library_symbol_property({
+            "schematicPath": str(sch),
+            "libraryName": "Device",
+            "symbolName": "R",
+            "propertyName": "Foo",
+            "propertyValue": "Bar",
+        })
+
+        assert result["success"] is False
+
+    def test_preserves_instances_after_add(self, tmp_path):
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text(_MINIMAL_SCH, encoding="utf-8")
+
+        add_library_symbol_property({
+            "schematicPath": str(sch),
+            "libraryName": "Device",
+            "symbolName": "R",
+            "propertyName": "Manufacturer",
+            "propertyValue": "YAGEO",
+        })
+
+        updated = sch.read_text(encoding="utf-8")
+        assert "bbbbbbbb-1111-2222-3333-444444444444" in updated
+        assert "bbbbbbbb-5555-6666-7777-888888888888" in updated
+        assert '(reference "R1")' in updated
+        assert "(instances" in updated

--- a/tests/test_add_symbol_property.py
+++ b/tests/test_add_symbol_property.py
@@ -1,0 +1,76 @@
+"""Tests for add_symbol_property — add custom properties to .kicad_sym library files."""
+import sys
+from pathlib import Path
+import pytest
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+from commands.add_symbol_property import add_symbol_property, _has_property, _find_symbol_in_lib
+
+LIB = """(kicad_symbol_lib (version 20231120) (generator "test")
+  (symbol "R" (pin_names hide) (in_bom yes) (on_board yes)
+    (property "Reference" "R" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "R" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (symbol "R_0_1" (pin "1" passive (at 0 2.54 0)))
+    (symbol "R_1_1" (pin "2" passive (at 0 -2.54 0))))
+  (symbol "C" (pin_names hide) (in_bom yes) (on_board yes)
+    (property "Reference" "C" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "C" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Manufacturer" "TDK" (at 0 0 0) (hide yes) (effects (font (size 1.27 1.27))))
+    (symbol "C_0_1" (pin "1" passive (at 0 2.54 0)))
+    (symbol "C_1_1" (pin "2" passive (at 0 -2.54 0))))
+)
+"""
+
+@pytest.fixture
+def tmp_lib(tmp_path):
+    p = tmp_path / "test.kicad_sym"
+    p.write_text(LIB, encoding="utf-8")
+    return str(p)
+
+def test_add_new_property(tmp_lib):
+    r = add_symbol_property({"libraryPath": tmp_lib, "symbolName": "R", "propertyName": "Manufacturer", "propertyValue": "YAGEO", "hide": True})
+    assert r["success"]
+    assert "added" in r["message"].lower()
+    assert "YAGEO" in Path(tmp_lib).read_text(encoding="utf-8")
+
+def test_replace_existing(tmp_lib):
+    r = add_symbol_property({"libraryPath": tmp_lib, "symbolName": "C", "propertyName": "Manufacturer", "propertyValue": "Murata"})
+    assert r["success"]
+    assert "updated" in r["message"].lower()
+    c = Path(tmp_lib).read_text(encoding="utf-8")
+    assert "Murata" in c
+    assert "TDK" not in c
+
+def test_symbol_not_found(tmp_lib):
+    r = add_symbol_property({"libraryPath": tmp_lib, "symbolName": "L", "propertyName": "Manufacturer", "propertyValue": "test"})
+    assert not r["success"]
+
+def test_library_not_found():
+    r = add_symbol_property({"libraryPath": "/no/such/file", "symbolName": "R", "propertyName": "M", "propertyValue": "x"})
+    assert not r["success"]
+
+def test_sub_symbol_not_matched(tmp_lib):
+    c = Path(tmp_lib).read_text(encoding="utf-8")
+    m = _find_symbol_in_lib(c, "C")
+    assert m is not None
+    b = c[m[0]:m[1]]
+    assert "Reference" in b
+    assert "symbol \"C_0_1\"" in b
+    assert m[0] < c.find('symbol "C_0_1"')
+
+def test_has_property_true(tmp_lib):
+    c = Path(tmp_lib).read_text(encoding="utf-8")
+    m = _find_symbol_in_lib(c, "C")
+    assert _has_property(c[m[0]:m[1]], "Manufacturer")
+
+def test_has_property_false(tmp_lib):
+    c = Path(tmp_lib).read_text(encoding="utf-8")
+    m = _find_symbol_in_lib(c, "R")
+    assert not _has_property(c[m[0]:m[1]], "Manufacturer")
+
+def test_has_property_partial(tmp_lib):
+    c = Path(tmp_lib).read_text(encoding="utf-8")
+    m = _find_symbol_in_lib(c, "C")
+    assert not _has_property(c[m[0]:m[1]], "Man")
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Two new MCP tools for adding/updating custom properties on symbols:

### `add_library_symbol_property` — for `.kicad_sch` schematics
Add or update a custom property (Manufacturer, MPN, LCSC, etc.) on a symbol definition in the `lib_symbols` section of a schematic. Makes the property available to all instances of that symbol.

- Uses text surgery + `prettify()` for canonical KiCad formatting
- Preserves placed instances (pin UUIDs, references)
- 12 tests

### `add_symbol_property` — for `.kicad_sym` library files
Add or update a custom property directly on a symbol in a .kicad_sym library file. Useful for batch-adding fields (Manufacturer, Supplier, JLCPCB Part #, etc.) to library symbols.

### Files changed
- `python/commands/add_schematic_symbol_property.py` — schematic tool
- `python/commands/add_library_symbol_property.py` — library tool
- `python/kicad_interface.py` — command routing + imports
- `python/schemas/tool_schemas.py` — MCP schemas
- `src/tools/schematic-batch.ts` — TS registration (schematic)
- `src/tools/symbol-creator.ts` — TS registration (library)
- `tests/test_add_schematic_symbol_property.py` — 12 tests