### PR TITLE
fix(jlcpcb): sanitize FTS query so hyphenated MPN search works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,19 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **JLCPCB part search finds hyphenated MPNs** (#327): `search_parts` built
+  its FTS5 `MATCH` query by appending `*` to each whitespace term, so a real
+  manufacturer part number like `SHT41-AD1F-R2` became `SHT41-AD1F-R2*` — and
+  FTS5 reads `-` as a column/NOT operator, raising
+  `sqlite3.OperationalError: no such column: AD1F`. `search_parts` wraps the
+  query in a broad `except` that returns `[]`, so searching by an exact MPN
+  silently found nothing instead of erroring. Each term is now emitted as a
+  quoted prefix phrase (`"term"*`) with any embedded double quote doubled, so
+  hyphens and other FTS punctuation are matched as literal text; plain prefix
+  matching (`SHT41` still matches the full MPN) is unchanged. A regression test
+  builds a tiny in-schema FTS database and pins both the pre-fix crash and the
+  fixed lookup.
+
 - **`add_schematic_component` snaps the placement origin to the 1.27 mm
   (50 mil) schematic connection grid** (#299): library pins sit at integer
   multiples of 1.27 mm from the symbol origin, so an off-grid origin leaves

--- a/python/commands/jlcpcb_parts.py
+++ b/python/commands/jlcpcb_parts.py
@@ -18,6 +18,37 @@ from utils.platform_helper import PlatformHelper
 logger = logging.getLogger("kicad_interface")
 
 
+def _build_fts_match_query(query: str) -> str:
+    """Turn a free-text search into a safe FTS5 MATCH expression.
+
+    Each whitespace-delimited term becomes a quoted prefix phrase
+    (``"term"*``), so FTS5 special characters — most importantly the hyphen in
+    real MPNs like ``SHT41-AD1F-R2`` — are treated as literal text rather than
+    query operators. Without quoting, FTS5 parses ``SHT41-AD1F-R2*`` as a
+    column filter / NOT expression and raises ``no such column: AD1F``, which
+    ``search_parts`` swallowed into an empty result — so searching by a real
+    MPN silently found nothing.
+
+    Embedded double quotes are escaped by doubling. A trailing ``*`` the caller
+    already supplied is normalized so the term stays a prefix match.
+
+    Args:
+        query: Raw free-text query (e.g. ``"SHT41-AD1F-R2"`` or ``"10k 0603"``).
+
+    Returns:
+        An FTS5 MATCH string, e.g. ``'"sht41-ad1f-r2"*'`` or ``'"10k"* "0603"*'``.
+    """
+    terms = []
+    for term in query.strip().split():
+        if term.endswith("*"):
+            term = term[:-1]
+        if not term:
+            continue
+        escaped = term.replace('"', '""')
+        terms.append(f'"{escaped}"*')
+    return " ".join(terms)
+
+
 class JLCPCBPartsManager:
     """
     Manages local database of JLCPCB parts
@@ -293,19 +324,19 @@ class JLCPCBPartsManager:
         params = []
 
         if query:
-            # Use FTS for text search
-            # Add prefix wildcard to each term for partial matching
-            # (e.g., "BQ25895" becomes "BQ25895*" so FTS matches "BQ25895RTWR")
-            fts_query = " ".join(
-                f"{term}*" if not term.endswith("*") else term for term in query.strip().split()
-            )
-            sql_parts.append("""
-                AND lcsc IN (
-                    SELECT lcsc FROM components_fts
-                    WHERE components_fts MATCH ?
-                )
-            """)
-            params.append(fts_query)
+            # Use FTS for text search. Each term becomes a quoted prefix phrase
+            # (e.g. "BQ25895" -> '"BQ25895"*' so FTS matches "BQ25895RTWR"), which
+            # also makes hyphenated MPNs like "SHT41-AD1F-R2" literal text instead
+            # of FTS operators. See _build_fts_match_query.
+            fts_query = _build_fts_match_query(query)
+            if fts_query:
+                sql_parts.append("""
+                    AND lcsc IN (
+                        SELECT lcsc FROM components_fts
+                        WHERE components_fts MATCH ?
+                    )
+                """)
+                params.append(fts_query)
 
         if category:
             sql_parts.append("AND category LIKE ?")

--- a/tests/test_jlcpcb_fts_search.py
+++ b/tests/test_jlcpcb_fts_search.py
@@ -1,0 +1,120 @@
+"""
+Regression tests for JLCPCB FTS search with hyphenated MPNs.
+
+`JLCPCBPartsManager.search_parts()` built its FTS5 MATCH query by appending
+``*`` to each whitespace term. A hyphenated MPN like ``SHT41-AD1F-R2`` then
+parsed ``-`` as an FTS operator -> ``sqlite3.OperationalError: no such column:
+AD1F``, which search_parts swallowed into an empty result — so searching by a
+real MPN silently found nothing. These tests build a tiny in-schema database (no
+network, no 465MB snapshot) and verify the fix.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Match the import root used elsewhere in the test suite (python/ on sys.path).
+PYTHON_DIR = Path(__file__).resolve().parent.parent / "python"
+if str(PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHON_DIR))
+
+from commands.jlcpcb_parts import JLCPCBPartsManager, _build_fts_match_query  # noqa: E402
+
+
+def _insert(mgr: JLCPCBPartsManager, lcsc, mfr_part, description, manufacturer, stock=1000):
+    cur = mgr.conn.cursor()
+    cur.execute(
+        "INSERT INTO components (lcsc, mfr_part, description, manufacturer, stock, price_json)"
+        " VALUES (?, ?, ?, ?, ?, ?)",
+        (lcsc, mfr_part, description, manufacturer, stock, "[]"),
+    )
+    cur.execute(
+        "INSERT INTO components_fts (rowid, lcsc, description, mfr_part, manufacturer)"
+        " SELECT rowid, lcsc, description, mfr_part, manufacturer FROM components WHERE lcsc = ?",
+        (lcsc,),
+    )
+    mgr.conn.commit()
+
+
+@pytest.fixture()
+def manager(tmp_path):
+    mgr = JLCPCBPartsManager(db_path=str(tmp_path / "parts.db"))
+    _insert(
+        mgr,
+        "C7461862",
+        "SHT41-AD1F-R2",
+        "Temperature and humidity sensor I2C",
+        "Sensirion",
+    )
+    _insert(mgr, "C25804", "0603WAF1002T5E", "10kOhms 1% resistor", "UNI-ROYAL", stock=5000)
+    yield mgr
+    mgr.close()
+
+
+# ---------------------------------------------------------------------------
+# Regression: hyphenated MPN
+# ---------------------------------------------------------------------------
+
+
+def test_hyphenated_mpn_returns_the_part(manager):
+    results = manager.search_parts(query="SHT41-AD1F-R2")
+    assert [r["lcsc"] for r in results] == ["C7461862"]
+
+
+def test_raw_hyphenated_query_would_crash_fts(manager):
+    # Demonstrates the bug the fix addresses: the pre-fix query string raises.
+    with pytest.raises(sqlite3.OperationalError):
+        manager.conn.execute(
+            "SELECT lcsc FROM components_fts WHERE components_fts MATCH ?",
+            ("SHT41-AD1F-R2*",),
+        ).fetchall()
+    # The sanitized query does not raise and matches.
+    safe = _build_fts_match_query("SHT41-AD1F-R2")
+    rows = manager.conn.execute(
+        "SELECT lcsc FROM components_fts WHERE components_fts MATCH ?", (safe,)
+    ).fetchall()
+    assert [r[0] for r in rows] == ["C7461862"]
+
+
+def test_prefix_matching_still_works(manager):
+    # "SHT41" (no hyphen) should still prefix-match the MPN.
+    results = manager.search_parts(query="SHT41")
+    assert [r["lcsc"] for r in results] == ["C7461862"]
+
+
+def test_multi_term_query_all_terms_must_match(manager):
+    # Both terms present -> the sensor; a term absent -> no rows.
+    assert [r["lcsc"] for r in manager.search_parts(query="humidity sensor")] == ["C7461862"]
+    assert manager.search_parts(query="humidity resistor") == []
+
+
+def test_embedded_quote_does_not_crash(manager):
+    # A stray double quote must not raise; it simply matches nothing here.
+    assert manager.search_parts(query='SHT41"weird') == []
+
+
+def test_search_with_other_filters_and_hyphen(manager):
+    results = manager.search_parts(query="SHT41-AD1F-R2", manufacturer="Sensirion")
+    assert [r["lcsc"] for r in results] == ["C7461862"]
+
+
+# ---------------------------------------------------------------------------
+# _build_fts_match_query unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        ("SHT41-AD1F-R2", '"SHT41-AD1F-R2"*'),
+        ("10k 0603", '"10k"* "0603"*'),
+        ("BQ25895*", '"BQ25895"*'),  # caller-supplied trailing * normalized
+        ('weird"quote', '"weird""quote"*'),  # embedded quote doubled
+        ("   spaced   out  ", '"spaced"* "out"*'),
+        ("*", ""),  # nothing left after stripping the star
+    ],
+)
+def test_build_fts_match_query(query, expected):
+    assert _build_fts_match_query(query) == expected


