### PR TITLE
fix: use Path.open() instead of write_text(newline=) for Python 3.9 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,18 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`.kicad_sym` and schematic writes work again on Python 3.9** (#328): the
+  library-management (`import_symbol`/`export_symbol`/`rename_symbol`), Eagle
+  prettify, and symbol-schematic writers introduced with the recent tooling
+  wrote files via `Path.write_text(content, newline="\n")`, but
+  `Path.write_text` did not accept the `newline` keyword until Python 3.10 —
+  so on the project's declared `>=3.9` floor every one of those calls raised
+  `TypeError: write_text() got an unexpected keyword argument 'newline'`. Each
+  site now opens the file explicitly (`path.open("w", encoding="utf-8",
+  newline="\n")`) and writes through the handle, preserving the forced LF line
+  ending (so the files stay byte-identical on Windows rather than emitting
+  CRLF) while running on 3.9.
+
 - **JLCPCB part search finds hyphenated MPNs** (#327): `search_parts` built
   its FTS5 `MATCH` query by appending `*` to each whitespace term, so a real
   manufacturer part number like `SHT41-AD1F-R2` became `SHT41-AD1F-R2*` — and

--- a/python/commands/eagle.py
+++ b/python/commands/eagle.py
@@ -1894,7 +1894,8 @@ class EagleCommands:
                 from utils.sexpr_format import prettify
 
                 text = Path(sch_out).read_text(encoding="utf-8")
-                Path(sch_out).write_text(prettify(text), encoding="utf-8", newline="\n")
+                with Path(sch_out).open("w", encoding="utf-8", newline="\n") as f:
+                    f.write(prettify(text))
                 logger.info("Prettified schematic: %s", sch_out)
             except Exception as e:
                 logger.warning("Schematic prettify skipped: %s", e)

--- a/python/commands/library_management.py
+++ b/python/commands/library_management.py
@@ -148,7 +148,8 @@ class LibraryManagementCommands:
             tgt_content[:lib_close].rstrip() + "\n" + block + "\n" + tgt_content[lib_close:]
         )
 
-        tgt.write_text(tgt_content, encoding="utf-8", newline="\n")
+        with tgt.open("w", encoding="utf-8", newline="\n") as f:
+            f.write(tgt_content)
         logger.info(f"Imported symbol '{symbol_name}' as '{new_name}' into {tgt_path}")
         _invalidate_symbol_caches()
 
@@ -195,7 +196,8 @@ class LibraryManagementCommands:
         new_lib = _NEW_LIB_HEADER[: _NEW_LIB_HEADER.rfind(")")] + block + "\n)\n"
 
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(new_lib, encoding="utf-8", newline="\n")
+        with out.open("w", encoding="utf-8", newline="\n") as f:
+            f.write(new_lib)
         logger.info(f"Exported symbol '{symbol_name}' to {out_path}")
         _invalidate_symbol_caches()
 
@@ -251,7 +253,8 @@ class LibraryManagementCommands:
         if extends_updated:
             content = content.replace(f'(extends "{old_name}")', f'(extends "{new_name}")')
 
-        lib.write_text(content, encoding="utf-8", newline="\n")
+        with lib.open("w", encoding="utf-8", newline="\n") as f:
+            f.write(content)
         logger.info(f"Renamed symbol '{old_name}' to '{new_name}' in {lib_path}")
         _invalidate_symbol_caches()
 

--- a/python/commands/symbol_schematic.py
+++ b/python/commands/symbol_schematic.py
@@ -125,7 +125,8 @@ class SymbolSchematicCommands:
             inst_part = pattern.sub(_replace, inst_part)
 
             new_content = lib_part + inst_part
-            Path(sch_path).write_text(new_content, encoding="utf-8", newline="\n")
+            with Path(sch_path).open("w", encoding="utf-8", newline="\n") as f:
+                f.write(new_content)
 
             remaining = inst_part.count(f'(lib_id "{source_lib}:')
 

--- a/tests/test_library_management.py
+++ b/tests/test_library_management.py
@@ -82,7 +82,8 @@ SAMPLE_LIB = """(kicad_symbol_lib
 
 def _write_lib(tmp_path: Path, name: str = "test.kicad_sym") -> Path:
     p = tmp_path / name
-    p.write_text(SAMPLE_LIB, encoding="utf-8", newline="\n")
+    with p.open("w", encoding="utf-8", newline="\n") as f:
+        f.write(SAMPLE_LIB)
     return p
 
 

--- a/tests/test_symbol_schematic.py
+++ b/tests/test_symbol_schematic.py
@@ -51,7 +51,8 @@ SINGLE_LINE_SCH = """(kicad_sch
 
 def _write_sch(tmp_path: Path, content: str = SAMPLE_SCH) -> Path:
     p = tmp_path / "test.kicad_sch"
-    p.write_text(content, encoding="utf-8", newline="\n")
+    with p.open("w", encoding="utf-8", newline="\n") as f:
+        f.write(content)
     return p
 
 


### PR DESCRIPTION
## Summary

`Path.write_text()`'s `newline` keyword argument was added in **Python 3.10**, but this project supports **Python 3.9+** — and on macOS that isn't optional: KiCad's macOS builds bundle Python 3.9.13, and `pcbnew` is version-locked to that interpreter, so the server *must* run on 3.9 there.

On Python 3.9 every code path below raised:

```
TypeError: write_text() got an unexpected keyword argument 'newline'
```

Affected commands:
- `import_symbol`, `export_symbol`, `rename_symbol` (`commands/library_management.py`)
- Eagle-import canonical-formatting step (`commands/eagle.py`)
- `replace_instance_lib_ids` (`commands/symbol_schematic.py`)

Two test helpers (`tests/test_library_management.py`, `tests/test_symbol_schematic.py`) used the same kwarg, so the pytest suite couldn't run on 3.9 either.

## Fix

Replace the five calls with `Path.open("w", encoding="utf-8", newline="\n")`. This is behaviourally identical — `write_text` simply forwards `newline` to the same underlying `TextIOWrapper` — and works on 3.9. The LF-forcing behaviour (`newline="\n"`) is preserved.

## Verification

- The previously-failing tests in `test_library_management.py` and `test_symbol_schematic.py` now pass on Python 3.9.13.
- `compileall` and `vermin` confirm a 3.9 minimum-version floor for `python/` and `tests/` after this change (this was the only 3.10+ API in the codebase).
- Full pytest suite: no regressions.

## Notes

The docs already state "Python 3.9 or Higher" and that macOS KiCad ships 3.9; this makes the code match that contract. CI covers 3.9 in its matrix, so this path is exercised there.
