### PR TITLE
ci: actually gate the Python suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,19 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
+      # Formatting and type checks run ONCE, not once per matrix entry. pip
+      # resolves a different linter build per interpreter (black >=25.12
+      # requires Python >=3.10, so the 3.9 runner silently gets black 25.1.0,
+      # which formats three files differently from the 26.x used everywhere
+      # else). Pinning the interpreter for these steps is what makes the gate
+      # deterministic; the matrix is there to exercise the CODE on each Python,
+      # which pytest below still does. Same condition the coverage upload uses.
       - name: Run Black formatter check
+        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-24.04'
         run: black --check python/
 
       - name: Run MyPy type checker
+        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-24.04'
         run: mypy python/
 
       # Advisory only: pylint's default rule set has never been enforced on this
@@ -85,6 +94,7 @@ jobs:
       # --exit-zero says that honestly instead of hiding a real failure behind
       # `|| echo`, which is what the other four steps used to do.
       - name: Run Pylint (advisory)
+        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-24.04'
         run: pylint python/ --exit-zero
 
       # `pytest python/` pointed at the SOURCE tree, and an explicit path

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
+      # The autoroute/freerouting suites resolve a `java` executable before
+      # they mock out the actual subprocess call, so without a JRE on PATH
+      # 8 tests fail for a purely environmental reason.
+      - name: Set up Java (required by the freerouting test suites)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -66,16 +75,24 @@ jobs:
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
       - name: Run Black formatter check
-        run: black --check python/ || echo "Black not configured yet"
+        run: black --check python/
 
       - name: Run MyPy type checker
-        run: mypy python/ || echo "MyPy not configured yet"
+        run: mypy python/
 
-      - name: Run Pylint
-        run: pylint python/ || echo "Pylint not configured yet"
+      # Advisory only: pylint's default rule set has never been enforced on this
+      # tree, so a hard gate would fail on thousands of pre-existing findings.
+      # --exit-zero says that honestly instead of hiding a real failure behind
+      # `|| echo`, which is what the other four steps used to do.
+      - name: Run Pylint (advisory)
+        run: pylint python/ --exit-zero
 
+      # `pytest python/` pointed at the SOURCE tree, and an explicit path
+      # argument overrides pytest.ini's `testpaths = tests` — so CI collected 7
+      # tests from a stray python/test_ipc_backend.py while the real suite in
+      # tests/ never ran. Bare `pytest` picks up testpaths correctly.
       - name: Run pytest
-        run: pytest python/ --cov=python --cov-report=xml || echo "Tests not configured yet"
+        run: pytest --cov=python --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/python/annotations/__init__.py
+++ b/python/annotations/__init__.py
@@ -1,4 +1,5 @@
 """KiCad IPC API tool annotations package."""
+
 from .loader import AnnotationLoader
 
 __all__ = ["AnnotationLoader"]

--- a/python/kicad_api/ipc_backend.py
+++ b/python/kicad_api/ipc_backend.py
@@ -1431,11 +1431,13 @@ class IPCBoardAPI(BoardAPI):
             if name:
                 zone.name = name
 
-            # Set fill mode
-            if fill_mode == "hatched":
-                zone.fill_mode = ZoneFillMode.ZFM_HATCHED
-            else:
-                zone.fill_mode = ZoneFillMode.ZFM_SOLID
+            # Set fill mode. kipy's Zone.fill_mode is a read-only property
+            # (its getter reads _proto.copper_settings.fill_mode and there is
+            # no setter), so assigning to it raises AttributeError at runtime.
+            # Write through the proto, the same way the outline is set below.
+            zone._proto.copper_settings.fill_mode = (
+                ZoneFillMode.ZFM_HATCHED if fill_mode == "hatched" else ZoneFillMode.ZFM_SOLID
+            )
 
             # Create outline polyline
             outline = PolyLine()

