### PR TITLE
fix(schematic): scope replace-field restore to the component block; refuse ambiguous label deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **`replace_schematic_component` no longer corrupts `lib_symbols` while
+  restoring fields**: the post-replace field restore ran a `count=1` regex
+  substitution over the whole file, so the first matching
+  `(property "<name>" ...)` in the document was rewritten — for common field
+  names like `Description` that is a library symbol definition inside
+  `lib_symbols`, not the replaced component (observed corrupting an unrelated
+  `Conn_01x04` entry and tripping ERC library-mismatch warnings on every
+  instance). Restoration now delegates to the block-scoped
+  `edit_schematic_component` path, which also creates fields that the new
+  symbol does not carry yet instead of silently dropping them.
+
+- **`delete_schematic_net_label` refuses ambiguous bare-name deletes**:
+  without a `position`, `WireManager.delete_label` silently removed the first
+  label matching the name — dangerous when the same net name appears many
+  times (and easy to trigger, since misspelled top-level `x`/`y` arguments are
+  stripped by schema validation and arrive as `position=None`). A bare-name
+  delete of a name that occurs more than once now fails with the full list of
+  candidate positions so the caller can disambiguate; unique names and
+  position-qualified deletes behave as before.
+
 ### Performance
 
 - **Module-level caches for symbol library discovery, resolution, and

--- a/python/commands/schematic_batch.py
+++ b/python/commands/schematic_batch.py
@@ -385,17 +385,29 @@ class SchematicBatchCommands:
                 )
 
             if fields_to_restore:
-                content_after = sch_file.read_text(encoding="utf-8")
-                new_block, _, _ = _find_placed_symbol_block(content_after, reference)
-                if new_block:
-                    for fname, fval in fields_to_restore.items():
-                        prop_pat = re.compile(
-                            r'(\(property\s+"' + re.escape(fname) + r'"\s+)"[^"]*"'
-                        )
-                        content_after = prop_pat.sub(
-                            r'\1"' + fval.replace('"', '\\"') + '"', content_after, count=1
-                        )
-                    sch_file.write_text(content_after, encoding="utf-8")
+                # Restore the remaining fields through the block-scoped component
+                # editor. A plain regex substitution over the whole file (the
+                # previous implementation) replaced the FIRST matching
+                # (property "<name>" ...) in the file, which for common field
+                # names like "Description" lives inside lib_symbols — corrupting
+                # an unrelated library symbol definition instead of this
+                # component instance.
+                restore_result = self.iface._handle_edit_schematic_component(
+                    {
+                        "schematicPath": schematic_path,
+                        "reference": reference,
+                        "properties": {
+                            fname: {"value": fval} for fname, fval in fields_to_restore.items()
+                        },
+                    }
+                )
+                if not restore_result.get("success"):
+                    logger.warning(
+                        "Could not restore fields %s on %s after replace: %s",
+                        sorted(fields_to_restore),
+                        reference,
+                        restore_result.get("message"),
+                    )
 
             pin_locator = PinLocator()
             pins_raw = pin_locator.get_all_symbol_pins(sch_file, reference) or {}

--- a/python/commands/wire_manager.py
+++ b/python/commands/wire_manager.py
@@ -896,6 +896,35 @@ class WireManager:
             sch_data = sexpdata.loads(sch_content)
 
             _LABEL_TYPES = {_SYM_LABEL, _SYM_GLOBAL_LABEL, _SYM_HIERARCHICAL_LABEL}
+
+            if position is None:
+                # Refuse a bare-name delete when the name is ambiguous: silently
+                # removing the first match has destroyed the wrong label before
+                # (the caller thought coordinates were being honoured). Report
+                # every candidate position so the caller can disambiguate.
+                candidates = []
+                for item in sch_data:
+                    if not (isinstance(item, list) and len(item) > 1 and item[0] in _LABEL_TYPES):
+                        continue
+                    if item[1] != net_name:
+                        continue
+                    at_entry = next(
+                        (
+                            p
+                            for p in item[1:]
+                            if isinstance(p, list) and len(p) >= 3 and p[0] == _SYM_AT
+                        ),
+                        None,
+                    )
+                    if at_entry is not None:
+                        candidates.append((float(at_entry[1]), float(at_entry[2])))
+                if len(candidates) > 1:
+                    listing = ", ".join(f"({x}, {y})" for x, y in candidates)
+                    raise ValueError(
+                        f"Label '{net_name}' appears {len(candidates)} times "
+                        f"(at {listing}); pass position to select which one to delete"
+                    )
+
             for i, item in enumerate(sch_data):
                 if not (isinstance(item, list) and len(item) > 0 and item[0] in _LABEL_TYPES):
                     continue
@@ -931,6 +960,10 @@ class WireManager:
             logger.warning(f"No matching label found for '{net_name}'")
             return False
 
