### PR TITLE
fix: prevent CHANGELOG.md inline code spans from crossing line breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,8 +228,8 @@ load on every KiCad 10.0.x build.
   `add_schematic_component` tool synthesizes its own `lib_symbols` via the
   dynamic loader (and the legacy fallback was removed in #288), so the seeds only
   leaked into user files. Both tools now copy a new blank KiCad 10 template
-  (`python/templates/blank.kicad_sch`: `(version 20260101) (generator
-  "eeschema")`, empty `lib_symbols`, no placed symbols).
+  (`python/templates/blank.kicad_sch`: `(version 20260101) (generator "eeschema")`,
+  empty `lib_symbols`, no placed symbols).
   `template_with_symbols.kicad_sch` is kept unchanged in-repo as a test fixture.
   A regression test asserts a created schematic contains no `_TEMPLATE_`
   references and no seeded `lib_symbols` entries.
@@ -407,8 +407,8 @@ the KiCad GUI connects later (reopen the project to adopt IPC).
 - **Fallback schematic writer emits the KiCad 10 header** (#221, partial): the
   template-missing fallback in `create_schematic` and `create_project` wrote the
   stale KiCad 9 header `(version 20250114) (generator "KiCAD-MCP-Server")`. It
-  now writes `(version 20260306) (generator "eeschema") (generator_version
-"10.0")`, matching what eeschema writes for a new file. This covers only the
+  now writes `(version 20260306) (generator "eeschema") (generator_version "10.0")`,
+  matching what eeschema writes for a new file. This covers only the
   fallback path; the main templates (which still carry the KiCad 9 version and
   the `_TEMPLATE_*` clone-source instances used by `add_schematic_component`)
   are tracked separately because rewriting them touches the component-cloning
@@ -534,9 +534,7 @@ the KiCad GUI connects later (reopen the project to adopt IPC).
   _would_ be made without modifying the board — useful for previewing
   before committing.
 
-  Returns `{ placed: [{x, y, unit}, ...], summary: {placed_count,
-candidates_evaluated, skipped_by_zone_membership,
-skipped_by_collision, ...} }`.
+  Returns `{ placed: [{x, y, unit}, ...], summary: {placed_count, candidates_evaluated, skipped_by_zone_membership, skipped_by_collision, ...} }`.
 
   Approach ported from
   [morningfire-pcb-automation](https://github.com/NiNjA-CodE/morningfire-pcb-automation)

--- a/tests/test_changelog_no_multiline_code_spans.py
+++ b/tests/test_changelog_no_multiline_code_spans.py
@@ -1,0 +1,49 @@
+"""Regression guard: CHANGELOG.md must not contain an inline code span that
+straddles a line break.
+
+An inline code span like `` `(version 1) (generator\n"eeschema")` `` (opening
+backtick on one line, closing backtick on the next) trips prettier's markdown
+list-continuation indentation logic: every time CHANGELOG.md is reformatted —
+which happens on essentially every PR that touches it, since the pre-commit
+hook runs prettier on the whole file — the line starting mid-span loses its
+leading indentation. This was found live on three separate entries (confirmed
+reproducible: copy a known-good CHANGELOG.md, add any unrelated new entry
+above the affected paragraph, run prettier, and the affected line's
+indentation drops), two of which a maintainer had to manually fix during
+review before this was traced to a root cause.
+
+The fix is never to let an inline code span cross a line break — keep the
+whole span on one physical line, wrapping (if needed) at a point outside it.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+CHANGELOG = Path(__file__).parent.parent / "CHANGELOG.md"
+
+
+@pytest.mark.unit
+def test_changelog_has_no_multiline_inline_code_spans():
+    lines = CHANGELOG.read_text(encoding="utf-8").splitlines()
+
+    open_span_from: Optional[int] = None
+    offenders = []
+    for lineno, line in enumerate(lines, start=1):
+        if line.strip().startswith("```"):
+            continue  # fenced code blocks are exempt; only inline `code` spans are unsafe
+        if open_span_from is not None:
+            offenders.append((open_span_from, lineno))
+            open_span_from = None
+        if line.count("`") % 2 == 1:
+            open_span_from = lineno
+
+    assert offenders == [], (
+        "CHANGELOG.md has an inline code span that crosses a line break "
+        "(opens on one line, closes on the next), which prettier's markdown "
+        "formatter mis-indents on the very next reformat: "
+        + ", ".join(f"lines {a}-{b}" for a, b in offenders)
+        + ". Rewrite so the whole `code span` stays on one physical line "
+        "(wrap at a point outside the backticks if the line is long)."
+    )

--- a/tests/test_changelog_no_multiline_code_spans.py
+++ b/tests/test_changelog_no_multiline_code_spans.py
@@ -30,9 +30,16 @@ def test_changelog_has_no_multiline_inline_code_spans():
 
     open_span_from: Optional[int] = None
     offenders = []
+    in_fence = False
     for lineno, line in enumerate(lines, start=1):
         if line.strip().startswith("```"):
-            continue  # fenced code blocks are exempt; only inline `code` spans are unsafe
+            # Fenced code blocks are exempt; only inline `code` spans are
+            # unsafe. Track the fence STATE, not just the fence lines — a
+            # lone backtick in fenced content must not count as an open span.
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
         if open_span_from is not None:
             offenders.append((open_span_from, lineno))
             open_span_from = None


### PR DESCRIPTION
## Summary

Root-cause fix for a formatting issue @mixelpixx flagged twice (once on #310,
once on #312): a CHANGELOG entry kept losing 2 spaces of indentation every
time it got reformatted, and had to be manually restored on both merges.

Traced it: the affected lines all had an **inline code span that crosses a
line break** — e.g. `` `(version 1) (generator\n"eeschema")` `` (opening
backtick on one line, closing backtick on the next). Prettier's markdown
list-continuation indentation logic mis-handles the line that starts mid-span,
dropping its leading indentation. Confirmed reproducible: take a known-good
CHANGELOG.md, add *any* unrelated new entry above the affected paragraph, run
`prettier --write`, and the affected line loses its indent — every time.

This isn't a one-off. A full scan of the file found **three** live instances
of the same pattern, two of which are already broken on `main` right now (not
just the one that got caught in review):

1. The `#221` blank-template entry (the one caught twice already)
2. The `#221, partial` fallback-header entry (`generator_version "10.0"`) —
   currently broken on `main`
3. The `add_gnd_stitching_vias` entry's `Returns \`{ placed: ... }\`` line —
   currently broken on `main`

## Fix

All three: keep the inline code span on one physical line, wrapping (if
needed) at a point *outside* the backticks instead of inside them. Verified
each is now stable — ran `prettier --write` twice in a row on the result,
zero further changes both times (true idempotency, not just "looks right
once").

## Regression test

`tests/test_changelog_no_multiline_code_spans.py`: scans CHANGELOG.md for any
inline code span (odd backtick count on a line, continuing into the next
non-fenced-code-block line) and fails with the exact line range if found.
Confirmed it fails on the original (broken) content and passes after the fix,
by temporarily reverting one instance and re-running.

## Verification

Full suite not needed — this only touches CHANGELOG.md and adds one new,
self-contained static test. Ran the new test standalone (pass), plus
`prettier --write` against the real file twice (no changes either time).