### PR DESCRIPTION
## Summary

Searching JLCPCB parts by a real, hyphenated manufacturer part number (e.g.
`SHT41-AD1F-R2`) silently returned zero results. `search_parts()` now sanitizes its
FTS5 MATCH query so hyphens (and other FTS special characters) are treated as literal
text, while prefix matching is preserved.

## Why

`JLCPCBPartsManager.search_parts()` built its FTS5 `MATCH` expression by splitting the
query on whitespace and appending `*` to each term. For a hyphenated token like
`SHT41-AD1F-R2`, FTS5 parses `-` as an operator and reads the following bareword as a
column, raising:

```
sqlite3.OperationalError: no such column: AD1F
```

`search_parts()` catches that exception and returns `[]`, so the failure is invisible —
searching by an exact MPN (a very common thing to do) just finds nothing.

## Changes

- **`python/commands/jlcpcb_parts.py`** — new `_build_fts_match_query()` helper emits each
  term as a **quoted prefix phrase** (`"term"*`), making special characters literal;
  embedded double quotes are escaped by doubling, and a caller-supplied trailing `*` is
  normalized so the term stays a prefix. `search_parts()` uses it (and skips the FTS
  filter entirely if the sanitized query is empty).
- **`tests/test_jlcpcb_fts_search.py`** — regression tests on a tiny in-schema SQLite DB
  (no network, no 465MB snapshot): `SHT41-AD1F-R2` now returns `C7461862` (Sensirion),
  the pre-fix raw query still raises, prefix matching still works, multi-term/manufacturer
  filters, and the helper's output shapes/escaping.

## Test plan

- `python -m pytest tests/test_jlcpcb_fts_search.py -q -o addopts=""` → **12 passed**

Python 3.9-compatible; type hints + docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