+        except ValueError:
+            # Ambiguity refusal — propagate so the caller sees the candidate
+            # positions instead of a generic "not found".
+            raise
         except Exception as e:
             logger.error(f"Error deleting label: {e}")
             import traceback

--- a/tests/test_schematic_batch.py
+++ b/tests/test_schematic_batch.py
@@ -213,3 +213,106 @@ class TestBatchAddAndConnect:
         assert "nets" not in add_args["components"][0]
         # nets routed to batch_connect keyed by reference
         assert conn_args["connections"] == {"R1": {"1": "VCC"}}
+
+
+class TestReplaceFieldRestore:
+    """Regression: field restore after replace must be block-scoped.
+
+    The old implementation regex-substituted the first matching
+    (property "<name>" ...) in the WHOLE file, which for names like
+    "Description" lives inside lib_symbols — corrupting an unrelated
+    library symbol definition.
+    """
+
+    _SCH = """\
+(kicad_sch (version 20250114) (generator "test")
+  (uuid aaaaaaaa-0000-0000-0000-000000000020)
+  (paper "A4")
+  (lib_symbols
+    (symbol "Connector_Generic:Conn_01x04"
+      (property "Description" "LIBRARY TEXT"
+        (at 0 0 0)
+      )
+    )
+  )
+  (symbol (lib_id "Device:D_TVS") (at 44.45 57.15 0)
+    (uuid dddddddd-0000-0000-0000-000000000021)
+    (property "Reference" "D1" (at 0 0 0))
+    (property "Value" "SMBJ15A" (at 0 0 0))
+    (property "Description" "OLD DESC" (at 0 0 0))
+  )
+  (sheet_instances (path "/" (page "1")))
+)
+"""
+
+    _NEW_BLOCK = """  (symbol (lib_id "Device:D_Zener") (at 44.45 57.15 0)
+    (uuid dddddddd-0000-0000-0000-000000000022)
+    (property "Reference" "D1" (at 0 0 0))
+    (property "Value" "SMBJ15A" (at 0 0 0))
+    (property "Description" "" (at 0 0 0))
+  )
+"""
+
+    def test_restore_delegates_to_block_scoped_editor(self, tmp_path, monkeypatch):
+        sch = tmp_path / "board.kicad_sch"
+        sch.write_text(self._SCH, encoding="utf-8")
+
+        def fake_get_component(params):
+            return {
+                "success": True,
+                "position": {"x": 44.45, "y": 57.15, "angle": 0},
+                "fields": {
+                    "Reference": {"value": "D1"},
+                    "Value": {"value": "SMBJ15A"},
+                    "Footprint": {"value": "Diode_SMD:D_SMB"},
+                    "Description": {"value": "OLD DESC"},
+                },
+            }
+
+        edit_calls = []
+
+        def fake_edit(params):
+            edit_calls.append(params)
+            return {"success": True}
+
+        def fake_add_component(self_loader, sch_file, *a, **kw):
+            content = sch_file.read_text(encoding="utf-8")
+            idx = content.rindex("  (sheet_instances")
+            sch_file.write_text(
+                content[:idx] + TestReplaceFieldRestore._NEW_BLOCK + content[idx:],
+                encoding="utf-8",
+            )
+            return {"success": True}
+
+        fake_loader_cls = type(
+            "FakeLoader",
+            (),
+            {"__init__": lambda self, **kw: None, "add_component": fake_add_component},
+        )
+        monkeypatch.setattr(sb, "DynamicSymbolLoader", fake_loader_cls)
+        fake_pins = types.SimpleNamespace(
+            get_all_symbol_pins=lambda p, ref: {},
+            get_symbol_pins=lambda p, sym: {},
+        )
+        monkeypatch.setattr(sb, "PinLocator", lambda: fake_pins)
+
+        iface = types.SimpleNamespace(
+            _handle_get_schematic_component=fake_get_component,
+            _handle_edit_schematic_component=fake_edit,
+        )
+        c = SchematicBatchCommands(iface)
+        r = c.replace_schematic_component(
+            {
+                "schematicPath": str(sch),
+                "reference": "D1",
+                "newSymbol": "Device:D_Zener",
+            }
+        )
+
+        assert r["success"] is True
+        # the library symbol definition must be untouched
+        assert '"LIBRARY TEXT"' in sch.read_text(encoding="utf-8")
+        # restoration went through the block-scoped editor with the old value
+        assert len(edit_calls) == 1
+        assert edit_calls[0]["reference"] == "D1"
+        assert edit_calls[0]["properties"]["Description"] == {"value": "OLD DESC"}

--- a/tests/test_schematic_tools.py
+++ b/tests/test_schematic_tools.py
@@ -43,6 +43,23 @@ _WIRE_SCH = """\
 """
 
 
