### PR TITLE
fix: autoroute no longer times out at 30s (#251)

### DIFF
--- a/src/command-timeout.ts
+++ b/src/command-timeout.ts
@@ -1,0 +1,71 @@
+/**
+ * Per-command timeout policy for the Python worker bridge.
+ *
+ * Kept as a pure function so the policy is unit-testable without spawning a
+ * worker — the same reason `tools/registry.ts` and `tools/tool-response.ts`
+ * are separated out.
+ */
+
+/** Fallback for commands that should answer promptly. */
+export const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+
+/** Blanket allowance for operations that are slow but not caller-tunable. */
+export const LONG_COMMAND_TIMEOUT_MS = 600_000;
+
+/**
+ * Commands whose cost scales with board/schematic size rather than with any
+ * parameter the caller passes.
+ */
+export const LONG_RUNNING_COMMANDS = [
+  "run_drc",
+  "export_gerber",
+  "export_pdf",
+  "export_3d",
+  "sync_schematic_to_board",
+  "list_schematic_nets",
+  "list_schematic_labels",
+  "get_schematic_view",
+] as const;
+
+/**
+ * Extra wall-clock granted to `autoroute` on top of the routing budget the
+ * caller asked for, covering DSN export, JVM start-up per attempt, SES import
+ * and the board save.
+ */
+export const AUTOROUTE_OVERHEAD_MS = 120_000;
+
+/**
+ * How long the Node side waits for `command` before abandoning the request.
+ *
+ * `autoroute` is computed rather than fixed: its Python side takes a
+ * per-attempt `timeout` (seconds, default 300) and repeats it `attempts` times
+ * for best-of-N, so a flat ceiling would still cut off a caller who legitimately
+ * raised either. Under-waiting here is what issue #251 reports — the Node
+ * default fired at 30 s while Freerouting was still working, so the tool
+ * reported failure even though a valid .ses had been written.
+ */
+export function computeCommandTimeout(command: string, params?: unknown): number {
+  if (command === "autoroute") {
+    const p = (params ?? {}) as Record<string, unknown>;
+
+    const perAttemptSec = toPositiveNumber(p.timeout) ?? 300;
+    const attempts = Math.max(1, Math.floor(toPositiveNumber(p.attempts) ?? 1));
+
+    const budgetMs = perAttemptSec * 1000 * attempts + AUTOROUTE_OVERHEAD_MS;
+    // Never drop below the blanket long-running allowance.
+    return Math.max(budgetMs, LONG_COMMAND_TIMEOUT_MS);
+  }
+
+  if ((LONG_RUNNING_COMMANDS as readonly string[]).includes(command)) {
+    return LONG_COMMAND_TIMEOUT_MS;
+  }
+
+  return DEFAULT_COMMAND_TIMEOUT_MS;
+}
+
+/** Finite, positive numbers only; anything else falls back to the default. */
+function toPositiveNumber(value: unknown): number | undefined {
+  const n = typeof value === "string" ? Number(value) : value;
+  if (typeof n !== "number" || !Number.isFinite(n) || n <= 0) return undefined;
+  return n;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { spawn, exec, execSync, ChildProcess } from "child_process";
 import { existsSync, readdirSync } from "fs";
 import { join, dirname } from "path";
 import { logger } from "./logger.js";
+import { computeCommandTimeout, DEFAULT_COMMAND_TIMEOUT_MS } from "./command-timeout.js";
 
 // Import tool registration functions
 import { registerProjectTools } from "./tools/project.js";
@@ -722,21 +723,9 @@ export class KiCADMcpServer {
         return;
       }
 
-      // Determine timeout based on command type
-      // DRC and export operations need longer timeouts for large boards
-      let commandTimeout = 30000; // Default 30 seconds
-      const longRunningCommands = [
-        "run_drc",
-        "export_gerber",
-        "export_pdf",
-        "export_3d",
-        "sync_schematic_to_board",
-        "list_schematic_nets",
-        "list_schematic_labels",
-        "get_schematic_view",
-      ];
-      if (longRunningCommands.includes(command)) {
-        commandTimeout = 600000; // 10 minutes for long operations
+      // Determine timeout based on command type (see src/command-timeout.ts).
+      const commandTimeout = computeCommandTimeout(command, params);
+      if (commandTimeout !== DEFAULT_COMMAND_TIMEOUT_MS) {
         logger.info(`Using extended timeout (${commandTimeout / 1000}s) for command: ${command}`);
       }
 

--- a/tests-ts/command-timeout.test.ts
+++ b/tests-ts/command-timeout.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeCommandTimeout,
+  DEFAULT_COMMAND_TIMEOUT_MS,
+  LONG_COMMAND_TIMEOUT_MS,
+  LONG_RUNNING_COMMANDS,
+  AUTOROUTE_OVERHEAD_MS,
+} from "../src/command-timeout.js";
+
+describe("computeCommandTimeout", () => {
+  it("gives ordinary commands the short default", () => {
+    expect(computeCommandTimeout("get_board_info", {})).toBe(DEFAULT_COMMAND_TIMEOUT_MS);
+    expect(computeCommandTimeout("place_component", { x: 1 })).toBe(DEFAULT_COMMAND_TIMEOUT_MS);
+  });
+
+  it("gives size-bound commands the blanket long allowance", () => {
+    for (const command of LONG_RUNNING_COMMANDS) {
+      expect(computeCommandTimeout(command, {})).toBe(LONG_COMMAND_TIMEOUT_MS);
+    }
+  });
+
+  describe("autoroute (issue #251)", () => {
+    it("is never left on the 30s default", () => {
+      // The regression itself: autoroute was absent from the long-running list,
+      // so Node abandoned the call while Freerouting was still routing and a
+      // valid .ses had been written.
+      const timeout = computeCommandTimeout("autoroute", {});
+      expect(timeout).toBeGreaterThan(DEFAULT_COMMAND_TIMEOUT_MS);
+      expect(timeout).toBeGreaterThanOrEqual(LONG_COMMAND_TIMEOUT_MS);
+    });
+
+    it("covers the caller's own per-attempt budget plus overhead", () => {
+      // 900s per attempt is well past the blanket 600s ceiling.
+      expect(computeCommandTimeout("autoroute", { timeout: 900 })).toBe(
+        900 * 1000 + AUTOROUTE_OVERHEAD_MS,
+      );
+    });
+
+    it("multiplies the budget by attempts for best-of-N", () => {
+      // Python runs `attempts` sequential passes of `timeout` seconds each.
+      expect(computeCommandTimeout("autoroute", { timeout: 300, attempts: 5 })).toBe(
+        300 * 1000 * 5 + AUTOROUTE_OVERHEAD_MS,
+      );
+    });
+
+    it("still waits at least the blanket allowance for small budgets", () => {
+      expect(computeCommandTimeout("autoroute", { timeout: 10 })).toBe(LONG_COMMAND_TIMEOUT_MS);
+    });
+
+    it("falls back to the 300s default when timeout is absent or nonsense", () => {
+      const expected = 300 * 1000 * 3 + AUTOROUTE_OVERHEAD_MS;
+      for (const bad of [undefined, null, 0, -5, NaN, "abc", {}]) {
+        expect(computeCommandTimeout("autoroute", { timeout: bad, attempts: 3 })).toBe(expected);
+      }
+    });
+
+    it("accepts numeric strings, since MCP clients stringify params", () => {
+      expect(computeCommandTimeout("autoroute", { timeout: "900" })).toBe(
+        900 * 1000 + AUTOROUTE_OVERHEAD_MS,
+      );
+    });
+
+    it("treats bad attempts values as a single attempt", () => {
+      const single = computeCommandTimeout("autoroute", { timeout: 900, attempts: 1 });
+      for (const bad of [undefined, 0, -3, NaN, "xyz"]) {
+        expect(computeCommandTimeout("autoroute", { timeout: 900, attempts: bad })).toBe(single);
+      }
+    });
+
+    it("floors fractional attempts rather than inflating the budget", () => {
+      expect(computeCommandTimeout("autoroute", { timeout: 900, attempts: 2.9 })).toBe(
+        computeCommandTimeout("autoroute", { timeout: 900, attempts: 2 }),
+      );
+    });
+
+    it("tolerates a missing params object", () => {
+      expect(computeCommandTimeout("autoroute")).toBe(LONG_COMMAND_TIMEOUT_MS);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #251.

## Problem

`autoroute` was missing from `longRunningCommands` in `src/server.ts`, so the Node bridge abandoned the call after its **30 s default** — while the Python side had already been granted **300 s**. On any board past ~20 nets the tool reported failure even though Freerouting was still running or had already written a valid `.ses`.

The reporter's workaround was to note the `.ses` path, wait for the file to appear, and call `import_ses` by hand.

## Fix

Adding `autoroute` to the fixed 600 s list would be the one-line version, but it would still cut off callers who legitimately need longer. The Python side takes a **per-attempt** `timeout` (seconds, default 300) and repeats it `attempts` times for best-of-N — so `attempts: 5` alone is a 1500 s routing budget against a 600 s ceiling, and `timeout: 900` blows it on a single attempt.

So autoroute's timeout is now derived from the caller's own parameters:

```
attempts × timeout × 1000 + 120 s overhead, floored at the 600 s blanket allowance
```

The overhead covers DSN export, JVM start-up per attempt, SES import and the board save.

The policy moves into `src/command-timeout.ts` as a pure function, so it is unit-testable without spawning a worker — the same reason `tools/registry.ts` and `tools/tool-response.ts` are separated out. **Behaviour for every other command is unchanged**, which the tests pin explicitly.

## Tests

11 new tests in `tests-ts/command-timeout.test.ts`:

- the regression itself — autoroute is never left on the 30 s default
- ordinary commands still get 30 s; every `LONG_RUNNING_COMMANDS` entry still gets exactly 600 s
- budget scales with `timeout` and multiplies by `attempts`
- small budgets still floor at the blanket allowance
- coercion of absent / zero / negative / `NaN` / non-numeric / fractional inputs
- numeric **strings** accepted, since MCP clients stringify params

`npm run build` clean, `npm run test:ts` 35 passed (24 → 35), prettier and eslint clean.

## Not addressed here

The issue also suggests a fire-and-forget job ID with a polling tool, or streaming progress. Those are larger design changes; this fix removes the false-failure symptom, which is what makes the tool unusable today. Worth a separate issue if the async model is still wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)