--- a/tests/test_ipc_zone_fill_mode.py
+++ b/tests/test_ipc_zone_fill_mode.py
@@ -1,0 +1,62 @@
+"""Regression test: IPC zone creation must set fill_mode through the proto.
+
+kipy's ``Zone.fill_mode`` is a read-only property — its getter reads
+``_proto.copper_settings.fill_mode`` and there is no setter — so
+``zone.fill_mode = ...`` raises ``AttributeError`` the moment a user creates a
+zone over the IPC backend. mypy catches it as
+``Property "fill_mode" defined in "Zone" is read-only``, but only when kipy is
+actually installed; with kipy absent it is silently typed ``Any``, which is why
+this survived until CI began installing requirements.txt.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+kipy_board_types = pytest.importorskip(
+    "kipy.board_types", reason="kipy (kicad-python) not installed"
+)
+kipy_pb2 = pytest.importorskip("kipy.proto.board.board_types_pb2")
+
+Zone = kipy_board_types.Zone
+ZoneFillMode = kipy_pb2.ZoneFillMode
+
+
+def test_fill_mode_has_no_setter() -> None:
+    """Pin the upstream contract this fix exists for. If kipy ever adds a
+    setter, the workaround can be simplified — this test is the tripwire."""
+    prop = Zone.fill_mode
+    assert isinstance(prop, property)
+    assert prop.fset is None, "kipy added a fill_mode setter; simplify create_zone"
+
+    with pytest.raises(AttributeError):
+        Zone().fill_mode = ZoneFillMode.ZFM_SOLID
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [("hatched", ZoneFillMode.ZFM_HATCHED), ("solid", ZoneFillMode.ZFM_SOLID)],
+)
+def test_proto_write_round_trips(requested: str, expected: int) -> None:
+    """The assignment form used by create_zone must be readable back off the
+    public property — i.e. the proto path is the correct channel."""
+    zone = Zone()
+    zone._proto.copper_settings.fill_mode = (
+        ZoneFillMode.ZFM_HATCHED if requested == "hatched" else ZoneFillMode.ZFM_SOLID
+    )
+    assert zone.fill_mode == expected
+
+
+def test_create_zone_source_does_not_assign_the_property() -> None:
+    """Guard the specific line that regressed: create_zone must not contain a
+    bare ``zone.fill_mode =`` assignment."""
+    source = (Path(__file__).parent.parent / "python" / "kicad_api" / "ipc_backend.py").read_text(
+        encoding="utf-8"
+    )
+    assert "zone.fill_mode =" not in source, (
+        "create_zone assigns the read-only Zone.fill_mode property; "
+        "write through zone._proto.copper_settings.fill_mode instead"
+    )

--- a/tests/test_kicad_roots.py
+++ b/tests/test_kicad_roots.py
@@ -114,8 +114,17 @@ def _make_fake_winreg(hive_trees):
 
 @pytest.fixture
 def as_windows(monkeypatch):
-    """Force the module to take its Windows path."""
+    """Force the module to take its Windows path.
+
+    Also simulates Windows path-case semantics. The dedup in
+    ``_merge_roots`` relies on ``os.path.normcase`` folding case, which it
+    only does on Windows — on POSIX it is the identity function, so
+    differently-cased spellings of one root stay distinct and the dedup
+    assertions fail on Linux CI for a reason that cannot occur in
+    production (these code paths are guarded by a platform check).
+    """
     monkeypatch.setattr(kr.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(kr.os.path, "normcase", lambda p: str(p).lower())
 
 
 def _install(tmp_path, name):

--- a/tests/test_seven_zip_resolver.py
+++ b/tests/test_seven_zip_resolver.py
@@ -87,10 +87,15 @@ class TestWindowsInstallDirs:
         monkeypatch.setattr(sz.platform, "system", lambda: "Windows")
         monkeypatch.setenv("ProgramW6432", r"C:\Program Files")
         monkeypatch.setenv("ProgramFiles", r"C:\Program Files")
-        candidates = [str(c) for c in sz._candidate_paths()]
-        assert any(c.endswith(r"7-Zip\7z.exe") for c in candidates)
+        # Compare path components, not a string with a hardcoded separator:
+        # under a faked Windows platform the Path objects are still built by
+        # the host's flavour, so on Linux CI these render with "/" and an
+        # endswith(r"7-Zip\7z.exe") check fails for a reason that has nothing
+        # to do with the resolver.
+        tails = [Path(c).parts[-2:] for c in sz._candidate_paths()]
+        assert ("7-Zip", "7z.exe") in tails
         # Reduced CLIs are offered as fallbacks too.
-        assert any(c.endswith(r"7-Zip\7za.exe") for c in candidates)
+        assert ("7-Zip", "7za.exe") in tails
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

The `python-tests` job has never gated anything, and **Actions was disabled repo-wide** so `ci.yml` never executed at all. Workflow history: **32 failures, 1 cancelled, 0 successes** — it has never once passed, and was switched off in Jan 2026.

Four independent no-ops in the job itself:

1. **Every gate was swallowed** — `black --check python/ || echo "Black not configured yet"`, same `|| echo` on `mypy`, `pylint`, `pytest`. All reported success regardless of outcome.
2. **`pytest python/` pointed at the source tree.** An explicit path argument overrides `pytest.ini`'s `testpaths = tests`, so it collected **7 tests** from a stray `python/test_ipc_backend.py`. The real suite never ran.
3. **No JRE** — the autoroute/freerouting suites resolve a `java` executable before mocking the subprocess call, so 8 tests would have failed environmentally.
4. Pylint was in the same swallowed state.

This is the mechanism behind a recurring pattern: contributor PRs routinely arrive needing black/mypy fixes, and #308 shipped a `command_routes` entry referencing an unimported function — green CI, `NameError` at server startup.

## Changes

- `pytest python/` → `pytest`, so `testpaths = tests` applies.
- `|| echo` removed from black, mypy and pytest.
- `actions/setup-java@v4` (Temurin 21) — the Python job genuinely needs a JRE.
- Pylint → its own `--exit-zero` rather than a fake pass. Its default rule set has never been enforced here; `--exit-zero` says that honestly.
- **Format/type gates run once** (ubuntu-24.04 / 3.12) instead of per matrix entry. `pip install black` resolves a *different build per interpreter* — black ≥25.12 requires Python ≥3.10, so the 3.9 runner silently gets black 25.1.0, which formats three files differently from the 26.x used everywhere else. The matrix is for exercising the code on each Python, which pytest still does.

## What turning it on immediately found

Three real defects, none of which local gating could have caught:

1. **`create_zone` was broken on the IPC backend.** `python/kicad_api/ipc_backend.py` assigned `zone.fill_mode`, but kipy's `Zone.fill_mode` is a **read-only property** — its getter reads `_proto.copper_settings.fill_mode` and there is no setter, so every IPC `create_zone` call raised `AttributeError`. It hid because kipy isn't installed in a bare dev environment, so mypy typed `Zone` as `Any`; CI installs `requirements.txt` and sees the real type. Fixed by writing through the proto (verified against real kipy that it round-trips and that direct assignment raises), with `tests/test_ipc_zone_fill_mode.py` pinning the upstream no-setter contract.
2. **Two Windows-only test assertions that can never pass on Linux** — a `normcase` case-fold assumption and a hardcoded `\` path separator. Both fixed to simulate Windows semantics properly rather than skipping, so the coverage survives on Linux runners.

## Verification

**CI: 22/22 jobs green — the first successful run in this repository's history.** 1426 passed / 27 skipped on every interpreter (3.9–3.12 × ubuntu-22.04/24.04), plus TypeScript across 4 OSes, Integration Tests against KiCAD 8/9/10, Code Quality, Docker and Docs.

Locally: 1445 passed, 4 skipped with a java shim; `black --check python/` and `mypy python/` clean with kipy installed to match CI.

## Deliberately not included

A `pre-commit run --all-files` step. That hook set (isort/prettier/trailing-whitespace over `tests/`, `src/`, `docs/`) currently rewrites **32 files / 431 lines** of pre-existing drift that `black --check python/` never covered. Landing that now would conflict with most of the 14 open PRs — it should be its own change once the merge queue drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)