### PR TITLE
feat(jlcpcb): real-time part lookup via Open Platform API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# JLCPCB Open Platform API credentials (for real-time get_jlcpcb_part lookup).
+#
+# Copy this file to `.env` in the project root and fill in your own values.
+# `.env` is gitignored — never commit real credentials.
+#
+# Obtain these from your JLCPCB account: Account -> API Management -> create key.
+# Without them, get_jlcpcb_part transparently uses the local snapshot database
+# (populated via download_jlcpcb_database); search is always local.
+
+JLCPCB_APP_ID=your_app_id
+JLCPCB_API_KEY=your_access_key
+JLCPCB_API_SECRET=your_secret_key

--- a/docs/JLCPCB_INTEGRATION.md
+++ b/docs/JLCPCB_INTEGRATION.md
@@ -4,16 +4,64 @@
 
 The KiCAD MCP Server integrates with JLCPCB's parts library to provide intelligent component selection, cost optimization, and automated part sourcing for PCB assembly.
 
-**Current Implementation**: Uses the **JLCSearch public API** (by tscircuit) for free, unauthenticated access to JLCPCB's ~100k parts catalog.
+**Current implementation — two backends, by design:**
+
+- **Search is local.** `search_jlcpcb_parts` queries a local SQLite snapshot that
+  you populate once with `download_jlcpcb_database` (the default `cdfer` source is a
+  ~600k in-stock subset). The JLCPCB Open Platform API has **no keyword/parametric
+  search endpoint**, so search must stay local.
+- **Single-part lookup is real-time.** `get_jlcpcb_part` prefers the **JLCPCB Open
+  Platform** `getComponentDetailByCode` endpoint (`https://open.jlcpcb.com`) for live
+  stock and tiered pricing when credentials are configured, and transparently falls
+  back to the local snapshot otherwise. The response's `source` field reports which
+  backend answered (`"live-api"` vs `"local-db"`).
+
+Why the split matters: the local snapshot mirror can lag JLCPCB by weeks, so its
+stock/price for a specific part may be stale — real-time lookup exists to close that
+gap for the part you actually care about.
 
 ## Features
 
-✅ **Parametric Search** - Find components by specifications (resistance, capacitance, package, etc.)
+✅ **Parametric Search** - Find components by specifications (resistance, capacitance, package, etc.) against the local snapshot
+✅ **Real-time Lookup** - Live stock + tiered pricing for a specific LCSC part via the Open Platform API (with local fallback)
 ✅ **Price Comparison** - Compare Basic vs Extended library pricing
 ✅ **Alternative Suggestions** - Find cheaper or higher-stock alternatives
 ✅ **Footprint Mapping** - Automatic JLCPCB package to KiCad footprint mapping
-✅ **Stock Availability** - Real-time stock levels from JLCPCB
-✅ **No Authentication Required** - Public API, no API keys needed
+
+## Real-time part lookup (Open Platform API)
+
+`get_jlcpcb_part` performs a **real-time** lookup when JLCPCB Open Platform
+credentials are configured, and falls back to the local snapshot otherwise.
+
+- **Endpoint:** `POST https://open.jlcpcb.com/overseas/openapi/component/getComponentDetailByCode`
+  with JSON body `{"componentCodes": ["C25804", ...]}` (batched up to 1000 codes per
+  call). Returns live `stockCount`, tiered `priceRanges`, `parameters`, `datasheetUrl`
+  and `libraryType` (base → Basic, expand → Extended).
+- **Auth:** JOP / HMAC-SHA256 (`Authorization: JOP appid=...,accesskey=...,nonce=...,timestamp=...,signature=...`).
+  The signed body must be byte-identical to the wire body, so the request is sent as
+  a raw JSON string.
+- **No server-side search:** the Open Platform only exposes detail-by-code and a
+  full library dump (`getComponentLibraryList`, `{componentCode, componentModel,
+  componentSpecification}` only) — there is no keyword/parametric search, which is
+  why `search_jlcpcb_parts` stays local.
+- **`source` field:** every `get_jlcpcb_part` result includes `source` — `"live-api"`
+  when the Open Platform answered, `"local-db"` when the snapshot did.
+- **Manufacturer:** the detail response omits `manufacturer`; it is backfilled from
+  the local snapshot row when available.
+
+### Configuring credentials (`.env`)
+
+Create a `.env` file in the project root (it is gitignored — see `.env.example`):
+
+```
+JLCPCB_APP_ID=your_app_id
+JLCPCB_API_KEY=your_access_key
+JLCPCB_API_SECRET=your_secret_key
+```
+
+The server auto-loads this `.env` on first use of the JLCPCB client (non-destructively —
+it never overrides a variable already present in the environment). Without credentials,
+`get_jlcpcb_part` silently uses the local snapshot.
 
 ## Quick Start
 
@@ -339,29 +387,27 @@ JLCSearch may not have all fields that official JLCPCB API provides:
 
 Stock levels are updated periodically but may lag real-time JLCPCB data by a few hours.
 
-## Official JLCPCB API (Alternative)
+## JLCPCB Open Platform API (real-time lookup)
 
-The project also includes an implementation of the official JLCPCB API with HMAC-SHA256 authentication. However, this requires:
-
-1. API approval from JLCPCB (not all applications are approved)
-2. APP_ID, ACCESS_KEY, and SECRET_KEY credentials
-3. Previous order history with JLCPCB
-
-To use the official API instead of JLCSearch:
+`get_jlcpcb_part` uses the JLCPCB **Open Platform** (`https://open.jlcpcb.com`) with
+HMAC-SHA256 (JOP) authentication for real-time single-part detail. This requires
+APP_ID, ACCESS_KEY and SECRET_KEY credentials from your JLCPCB account (see
+"Configuring credentials" above). The client:
 
 ```python
 from commands.jlcpcb import JLCPCBClient
 
-# Set credentials in .env file:
-# JLCPCB_APP_ID=<your_app_id>
-# JLCPCB_API_KEY=<your_access_key>
-# JLCPCB_API_SECRET=<your_secret_key>
-
-client = JLCPCBClient(app_id, access_key, secret_key)
-data = client.fetch_parts_page()
+# Credentials are read from the project-root .env (auto-loaded) or the environment:
+# JLCPCB_APP_ID / JLCPCB_API_KEY / JLCPCB_API_SECRET
+client = JLCPCBClient()
+if client.has_credentials():
+    part = client.get_part_by_lcsc("C25804")  # live stock + tiered pricing
 ```
 
