### PR TITLE
fix: restore sys.modules state leaked by test_rotate_schematic_mirror.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **Fixed a test-suite state leak that caused spurious pin-position failures
+  when test files ran in combination** (#287): `tests/test_rotate_schematic_mirror.py`
+  installed a throwaway `MagicMock` at `sys.modules["commands.pin_locator"]`
+  via `sys.modules.setdefault(...)` at module-collection time, with no
+  teardown. Any later-collected file relying on the real
+  `commands.pin_locator` (e.g. `WireDragger.get_pin_defs`, via
+  `commands.wire_dragger`) silently got empty pin data instead of an error —
+  iterating a bare `MagicMock()` is a no-op by default. A `teardown_module`
+  now undoes the stub, and `test_rotate_handler_no_crash`'s stubbed
+  `kicad_interface.py` exec additionally evicts any `commands.*` submodule it
+  imported for the first time while `pcbnew`/`skip` were mocked, so later
+  tests get a clean re-import instead of a module bound to a discarded mock.
+  Test-only change; no production code touched.
+
 - **`import_ses` no longer creates phantom slashless nets — routed tracks bind
   to the real board nets** (#246): KiCad global-label nets are named with a
   leading `/` (e.g. `/GND`), but a Specctra DSN round-trip through Freerouting
@@ -155,7 +169,7 @@ load on every KiCad 10.0.x build.
   dynamic loader (and the legacy fallback was removed in #288), so the seeds only
   leaked into user files. Both tools now copy a new blank KiCad 10 template
   (`python/templates/blank.kicad_sch`: `(version 20260101) (generator
-  "eeschema")`, empty `lib_symbols`, no placed symbols).
+"eeschema")`, empty `lib_symbols`, no placed symbols).
   `template_with_symbols.kicad_sch` is kept unchanged in-repo as a test fixture.
   A regression test asserts a created schematic contains no `_TEMPLATE_`
   references and no seeded `lib_symbols` entries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,7 +187,7 @@ load on every KiCad 10.0.x build.
   dynamic loader (and the legacy fallback was removed in #288), so the seeds only
   leaked into user files. Both tools now copy a new blank KiCad 10 template
   (`python/templates/blank.kicad_sch`: `(version 20260101) (generator
-"eeschema")`, empty `lib_symbols`, no placed symbols).
+  "eeschema")`, empty `lib_symbols`, no placed symbols).
   `template_with_symbols.kicad_sch` is kept unchanged in-repo as a test fixture.
   A regression test asserts a created schematic contains no `_TEMPLATE_`
   references and no seeded `lib_symbols` entries.

--- a/tests/test_pin_locator_module_leak.py
+++ b/tests/test_pin_locator_module_leak.py
@@ -1,0 +1,52 @@
+"""Regression test for issue #287: cross-file sys.modules pollution.
+
+``tests/test_rotate_schematic_mirror.py`` used to install a throwaway
+``MagicMock`` at ``sys.modules["commands.pin_locator"]`` via
+``sys.modules.setdefault(...)`` at module-collection time, with no teardown.
+Any later-collected file relying on the real ``commands.pin_locator`` (e.g.
+``WireDragger.get_pin_defs``, via ``commands.wire_dragger``) silently got
+empty pin data instead of an error: iterating a bare ``MagicMock()`` is a
+no-op by default (``MagicMock.__iter__`` returns ``iter([])``), so
+``WireDragger.compute_pin_positions`` returned ``{}`` instead of raising.
+
+The leak only manifests across a real pytest collection/run boundary (a
+module-level side effect in one file affecting a later-collected file), so it
+can't be reproduced by importing modules directly in-process — this runs
+pytest as a subprocess against the exact repro from the issue, trimmed to the
+fast (no live ``KiCADInterface``) subset so the regression test itself stays
+quick.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).parent
+
+
+@pytest.mark.slow
+def test_rotate_mirror_then_compute_pin_positions_no_state_leak():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(TESTS_DIR / "test_rotate_schematic_mirror.py"),
+            str(TESTS_DIR / "test_move_with_wire_preservation.py") + "::TestComputePinPositions",
+            "-q",
+            "--no-cov",
+            "--timeout=60",
+            "--timeout-method=thread",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+    assert result.returncode == 0, (
+        "Collecting test_rotate_schematic_mirror.py before "
+        "test_move_with_wire_preservation.py::TestComputePinPositions must not "
+        "leak sys.modules state across files (#287).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/tests/test_pin_locator_module_leak.py
+++ b/tests/test_pin_locator_module_leak.py
@@ -37,11 +37,12 @@ def test_rotate_mirror_then_compute_pin_positions_no_state_leak():
             str(TESTS_DIR / "test_move_with_wire_preservation.py") + "::TestComputePinPositions",
             "-q",
             "--no-cov",
-            "--timeout=60",
-            "--timeout-method=thread",
         ],
         capture_output=True,
         text=True,
+        # Hang protection lives here rather than in pytest-timeout flags:
+        # the plugin is not a declared dependency of this repo, and passing
+        # --timeout to a pytest without it is a usage error (exit code 4).
         timeout=90,
     )
     assert result.returncode == 0, (

--- a/tests/test_rotate_schematic_mirror.py
+++ b/tests/test_rotate_schematic_mirror.py
@@ -30,10 +30,23 @@ _wd_mod = importlib.util.module_from_spec(_wd_spec)
 # We stub only the submodule, not the parent package, so that
 # kicad_interface can still import commands.board etc. from disk.
 _pin_locator_mock = MagicMock()
+_had_real_pin_locator = "commands.pin_locator" in sys.modules
 sys.modules.setdefault("commands.pin_locator", _pin_locator_mock)
 
 _wd_spec.loader.exec_module(_wd_mod)
 WireDragger = _wd_mod.WireDragger
+
+
+def teardown_module(module: object) -> None:
+    """Undo the module-level ``commands.pin_locator`` stub above.
+
+    Without this, ``setdefault`` leaves the throwaway mock installed for the
+    rest of the pytest process: every later-collected file that imports the
+    real ``commands.pin_locator`` (e.g. via ``WireDragger.get_pin_defs``) gets
+    this mock instead, silently returning empty pin data (#287).
+    """
+    if not _had_real_pin_locator and sys.modules.get("commands.pin_locator") is _pin_locator_mock:
+        del sys.modules["commands.pin_locator"]
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +219,7 @@ def test_rotate_handler_no_crash(tmp_path):
         "annotations",
     )
     _saved_modules = {n: sys.modules.get(n) for n in _stub_modnames}
+    _modules_before = set(sys.modules)
     try:
         for modname in _stub_modnames:
             sys.modules[modname] = MagicMock()
@@ -230,6 +244,22 @@ def test_rotate_handler_no_crash(tmp_path):
                 sys.modules.pop(modname, None)
             else:
                 sys.modules[modname] = mod
+
+        # kicad_interface.py eagerly imports ~20 commands.* submodules, several
+        # of which do `from skip import Schematic` / `import pcbnew` at their
+        # own module level. Any of those imported here for the first time in
+        # the whole session captured a reference to *this test's* throwaway
+        # mocks — restoring sys.modules["skip"]/["pcbnew"] above doesn't fix
+        # that, since the submodule already bound its own name to the mock at
+        # import time. Evict any such newly-added commands.* submodule so a
+        # later, unstubbed import re-executes it against the real/conftest
+        # modules instead of silently keeping the stale mock reference (#287).
+        # Scoped to "commands." specifically: third-party/stdlib modules
+        # pulled in as a side effect (e.g. PIL's C extension) are not
+        # safely re-importable and must be left alone.
+        for modname in set(sys.modules) - _modules_before:
+            if modname.startswith("commands."):
+                sys.modules.pop(modname, None)
 
     # Write a minimal schematic file
     sch_path = str(tmp_path / "test.kicad_sch")


### PR DESCRIPTION
## Summary

Fixes #287. Reproduced exactly as reported:

```
pytest tests/test_rotate_schematic_mirror.py tests/test_move_with_wire_preservation.py
```
→ `6 failed, 44 passed` (matches the issue's own count for this file pair).

## Root cause

`tests/test_rotate_schematic_mirror.py` installs a private, unshared copy of
`wire_dragger.py` under the module name `"wire_dragger"` at **collection
time** (before any test runs), and — to keep that private copy's lazy
`from commands.pin_locator import PinLocator` (inside `get_pin_defs`) from
touching the real module — does:

```python
_pin_locator_mock = MagicMock()
sys.modules.setdefault("commands.pin_locator", _pin_locator_mock)
```

`setdefault` never gets undone. Once installed, it stays for the rest of the
pytest process. Any *later-collected* file that imports the real
`commands.pin_locator` — e.g. `test_move_with_wire_preservation.py`, via
`commands.wire_dragger.WireDragger.get_pin_defs` — gets this throwaway mock
instead. `PinLocator.parse_symbol_definition(...)` becomes a `MagicMock()`
call, and iterating the result (`for pin_num, pin in pins.items():`) is a
silent no-op — `MagicMock.__iter__` defaults to `iter([])` — so
`compute_pin_positions` returns `{}` instead of raising, which is exactly the
failure signature reported (`assert "1" in positions` against an empty dict).

A second, related leak exists in the same file's `test_rotate_handler_no_crash`:
it stubs `sys.modules["pcbnew"]`/`["skip"]`/etc. with *fresh* throwaway mocks,
`exec_module`s a private copy of `kicad_interface.py` (which eagerly imports
~20 `commands.*` submodules — several do `from skip import Schematic` /
`import pcbnew` at their own module level), then only restores the
*top-level* `sys.modules` entries in its `finally`. Any submodule imported
for the first time during that window keeps its own already-bound reference
to the discarded mock — restoring `sys.modules["skip"]` afterward doesn't
retroactively fix a submodule that already did `from skip import Schematic`
against it. This is the same class of bug and is plausibly what causes the
14 `test_pin_world_xy_eeschema_truth.py` oracle failures the original report
also lists (`SchematicManager`/`ComponentManager` both do
`from skip import Schematic` at module level) — see Verification note below.

## Fix (`tests/test_rotate_schematic_mirror.py` only — no production code touched)

- Added `teardown_module`, which undoes the `commands.pin_locator`
  `setdefault` once this file's own tests are done (only if it's still our
  mock instance, and only if nothing was there before).
- In `test_rotate_handler_no_crash`, track `sys.modules` before the stubbed
  `exec_module` call; in `finally`, evict any **`commands.*`** submodule that
  got newly added during that window, so a later, unstubbed import
  re-executes it cleanly. Scoped specifically to `commands.*` — an earlier
  version of this fix evicted *everything* new and broke re-importing PIL's
  C extension (`cannot import name '_imaging' from 'PIL'`), so third-party/
  stdlib modules pulled in as a side effect are left alone.

## Tests

`tests/test_pin_locator_module_leak.py` (new): runs pytest as a subprocess
against `test_rotate_schematic_mirror.py` + the fast, non-`KiCADInterface`
subset of `test_move_with_wire_preservation.py`
(`TestComputePinPositions`), asserting a clean pass. This is a cross-file
collection-order bug, so it can't be reproduced by importing modules
directly in-process — confirmed this test fails (reproducing both
`TestComputePinPositions` failures) when the fix is reverted, and passes
with it restored.

Manually reproduced and fixed the full reported combination:
`tests/test_rotate_schematic_mirror.py tests/test_move_with_wire_preservation.py`
→ was `6 failed, 44 passed`, now `50 passed`.

## Verification note

The issue's other reported symptom — 14 failures in
`test_pin_world_xy_eeschema_truth.py` — could not be re-verified on this
machine: that file's own gating (`shutil.which("kicad-cli")` plus a
hardcoded `/usr/share/kicad/symbols/Device.kicad_sym` check) always skips
here (no such path exists on Windows), so its test bodies never execute
regardless of this fix. The second leak this PR also closes (the
`test_rotate_handler_no_crash` submodule eviction) targets the same
`from skip import Schematic`-at-module-level pattern that
`commands.schematic`/`commands.component_schematic` share — the modules
those 14 oracle tests depend on via `SchematicManager`/`ComponentManager` —
so the fix should cover that failure mode too, but I can't directly confirm
it on this machine. If you can retest the original 4-file reproduction where
`kicad-cli` + the `Device` library are available, that would close the loop.