+_DUP_LABEL_SCH = """\
+(kicad_sch (version 20250114) (generator "test")
+  (uuid aaaaaaaa-0000-0000-0000-000000000010)
+  (paper "A4")
+  (label "X" (at 10 10 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid cccccccc-0000-0000-0000-000000000011)
+  )
+  (label "X" (at 50 50 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid cccccccc-0000-0000-0000-000000000012)
+  )
+  (sheet_instances (path "/" (page "1")))
+)
+"""
+
+
 def _write_temp_sch(content: str) -> Path:
     """Write *content* to a temp file and return its Path."""
     tmp = tempfile.NamedTemporaryFile(suffix=".kicad_sch", delete=False, mode="w", encoding="utf-8")
@@ -112,6 +129,40 @@ class TestDeleteLabelUnit:
         shutil.copy(EMPTY_SCH, sch)
         result = self.WireManager.delete_label(sch, "VCC", position=[10.0, 20.0], tolerance=0.5)
         assert result is False
+
+    def test_ambiguous_name_without_position_refuses(self, tmp_path: Any) -> None:
+        """Two labels share a name: a bare-name delete must refuse, not pick one."""
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text(_DUP_LABEL_SCH, encoding="utf-8")
+
+        with pytest.raises(ValueError, match=r"2 times"):
+            self.WireManager.delete_label(sch, "X")
+
+        # nothing was deleted
+        data = sexpdata.loads(sch.read_text(encoding="utf-8"))
+        labels = [
+            item for item in data if isinstance(item, list) and item and str(item[0]) == "label"
+        ]
+        assert len(labels) == 2
+
+    def test_ambiguous_name_with_position_deletes_only_match(self, tmp_path: Any) -> None:
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text(_DUP_LABEL_SCH, encoding="utf-8")
+
+        assert self.WireManager.delete_label(sch, "X", position=[50.0, 50.0]) is True
+
+        data = sexpdata.loads(sch.read_text(encoding="utf-8"))
+        remaining = [
+            item for item in data if isinstance(item, list) and item and str(item[0]) == "label"
+        ]
+        assert len(remaining) == 1
+        at = next(pp for pp in remaining[0] if isinstance(pp, list) and str(pp[0]) == "at")
+        assert (float(at[1]), float(at[2])) == (10.0, 10.0)
+
+    def test_unique_name_without_position_still_deletes(self, tmp_path: Any) -> None:
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text(_WIRE_SCH, encoding="utf-8")
+        assert self.WireManager.delete_label(sch, "VCC") is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #331.

Two write-safety fixes for the schematic tools, each with regression tests. Both bugs were hit in a real board-review session; details and repro in the linked issue.

## 1. `replace_schematic_component`: scope field restore to the component block

The post-replace field restore ran a `count=1` regex substitution over the **whole file**, rewriting the first matching `(property "<name>" ...)` in the document — for names like `Description` that is a library definition inside `lib_symbols`, not the replaced component. In practice a `D_TVS → D_Zener` replace stamped the diode's old `Description` into an unrelated `Conn_01x04` library entry, and every placed instance of that connector started failing ERC with *"doesn't match copy in library"*.

Restoration now delegates to the existing block-scoped `_handle_edit_schematic_component` path, which:

- skips the `lib_symbols` section and edits only the referenced component's block, and
- **creates** fields the new symbol doesn't carry yet, so custom BOM fields (`MPN`, `LCSC`, …) survive a replace instead of being silently dropped.

Regression test: `tests/test_schematic_batch.py::TestReplaceFieldRestore` — replaces a component whose `lib_symbols` contains another symbol with a `Description` property, asserts the library text is untouched and the restore flows through the block-scoped editor with the old value.

## 2. `delete_schematic_net_label`: refuse ambiguous bare-name deletes

`WireManager.delete_label` silently removed the **first** label matching the requested name whenever `position` was omitted. Power-rail names appear many times per sheet, and the mistake is easy to make because unknown top-level `x`/`y` arguments are stripped by the tool schema and arrive as `position=None`.

A bare-name delete of a name that occurs more than once now raises `ValueError` listing every candidate position (the handler already surfaces exception messages to the caller):

```
Label '3V3' appears 11 times (at (105.41, 53.34), (144.78, 49.53), ...);
pass position to select which one to delete
```

Unique names and position-qualified deletes behave exactly as before.

Regression tests in `tests/test_schematic_tools.py`: ambiguous name without position refuses and deletes nothing; ambiguous name **with** position deletes only the matching label; unique name without position still works.

## Checks

- `pytest tests/test_schematic_batch.py tests/test_schematic_tools.py`: 45 passed, 1 failed — the failure is `TestHelpers::test_find_project_root_fallback`, which fails identically on a clean `main` checkout (pre-existing, unrelated).
- `black` and `flake8` (repo config) clean on all four touched files.
- End-to-end verified over stdio JSON-RPC against the original failing schematic: the replace no longer touches `lib_symbols`, and the ambiguous delete refuses with the candidate list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