-**Note:** Most users should use JLCSearch public API instead, as it's freely available and requires no authentication.
+**Note:** The Open Platform has no search endpoint — keyword/parametric search always
+runs against the local snapshot (`search_jlcpcb_parts`). The legacy
+`jlcpcb.com/external` bulk-download path (`fetch_parts_page` /
+`download_full_database`) is deprecated and only kept for backwards compatibility.
 
 ## Credits
 

--- a/docs/JLCPCB_USAGE_GUIDE.md
+++ b/docs/JLCPCB_USAGE_GUIDE.md
@@ -2,13 +2,19 @@
 
 > **Note:** This document provides usage examples and workflow guidance. For complete API reference and setup instructions, see [JLCPCB_INTEGRATION.md](JLCPCB_INTEGRATION.md).
 
-The KiCAD MCP Server provides **three complementary approaches** for working with JLCPCB parts:
+The KiCAD MCP Server works with JLCPCB parts through two backends, by design:
 
-1. **JLCSearch Public API** - No authentication required, 2.5M+ parts with pricing (Recommended)
-2. **Local Symbol Libraries** - Search JLCPCB libraries installed via KiCad PCM _(contributed by [@l3wi](https://github.com/l3wi) in [PR #25](https://github.com/mixelpixx/KiCAD-MCP-Server/pull/25))_
-3. **Official JLCPCB API** - Requires enterprise account (Advanced)
+- **Search → local snapshot.** `search_jlcpcb_parts` queries a local SQLite database
+  you populate once with `download_jlcpcb_database` (default `cdfer` source, a ~600k
+  in-stock subset). The JLCPCB Open Platform API has **no search endpoint**, so search
+  must run locally.
+- **Single-part lookup → real-time.** `get_jlcpcb_part` prefers the JLCPCB **Open
+  Platform** `getComponentDetailByCode` endpoint for live stock and tiered pricing when
+  credentials are set, and falls back to the local snapshot otherwise. Each result's
+  `source` field says which backend answered (`"live-api"` vs `"local-db"`).
 
-All approaches can be used together to give you maximum flexibility.
+You can also search JLCPCB **local symbol libraries** installed via KiCad PCM
+_(contributed by [@l3wi](https://github.com/l3wi) in [PR #25](https://github.com/mixelpixx/KiCAD-MCP-Server/pull/25))_.
 
 ## Credits
 
@@ -17,39 +23,38 @@ All approaches can be used together to give you maximum flexibility.
 
 ---
 
-## Approach 1: JLCSearch Public API (Recommended)
+## Approach 1: Local snapshot database (Recommended for search)
 
 ### What It Does
 
-- Access to 2.5M+ JLCPCB parts with pricing and stock data
-- **No authentication required** - works immediately
-- **No JLCPCB account needed**
-- Real-time pricing with quantity breaks
-- Basic vs Extended library type identification
-- Local SQLite database for fast offline searching
-- Note: Download takes 40-60 minutes due to API pagination (100 parts per request)
+- A local SQLite snapshot of ~600k in-stock JLCPCB parts for fast offline **search**
+- **No authentication required** — the default `cdfer` source is a public prebuilt DB
+- Pricing, stock and Basic/Extended library type per part (as of the snapshot date)
+- Powers `search_jlcpcb_parts`, `suggest_jlcpcb_alternatives` and the local fallback
+  for `get_jlcpcb_part`
+
+> The snapshot mirror can lag JLCPCB by days-to-weeks, so a specific part's stock/price
+> may be stale. Use `get_jlcpcb_part` with Open Platform credentials (Approach 3) for
+> real-time figures on a part you care about.
 
 ### Setup
 
-No setup required! Just download the database:
+No credentials required — just download the database:
 
 ```
 download_jlcpcb_database({ force: false })
 ```
 
-This downloads ~2.5M parts from JLCSearch API and creates a local SQLite database (`data/jlcpcb_parts.db`).
+This fetches the prebuilt `cdfer` catalog and builds a local SQLite database. See
+`get_jlcpcb_database_stats` for the resulting counts and path.
 
 **Expected Output:**
 
 ```
-Downloading JLCPCB parts database...
-Downloaded 100 parts...
-Downloaded 200 parts...
-... (continues for 40-60 minutes)
-Downloaded 2,500,000 parts...
-
-Total parts: 2,500,000+
-Database size: 3-5 GB (full catalog)
+✓ Successfully downloaded JLCPCB parts database
+Source: cdfer
+Total parts: ~600,000
+Database size: ~465 MB
 ```
 
 ### Usage Examples
@@ -146,63 +151,61 @@ Class: Extended
 
 ---
 
-## Approach 3: Official JLCPCB API (Advanced - Enterprise Accounts Only)
+## Approach 3: JLCPCB Open Platform API (real-time lookup)
 
 ### What It Does
 
-- Downloads from the **official JLCPCB API** (requires enterprise account)
-- Provides **real-time pricing and stock information**
+- Real-time **single-part** detail via the JLCPCB **Open Platform**
+  (`https://open.jlcpcb.com`, `getComponentDetailByCode`)
+- Provides **live pricing and stock information** (not the snapshot)
 - Automatic **Basic vs Extended** library type identification (Basic = free assembly)
-- Smart suggestions for cheaper/in-stock alternatives
-- Package-to-footprint mapping for KiCad
+- Used by `get_jlcpcb_part`, which falls back to the local snapshot if the API call
+  fails or credentials are absent; the result's `source` field reports which backend
+  answered
+
+> The Open Platform has **no search endpoint** — it only returns detail by LCSC code.
+> Keyword/parametric search always runs against the local snapshot (Approach 1).
 
 ### Setup
 
 #### 1. Get JLCPCB API Credentials
 
-Visit [JLCPCB](https://jlcpcb.com/) and get your API credentials:
+Log in to your JLCPCB account, open **Account → API Management**, create an API key,
+and save your App ID, Access Key and Secret Key.
 
-1. Log in to your JLCPCB account
-2. Go to: **Account → API Management**
-3. Click "Create API Key"
-4. Save your `appKey` and `appSecret`
+#### 2. Configure credentials
 
-#### 2. Configure Environment Variables
-
-Add to your shell profile (`~/.bashrc`, `~/.zshrc`, or `~/.profile`):
-
-```bash
-export JLCPCB_API_KEY="your_app_key_here"
-export JLCPCB_API_SECRET="your_app_secret_here"
-```
-
-Or create a `.env` file in the project root:
+Create a `.env` file in the project root (it is gitignored — copy `.env.example`):
 
 ```
-JLCPCB_API_KEY=your_app_key_here
-JLCPCB_API_SECRET=your_app_secret_here
+JLCPCB_APP_ID=your_app_id
+JLCPCB_API_KEY=your_access_key
+JLCPCB_API_SECRET=your_secret_key
 ```
 
-#### 3. Download the Parts Database
+The server auto-loads this `.env` on first use of the JLCPCB client, non-destructively
+(it never overrides a variable already set in the environment). You may also export the
+same variables in your shell instead.
 
-**One-time setup** (takes 5-10 minutes):
+#### 3. Look up a part
 
-```
-download_jlcpcb_database({ force: false })
-```
-
-This downloads ~100k parts from JLCPCB and creates a local SQLite database (`data/jlcpcb_parts.db`).
-
-**Output:**
+No separate download step is needed for real-time lookup:
 
 ```
-✓ Successfully downloaded JLCPCB parts database
+get_jlcpcb_part({ lcsc_number: "C25804" })
+```
 
-Total parts: 108,523
-Basic parts: 2,856 (free assembly)
-Extended parts: 105,667 ($3 setup fee each)
-Database size: 42.3 MB
-Database path: /home/user/KiCAD-MCP-Server/data/jlcpcb_parts.db
+**Output (abridged):**
+
+```
+LCSC: C25804
+MFR Part: ...
+Stock: 12345
+Source: JLCPCB Open Platform (real-time)
+
+Price Breaks:
+  1+: $0.02/ea
+  100+: $0.01/ea
 ```
 
 ### Usage Examples

--- a/python/commands/jlcpcb.py
+++ b/python/commands/jlcpcb.py
@@ -15,11 +15,89 @@ import secrets
 import string
 import time
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import requests
 
 logger = logging.getLogger("kicad_interface")
+
+
+def _load_env_file(env_path: Optional[Path] = None) -> None:
+    """Best-effort load of a project-root ``.env`` so JLCPCB_* creds are picked up.
+
+    The MCP server only reads ``os.environ``; it never loaded ``.env`` before, so a
+    user who dropped credentials in a (gitignored) ``.env`` saw them silently ignored.
+    We load it lazily and non-destructively (never override an already-set env var).
+
+    Args:
+        env_path: Path to the ``.env`` file. Defaults to the repo-root ``.env``
+            (three parents up from this module); overridable for testing.
+    """
+    try:
+        from dotenv import load_dotenv
+    except Exception:  # python-dotenv is a declared dep, but degrade gracefully
+        return
+    if env_path is None:
+        # python/commands/jlcpcb.py -> repo root is three parents up.
+        env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.is_file():
+        load_dotenv(env_path, override=False)
+
+
+def _library_type_label(raw: Any) -> str:
+    """Normalize JLCPCB's library-type strings to Basic / Preferred / Extended.
+
+    The API returns ``base``/``Basic`` for basic parts and ``expand``/``Extended``
+    for extended; some responses use ``preferred``. Anything unknown -> Extended.
+    """
+    val = str(raw or "").strip().lower()
+    if val in ("base", "basic"):
+        return "Basic"
+    if val in ("preferred", "prefer"):
+        return "Preferred"
+    return "Extended"
+
+
+def normalize_detail_to_part(detail: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a getComponentDetailByCode item into the JLCPCBPartsManager part shape.
+
+    Produces the same keys ``get_part_info`` returns (so callers/UI stay uniform),
+    plus richer live-only fields: ``price_ranges`` (full tiers), ``parameters``,
+    ``rohs``, ``eccn_code``, and ``source='live-api'``.
+
+    ``price_breaks`` is deliberately kept in the *same* ``[{qty, price}]`` shape the
+    local ``get_part_info`` emits (the TS renderer at ``src/tools/jlcpcb-api.ts``
+    reads ``pb.qty`` / ``pb.price``). The verbose per-tier ranges from the API — with
+    start/end quantities — are exposed separately under ``price_ranges``.
+    """
+    price_ranges = detail.get("priceRanges") or []
+    # Manager-compatible [{qty, price}] list, keyed on each tier's start quantity.
+    price_breaks = [
+        {"qty": pr.get("startQuantity", 1), "price": pr.get("unitPrice")}
+        for pr in price_ranges
+        if pr.get("unitPrice") is not None
+    ]
+    return {
+        "lcsc": detail.get("componentCode"),
+        "category": detail.get("firstTypeName", ""),
+        "subcategory": detail.get("secondTypeName", ""),
+        "mfr_part": detail.get("componentModel", ""),
+        "package": detail.get("componentSpecification", ""),
+        "solder_joints": detail.get("solderJointCount", 0),
+        "manufacturer": detail.get("manufacturer", ""),
+        "library_type": _library_type_label(detail.get("libraryType")),
+        "description": detail.get("description", ""),
+        "datasheet": detail.get("datasheetUrl", ""),
+        "stock": detail.get("stockCount", 0),
+        "price_json": json.dumps(price_breaks),
+        "price_breaks": price_breaks,  # [{qty, price}] — same shape as get_part_info
+        "price_ranges": price_ranges,  # full [{startQuantity,endQuantity,unitPrice}]
+        "parameters": detail.get("parameters", []),
+        "rohs": detail.get("rohsFlag"),
+        "eccn_code": detail.get("eccnCode"),
+        "assembly_component": detail.get("assemblyComponentFlag"),
+        "source": "live-api",
+    }
 
 
 class JLCPCBClient:
@@ -30,7 +108,12 @@ class JLCPCBClient:
     the complete parts library from JLCPCB's external API.
     """
 
+    # Legacy bulk-download host (kept for download_full_database compatibility).
     BASE_URL = "https://jlcpcb.com/external"
+    # New Open Platform host — real-time component detail / library-list endpoints.
+    OPEN_BASE_URL = "https://open.jlcpcb.com"
+    DETAIL_PATH = "/overseas/openapi/component/getComponentDetailByCode"
+    LIBRARY_LIST_PATH = "/overseas/openapi/component/getComponentLibraryList"
 
     def __init__(
         self,
@@ -46,6 +129,7 @@ class JLCPCBClient:
             access_key: JLCPCB Access Key (or reads from JLCPCB_API_KEY env var)
             secret_key: JLCPCB Secret Key (or reads from JLCPCB_API_SECRET env var)
         """
+        _load_env_file()
         self.app_id = app_id or os.getenv("JLCPCB_APP_ID")
         self.access_key = access_key or os.getenv("JLCPCB_API_KEY")
         self.secret_key = secret_key or os.getenv("JLCPCB_API_SECRET")
@@ -131,6 +215,71 @@ class JLCPCBClient:
         )
 
         return f'JOP appid="{self.app_id}",accesskey="{self.access_key}",nonce="{nonce}",timestamp="{timestamp}",signature="{signature}"'
+
+    def has_credentials(self) -> bool:
+        """True if all three credentials are present (App ID / Access Key / Secret Key)."""
+        return bool(self.app_id and self.access_key and self.secret_key)
+
+    def _post_signed(self, base_url: str, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Sign and POST a JSON payload, returning the parsed ``data`` field.
+
+        Shared by the Open Platform endpoints. The signed body string and the wire
+        body MUST be byte-identical, so we serialize once with compact separators
+        and send it as raw ``data`` (not ``json=``) to avoid re-encoding drift.
+        """
+        body_str = json.dumps(payload, separators=(",", ":"))
+        auth_header = self._get_auth_header("POST", path, body_str)
+        headers = {
+            "Authorization": auth_header,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        resp = requests.post(f"{base_url}{path}", headers=headers, data=body_str, timeout=30)
+        trace = resp.headers.get("J-Trace-ID")
+        logger.debug(f"POST {path} -> HTTP {resp.status_code} (J-Trace-ID={trace})")
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("code") != 200:
+            raise Exception(
+                f"JLCPCB API error (code {data.get('code')}): "
+                f"{data.get('message', 'Unknown error')} [J-Trace-ID={trace}]"
+            )
+        return data.get("data")
+
+    def get_component_detail(self, codes: List[str]) -> List[Dict[str, Any]]:
+        """Real-time detail lookup by LCSC C-code(s) via the Open Platform.
+
+        Uses ``getComponentDetailByCode`` (batch, up to 1000 codes per call), which
+        returns live stock, tiered pricing, parameters, datasheet and library type.
+
+        Args:
+            codes: List of C-codes (e.g. ``["C8734", "C25804"]``). A missing/normalized
+                ``C`` prefix is added automatically.
+
+        Returns:
+            List of raw detail dicts (see ``normalize_detail_to_part`` to reshape).
+        """
+        if not codes:
+            return []
+        # LCSC codes are "C" + digits; upper-case and ensure the C prefix.
+        norm = []
+        for c in codes:
+            s = str(c).strip().upper()
+            norm.append(s if s.startswith("C") else f"C{s}")
+        # API caps the batch at 1000 codes per request.
+        out: List[Dict[str, Any]] = []
+        for i in range(0, len(norm), 1000):
+            batch = norm[i : i + 1000]
+            data = self._post_signed(
+                self.OPEN_BASE_URL, self.DETAIL_PATH, {"componentCodes": batch}
+            )
+            # ``data`` is the list itself on this endpoint (not wrapped in a VOList key
+            # in the live response), but tolerate the documented wrapped shape too.
+            if isinstance(data, dict):
+                data = data.get("componentDetailResponseVOList", [])
+            if data:
+                out.extend(data)
+        return out
 
     def fetch_parts_page(self, last_key: Optional[str] = None) -> Dict:
         """
@@ -234,22 +383,22 @@ class JLCPCBClient:
 
     def get_part_by_lcsc(self, lcsc_number: str) -> Optional[Dict]:
         """
-        Get detailed information for a specific LCSC part number
+        Get real-time detail for a specific LCSC part number.
 
-        Note: This uses the same endpoint as fetching parts, as JLCPCB doesn't
-        have a dedicated single-part endpoint. In practice, you should use
-        the local database after initial download.
+        Backed by the Open Platform ``getComponentDetailByCode`` endpoint, so stock
+        and pricing are live (not the local snapshot).
 
         Args:
             lcsc_number: LCSC part number (e.g., "C25804")
 
         Returns:
-            Part info dict or None if not found
+            Part info dict (JLCPCBPartsManager shape, via ``normalize_detail_to_part``)
+            or None if not found.
         """
-        # For now, this would require searching through pages
-        # In practice, you'd use the local database
-        logger.warning("get_part_by_lcsc should use local database, not API")
-        return None
+        details = self.get_component_detail([lcsc_number])
+        if not details:
+            return None
+        return normalize_detail_to_part(details[0])
 
 
 def test_jlcpcb_connection(

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -5689,20 +5689,51 @@ print("ok")
             return {"success": False, "message": f"Search failed: {str(e)}"}
 
     def _handle_get_jlcpcb_part(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        """Get detailed information for a specific JLCPCB part"""
+        """Get detailed information for a specific JLCPCB part.
+
+        Prefers a real-time lookup via the Open Platform API (live stock + tiered
+        pricing) when credentials are configured; otherwise, or if the live call
+        fails, falls back to the local snapshot database. ``source`` in the result
+        reports which backend answered ("live-api" vs "local-db").
+        """
         try:
             lcsc_number = params.get("lcsc_number")
             if not lcsc_number:
                 return {"success": False, "message": "Missing lcsc_number parameter"}
 
-            part = self.jlcpcb_parts.get_part_info(lcsc_number)
+            part = None
+            source = "local-db"
+
+            # 1) Real-time API path (only when credentials are present).
+            if self.jlcpcb_client.has_credentials():
+                try:
+                    part = self.jlcpcb_client.get_part_by_lcsc(lcsc_number)
+                    if part:
+                        source = "live-api"
+                        # The live detail response omits manufacturer; backfill it
+                        # from the local snapshot row when one is available so the
+                        # rendered "Manufacturer:" line is never blank.
+                        if not part.get("manufacturer"):
+                            local = self.jlcpcb_parts.get_part_info(lcsc_number)
+                            if local and local.get("manufacturer"):
+                                part["manufacturer"] = local["manufacturer"]
+                except Exception as api_err:
+                    logger.warning(
+                        f"Live JLCPCB lookup for {lcsc_number} failed, "
+                        f"falling back to local DB: {api_err}"
+                    )
+
+            # 2) Local snapshot fallback.
+            if not part:
+                part = self.jlcpcb_parts.get_part_info(lcsc_number)
+
             if not part:
                 return {"success": False, "message": f"Part not found: {lcsc_number}"}
 
             # Get suggested KiCAD footprints
             footprints = self.jlcpcb_parts.map_package_to_footprint(part.get("package", ""))
 
-            return {"success": True, "part": part, "footprints": footprints}
+            return {"success": True, "part": part, "source": source, "footprints": footprints}
 
         except Exception as e:
             logger.error(f"Error getting JLCPCB part: {e}", exc_info=True)

--- a/src/tools/jlcpcb-api.ts
+++ b/src/tools/jlcpcb-api.ts
@@ -163,7 +163,13 @@ Use this to find components with exact specifications and cost optimization.`,
   // Get JLCPCB part details
   server.tool(
     "get_jlcpcb_part",
-    "Get detailed information about a specific JLCPCB part by LCSC number",
+    `Get detailed information about a specific JLCPCB part by LCSC number.
+
+When JLCPCB Open Platform credentials are configured (JLCPCB_APP_ID / JLCPCB_API_KEY /
+JLCPCB_API_SECRET, e.g. in a project-root .env), this performs a REAL-TIME lookup — live
+stock, tiered pricing, parameters and library type — and falls back to the local snapshot
+database if the API call fails or no credentials are set. The response reports which backend
+answered via "source" ("live-api" vs "local-db").`,
     {
       lcsc_number: z.string().describe("LCSC part number (e.g., 'C25804', 'C2286')"),
     },
@@ -183,6 +189,13 @@ Use this to find components with exact specifications and cost optimization.`,
               result.footprints.map((f: string) => `  - ${f}`).join("\n")
             : "";
 
+        const sourceLine =
+          result.source === "live-api"
+            ? `Source: JLCPCB Open Platform (real-time)\n`
+            : result.source === "local-db"
+              ? `Source: local snapshot database\n`
+              : "";
+
         return {
           content: [
             {
@@ -190,13 +203,14 @@ Use this to find components with exact specifications and cost optimization.`,
               text:
                 `LCSC: ${p.lcsc}\n` +
                 `MFR Part: ${p.mfr_part}\n` +
-                `Manufacturer: ${p.manufacturer}\n` +
+                `Manufacturer: ${p.manufacturer || "—"}\n` +
                 `Category: ${p.category} / ${p.subcategory}\n` +
                 `Package: ${p.package}\n` +
                 `Description: ${p.description}\n` +
                 `Library Type: ${p.library_type} ${p.library_type === "Basic" ? "(Free assembly!)" : ""}\n` +
                 `Stock: ${p.stock}\n` +
                 (p.datasheet ? `Datasheet: ${p.datasheet}\n` : "") +
+                sourceLine +
                 priceTable +
                 footprints,
             },

--- a/tests/test_jlcpcb_live_api.py
+++ b/tests/test_jlcpcb_live_api.py
@@ -1,0 +1,404 @@
+"""
+Unit tests for the real-time JLCPCB Open Platform lookup path.
+
+These tests do NOT hit the network — ``requests.post`` is always mocked and no
+real credentials are used. They cover:
+
+  * Authorization header construction (JOP / HMAC-SHA256).
+  * ``get_component_detail`` batching, C-prefix normalization, and that codes the
+    API doesn't return are simply absent from the result.
+  * ``normalize_detail_to_part`` mapping, incl. the ``[{qty, price}]`` price shape
+    and libraryType base/expand -> Basic/Extended.
+  * ``_load_env_file`` never overriding an already-set env var.
+  * ``has_credentials``.
+  * The ``get_jlcpcb_part`` handler's live-first-then-local fallback.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Match the import root used elsewhere in the test suite (python/ on sys.path).
+PYTHON_DIR = Path(__file__).resolve().parent.parent / "python"
+if str(PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_DIR))
+
+from commands import jlcpcb  # noqa: E402
+from commands.jlcpcb import (  # noqa: E402
+    JLCPCBClient,
+    _library_type_label,
+    _load_env_file,
+    normalize_detail_to_part,
+)
+
+CREDS = dict(app_id="app-123", access_key="ak-456", secret_key="sk-789")
+
+
+@pytest.fixture(autouse=True)
+def _no_real_env(monkeypatch):
+    """Never let a test touch the user's real repo-root .env or ambient creds.
+
+    Neutralizes the constructor's ``_load_env_file()`` call and clears the three
+    JLCPCB_* vars so credential state is entirely test-controlled.
+    """
+    monkeypatch.setattr(jlcpcb, "_load_env_file", lambda *a, **k: None)
+    for var in ("JLCPCB_APP_ID", "JLCPCB_API_KEY", "JLCPCB_API_SECRET"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _client() -> JLCPCBClient:
+    return JLCPCBClient(**CREDS)
+
+
+class _FakeResponse:
+    """Minimal stand-in for a ``requests.Response``."""
+
+    def __init__(self, payload, status_code=200, headers=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.headers = headers or {"J-Trace-ID": "trace-xyz"}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+# ---------------------------------------------------------------------------
+# Authorization header
+# ---------------------------------------------------------------------------
+
+
+def test_auth_header_construction(monkeypatch):
+    client = _client()
+    monkeypatch.setattr(client, "_generate_nonce", lambda: "n" * 32)
+    monkeypatch.setattr(jlcpcb.time, "time", lambda: 1_700_000_000)
+
+    body = json.dumps({"componentCodes": ["C8734"]}, separators=(",", ":"))
+    header = client._get_auth_header("POST", client.DETAIL_PATH, body)
+
+    assert header.startswith("JOP ")
+    assert 'appid="app-123"' in header
+    assert 'accesskey="ak-456"' in header
+    assert 'nonce="nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn"' in header
+    assert 'timestamp="1700000000"' in header
+
+    # Signature must match an independently computed HMAC-SHA256 of the canonical
+    # "METHOD\npath\ntimestamp\nnonce\nbody\n" string.
+    sig_string = f"POST\n{client.DETAIL_PATH}\n1700000000\n{'n' * 32}\n{body}\n"
+    expected = base64.b64encode(
+        hmac.new(b"sk-789", sig_string.encode(), hashlib.sha256).digest()
+    ).decode()
+    assert f'signature="{expected}"' in header
+
+
+# ---------------------------------------------------------------------------
+# get_component_detail
+# ---------------------------------------------------------------------------
+
+
+def _install_post_capture(monkeypatch, payload_for):
+    """Patch ``requests.post`` to record calls and return payload_for(batch)."""
+    calls = []
+
+    def fake_post(url, headers=None, data=None, timeout=None):
+        body = json.loads(data)
+        calls.append({"url": url, "headers": headers, "body": body})
+        return _FakeResponse({"code": 200, "data": payload_for(body["componentCodes"])})
+
+    monkeypatch.setattr(jlcpcb.requests, "post", fake_post)
+    return calls
+
+
+def test_get_component_detail_normalizes_c_prefix(monkeypatch):
+    client = _client()
+    calls = _install_post_capture(
+        monkeypatch, lambda codes: [{"componentCode": c} for c in codes]
+    )
+
+    client.get_component_detail(["8734", "c25804", "C100"])
+
+    assert len(calls) == 1
+    assert calls[0]["body"]["componentCodes"] == ["C8734", "C25804", "C100"]
+    assert calls[0]["url"].endswith(client.DETAIL_PATH)
+
+
+def test_get_component_detail_batches_over_1000(monkeypatch):
+    client = _client()
+    calls = _install_post_capture(
+        monkeypatch, lambda codes: [{"componentCode": c} for c in codes]
+    )
+
+    codes = [f"C{i}" for i in range(2500)]
+    result = client.get_component_detail(codes)
+
+    # 2500 codes -> batches of 1000, 1000, 500.
+    assert [len(c["body"]["componentCodes"]) for c in calls] == [1000, 1000, 500]
+    assert len(result) == 2500
+
+
+def test_get_component_detail_drops_codes_the_api_omits(monkeypatch):
+    client = _client()
+    # API only knows C1; C2 is unknown and simply not returned.
+    _install_post_capture(
+        monkeypatch,
+        lambda codes: [{"componentCode": c} for c in codes if c == "C1"],
+    )
+
+    result = client.get_component_detail(["C1", "C2"])
+
+    assert [d["componentCode"] for d in result] == ["C1"]
+
+
+def test_get_component_detail_empty_input_makes_no_call(monkeypatch):
+    client = _client()
+    calls = _install_post_capture(monkeypatch, lambda codes: [])
+    assert client.get_component_detail([]) == []
+    assert calls == []
+
+
+def test_get_component_detail_tolerates_wrapped_volist(monkeypatch):
+    client = _client()
+
+    def fake_post(url, headers=None, data=None, timeout=None):
+        return _FakeResponse(
+            {"code": 200, "data": {"componentDetailResponseVOList": [{"componentCode": "C1"}]}}
+        )
+
+    monkeypatch.setattr(jlcpcb.requests, "post", fake_post)
+    result = client.get_component_detail(["C1"])
+    assert [d["componentCode"] for d in result] == ["C1"]
+
+
+def test_post_signed_raises_on_api_error_code(monkeypatch):
+    client = _client()
+
+    def fake_post(url, headers=None, data=None, timeout=None):
+        return _FakeResponse({"code": 500, "message": "boom"})
+
+    monkeypatch.setattr(jlcpcb.requests, "post", fake_post)
+    with pytest.raises(Exception) as exc:
+        client.get_component_detail(["C1"])
+    assert "boom" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# normalize_detail_to_part
+# ---------------------------------------------------------------------------
+
+SAMPLE_DETAIL = {
+    "componentCode": "C25804",
+    "componentModel": "RC0805FR-0710KL",
+    "componentSpecification": "0805",
+    "firstTypeName": "Resistors",
+    "secondTypeName": "Chip Resistor - Surface Mount",
+    "libraryType": "base",
+    "description": "10kOhms ±1% 0805",
+    "datasheetUrl": "https://example.com/ds.pdf",
+    "solderJointCount": 2,
+    "stockCount": 12345,
+    "rohsFlag": True,
+    "eccnCode": "EAR99",
+    "assemblyComponentFlag": True,
+    "priceRanges": [
+        {"startQuantity": 1, "endQuantity": 99, "unitPrice": 0.02},
+        {"startQuantity": 100, "endQuantity": -1, "unitPrice": 0.01},
+    ],
+    "parameters": [{"parameterName": "Resistance", "parameterValue": "10kOhms"}],
+}
+
+
+def test_normalize_maps_core_fields():
+    part = normalize_detail_to_part(SAMPLE_DETAIL)
+    assert part["lcsc"] == "C25804"
+    assert part["mfr_part"] == "RC0805FR-0710KL"
+    assert part["package"] == "0805"
+    assert part["category"] == "Resistors"
+    assert part["subcategory"] == "Chip Resistor - Surface Mount"
+    assert part["stock"] == 12345
+    assert part["datasheet"] == "https://example.com/ds.pdf"
+    assert part["source"] == "live-api"
+
+
+def test_normalize_price_breaks_have_manager_shape():
+    part = normalize_detail_to_part(SAMPLE_DETAIL)
+    # Same [{qty, price}] shape the TS renderer and local get_part_info use.
+    assert part["price_breaks"] == [
+        {"qty": 1, "price": 0.02},
+        {"qty": 100, "price": 0.01},
+    ]
+    # price_json is a JSON string of the same list.
+    assert json.loads(part["price_json"]) == part["price_breaks"]
+    # Full tiers preserved separately.
+    assert part["price_ranges"] == SAMPLE_DETAIL["priceRanges"]
+
+
+def test_normalize_price_breaks_skip_null_prices():
+    detail = {"priceRanges": [{"startQuantity": 1, "unitPrice": None}, {"startQuantity": 10, "unitPrice": 0.5}]}
+    part = normalize_detail_to_part(detail)
+    assert part["price_breaks"] == [{"qty": 10, "price": 0.5}]
+
+
+def test_normalize_missing_manufacturer_is_empty_string():
+    # The detail response has no manufacturer field.
+    part = normalize_detail_to_part(SAMPLE_DETAIL)
+    assert part["manufacturer"] == ""
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("base", "Basic"),
+        ("Basic", "Basic"),
+        ("expand", "Extended"),
+        ("Extended", "Extended"),
+        ("preferred", "Preferred"),
+        ("something-else", "Extended"),
+        (None, "Extended"),
+    ],
+)
+def test_library_type_label(raw, expected):
+    assert _library_type_label(raw) == expected
+
+
+def test_normalize_library_type_base_and_expand():
+    assert normalize_detail_to_part({"libraryType": "base"})["library_type"] == "Basic"
+    assert normalize_detail_to_part({"libraryType": "expand"})["library_type"] == "Extended"
+
+
+# ---------------------------------------------------------------------------
+# _load_env_file + has_credentials
+# ---------------------------------------------------------------------------
+
+
+def test_load_env_file_never_overrides_existing(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("JLCPCB_APP_ID=from-file\nJLCPCB_API_KEY=key-from-file\n")
+
+    # APP_ID already set in the environment must survive; the unset one loads.
+    monkeypatch.setenv("JLCPCB_APP_ID", "already-set")
+    monkeypatch.delenv("JLCPCB_API_KEY", raising=False)
+
+    _load_env_file(env)
+
+    import os
+
+    assert os.environ["JLCPCB_APP_ID"] == "already-set"
+    assert os.environ["JLCPCB_API_KEY"] == "key-from-file"
+
+
+def test_load_env_file_missing_path_is_noop(tmp_path):
+    # Should not raise when the file does not exist.
+    _load_env_file(tmp_path / "does-not-exist.env")
+
+
+def test_has_credentials():
+    assert _client().has_credentials() is True
+    assert JLCPCBClient(app_id="a", access_key="b", secret_key=None).has_credentials() is False
+    # Constructing with no args reads env; force all-empty to assert False.
+    empty = JLCPCBClient(app_id="", access_key="", secret_key="")
+    assert empty.has_credentials() is False
+
+
+# ---------------------------------------------------------------------------
+# get_jlcpcb_part handler: live-first-then-local fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def interface():
+    """A KiCADInterface with __init__ skipped and JLCPCB backends mocked."""
+    from kicad_interface import KiCADInterface
+
+    iface = object.__new__(KiCADInterface)
+    iface.jlcpcb_client = MagicMock()
+    iface.jlcpcb_parts = MagicMock()
+    iface.jlcpcb_parts.map_package_to_footprint.return_value = ["R_0805_2012Metric"]
+    return iface
+
+
+def test_handler_live_success(interface):
+    interface.jlcpcb_client.has_credentials.return_value = True
+    interface.jlcpcb_client.get_part_by_lcsc.return_value = {
+        "lcsc": "C25804",
+        "package": "0805",
+        "manufacturer": "Yageo",
+        "source": "live-api",
+    }
+
+    result = interface._handle_get_jlcpcb_part({"lcsc_number": "C25804"})
+
+    assert result["success"] is True
+    assert result["source"] == "live-api"
+    assert result["part"]["lcsc"] == "C25804"
+    interface.jlcpcb_parts.get_part_info.assert_not_called()
+
+
+def test_handler_backfills_manufacturer_from_local(interface):
+    interface.jlcpcb_client.has_credentials.return_value = True
+    interface.jlcpcb_client.get_part_by_lcsc.return_value = {
+        "lcsc": "C25804",
+        "package": "0805",
+        "manufacturer": "",  # live detail lacks manufacturer
+        "source": "live-api",
+    }
+    interface.jlcpcb_parts.get_part_info.return_value = {"manufacturer": "Yageo"}
+
+    result = interface._handle_get_jlcpcb_part({"lcsc_number": "C25804"})
+
+    assert result["source"] == "live-api"
+    assert result["part"]["manufacturer"] == "Yageo"
+
+
+def test_handler_live_failure_falls_back_to_local(interface):
+    interface.jlcpcb_client.has_credentials.return_value = True
+    interface.jlcpcb_client.get_part_by_lcsc.side_effect = Exception("network down")
+    interface.jlcpcb_parts.get_part_info.return_value = {
+        "lcsc": "C25804",
+        "package": "0805",
+        "manufacturer": "Yageo",
+    }
+
+    result = interface._handle_get_jlcpcb_part({"lcsc_number": "C25804"})
+
+    assert result["success"] is True
+    assert result["source"] == "local-db"
+    assert result["part"]["manufacturer"] == "Yageo"
+
+
+def test_handler_no_creds_uses_local(interface):
+    interface.jlcpcb_client.has_credentials.return_value = False
+    interface.jlcpcb_parts.get_part_info.return_value = {
+        "lcsc": "C25804",
+        "package": "0805",
+    }
+
+    result = interface._handle_get_jlcpcb_part({"lcsc_number": "C25804"})
+
+    assert result["success"] is True
+    assert result["source"] == "local-db"
+    interface.jlcpcb_client.get_part_by_lcsc.assert_not_called()
+
+
+def test_handler_not_found(interface):
+    interface.jlcpcb_client.has_credentials.return_value = False
+    interface.jlcpcb_parts.get_part_info.return_value = None
+
+    result = interface._handle_get_jlcpcb_part({"lcsc_number": "C999"})
+
+    assert result["success"] is False
+    assert "not found" in result["message"].lower()
+
+
+def test_handler_missing_param(interface):
+    result = interface._handle_get_jlcpcb_part({})
+    assert result["success"] is False
+    assert "lcsc_number" in result["message"]


### PR DESCRIPTION
## Summary

`get_jlcpcb_part` now performs a **real-time** lookup against the JLCPCB **Open Platform**
(`getComponentDetailByCode`) — live stock and tiered pricing — when API credentials are
configured, and transparently falls back to the local snapshot database otherwise. Each
result reports which backend answered via a new `source` field (`"live-api"` vs `"local-db"`).

## Why

The local parts snapshot (populated by `download_jlcpcb_database`) mirrors a prebuilt catalog
that can lag JLCPCB by days-to-weeks, so a specific part's stock/price is often stale (observed:
a part reading 22.3M in-stock in the snapshot vs **0** live). The JLCPCB Open Platform exposes a
real `getComponentDetailByCode` endpoint for authoritative per-part data, but the repo never
used it — `get_part_by_lcsc` was a dead stub returning `None`, and the server never loaded the
`.env` where users put their credentials.

Note the Open Platform has **no keyword/parametric search endpoint** (only detail-by-code and a
thin full-catalog dump), so search intentionally stays local; only single-part lookup goes live.
The legacy `jlcpcb.com/external` bulk path (`fetch_parts_page`/`download_full_database`) is
deprecated and kept only for backwards compatibility.

## Changes

- **`python/commands/jlcpcb.py`** — `get_component_detail(codes)` (batched ≤1000, C-prefix
  normalization, tolerates both the bare-list and documented `componentDetailResponseVOList`
  shapes); a real `get_part_by_lcsc`; `normalize_detail_to_part` mapping the detail response to
  the `JLCPCBPartsManager` part shape — **`price_breaks` kept as `[{qty, price}]`** to match the
  local shape and the TS renderer, with the full tiers under `price_ranges`, and
  `libraryType` base/expand → Basic/Extended; `has_credentials`; `_post_signed` (reuses the
  existing JOP/HMAC-SHA256 auth, sends the signed body byte-identically as raw `data`); and
  `_load_env_file` (auto-loads a project-root `.env`, non-destructively — never overrides an
  already-set env var).
- **`python/kicad_interface.py`** — `_handle_get_jlcpcb_part` does live-first-then-local and
  backfills `manufacturer` (absent from the live detail) from the local snapshot row; adds
  `source` to the response.
- **`src/tools/jlcpcb-api.ts`** — `get_jlcpcb_part` description now documents the real-time
  behavior, surfaces `source`, and renders `manufacturer` gracefully when empty.
- **`tests/test_jlcpcb_live_api.py`** — new, fully mocked (no network): auth header
  construction, batching/normalization/dropped-codes, the fixed price shape and library-type
  mapping, `.env` non-override, `has_credentials`, and the handler's live-success /
  live-failure→local / no-creds→local paths.
- **`docs/JLCPCB_INTEGRATION.md`, `docs/JLCPCB_USAGE_GUIDE.md`, `.env.example`** — document the
  Open Platform endpoint, `.env` loading, the `source` field, and that search is local-only
  (replacing the stale JLCSearch offset-pagination narrative).

## Test plan

- `python -m pytest tests/test_jlcpcb_live_api.py -q -o addopts=""` → **28 passed**
- `python -m pytest tests/test_jlcpcb_downloader.py -q -o addopts=""` → **13 passed** (unchanged)
- `npx tsc --noEmit` → clean
- Manual (real creds in a gitignored `.env`): `get_jlcpcb_part {"lcsc_number":"C25804"}` returns
  live stock + tiered pricing with `source: "live-api"`; unplugging creds falls back to
  `source: "local-db"`.

Python 3.9-compatible; params are camelCase; type hints + docstrings. `.env` is gitignored and
never committed (a placeholder `.env.example` is provided instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
