### PR TITLE
fix(schematic): escape quotes in property values — corrupts .kicad_sch (likely the KiCad 10 corruption in the README)

### DIFF
--- a/python/commands/board/view.py
+++ b/python/commands/board/view.py
@@ -170,7 +170,15 @@ class BoardViewCommands:
                     "message": f"Unsupported format '{fmt}'. Use 'png', 'jpg', or 'svg'.",
                     "errorDetails": f"Got: {fmt}",
                 }
-            layers: List[str] = params.get("layers", [])
+            # KiCad 10 rejects `pcb export svg` without --layers ("at least one
+            # layer must be specified"), so an omitted layers list must not stay
+            # empty. Default to the layers that make a board readable at a glance.
+            layers: List[str] = params.get("layers") or [
+                "F.Cu",
+                "B.Cu",
+                "F.SilkS",
+                "Edge.Cuts",
+            ]
             response_mode = params.get("responseMode", "inline")
 
             kicad_cli = resolve_kicad_cli()

--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -41,6 +41,16 @@ _SYMBOL_DIR_ENV_VARS = (
 )
 
 
+def _esc_sexpr(value: str) -> str:
+    """Escape a string for safe insertion into an S-expression double-quoted token.
+
+    Library property values may themselves contain quotes — power:GND's Description
+    is `Power symbol creates a global label with name "GND"`. Emitted raw, the inner
+    quote closes the token early and corrupts the rest of the .kicad_sch.
+    """
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _symbol_dir_env_fingerprint() -> Tuple:
     """The env-var inputs library discovery depends on.
 
@@ -1009,7 +1019,7 @@ class DynamicSymbolLoader:
             """
             hide_line = "      (hide yes)\n" if hide else ""
             return (
-                f'    (property "{name}" "{value}"\n'
+                f'    (property "{_esc_sexpr(name)}" "{_esc_sexpr(value)}"\n'
                 f"      (at {_fmt(px)} {_fmt(py)} {_fmt(pa)})\n"
                 f"{hide_line}"
                 f"      (show_name no)\n"


### PR DESCRIPTION
Placing any symbol whose library property value contains a double quote writes an unparseable schematic. `power:GND` is the common case — its `Description` is:

```
Power symbol creates a global label with name "GND"
```

`_property()` in `dynamic_symbol_loader.py` interpolates the value straight into the S-expression, so that inner quote closes the token early and swallows the rest of the file. KiCad and `kicad-cli` then refuse the schematic outright, with unbalanced parens.

**Repro:** `add_schematic_component` with `power:GND`, then `kicad-cli sch export svg` → *"Failed to load schematic file"*.

This may well be the root cause behind the schematic corruption on KiCad 10 that the README warns about — it needs no exotic setup, just a GND symbol, which nearly every real schematic has.

The fix escapes backslashes and quotes before emitting. The codebase already has the correct helper (`SchematicHandlers._escape_sexpr_string`); this path simply never called it. Verified on KiCad 10.0.4: a schematic with `power:GND` that previously failed to load now exports cleanly.

**Also included:** `get_board_2d_view` failed for every caller that omitted `layers`, because KiCad 10 requires `--layers` on `pcb export svg` ("at least one layer must be specified") but the flag was only passed when the list was non-empty. Defaults to `F.Cu, B.Cu, F.SilkS, Edge.Cuts` so the no-argument call renders a readable board.

Happy to split these into two PRs if you prefer.