### PR TITLE
get_board_2d_view: always pass --layers to `pcb export svg` (#235)

### DIFF
--- a/python/commands/board/view.py
+++ b/python/commands/board/view.py
@@ -170,7 +170,17 @@ class BoardViewCommands:
                     "message": f"Unsupported format '{fmt}'. Use 'png', 'jpg', or 'svg'.",
                     "errorDetails": f"Got: {fmt}",
                 }
-            layers: List[str] = params.get("layers", [])
+            # `pcb export svg` requires at least one layer on KiCad 9+ — omitting
+            # it fails with "At least one layer must be specified" and no output.
+            # Default to a readable 2D view (copper + silkscreen + board outline)
+            # when the caller doesn't specify layers.
+            layers: List[str] = params.get("layers") or [
+                "F.Cu",
+                "B.Cu",
+                "F.SilkS",
+                "B.SilkS",
+                "Edge.Cuts",
+            ]
             response_mode = params.get("responseMode", "inline")
 
             kicad_cli = resolve_kicad_cli()

--- a/tests/test_get_board_2d_view_save_to_file.py
+++ b/tests/test_get_board_2d_view_save_to_file.py
@@ -227,3 +227,29 @@ def test_kicad10_export_cmd_uses_file_output_and_mode_single(tmp_path):
     out_idx = argv.index("--output")
     out_arg = argv[out_idx + 1]
     assert out_arg.endswith(".svg")  # a file path, not a directory
+
+
+# ---------------------------------------------------------------------------
+# --layers regression (KiCad 9+ requires at least one layer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_board_svg_export_always_passes_layers(tmp_path):
+    """`pcb export svg` must receive --layers with a non-empty spec even when the
+    caller specifies no layers. KiCad 9+ fails with "At least one layer must be
+    specified" (and writes no file) otherwise."""
+    cmd, root, board_path = _make_view_cmd(tmp_path)
+    fake_result = MagicMock(returncode=0, stderr="", stdout="")
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kicad-cli"),
+        patch("subprocess.run", return_value=fake_result) as run,
+    ):
+        cmd.get_board_2d_view({"pcbPath": str(board_path), "format": "svg"})
+
+    export_calls = [c.args[0] for c in run.call_args_list if c.args and "export" in c.args[0]]
+    assert export_calls, "kicad-cli export was not invoked"
+    argv = export_calls[0]
+    assert "--layers" in argv, f"--layers missing from command: {argv}"
+    assert argv[argv.index("--layers") + 1], "--layers passed with an empty spec"


### PR DESCRIPTION
Fixes #235 (remaining half). Cherry-picked from #277, commit `aa5875d`, **authored by @stefangordon** — authorship is preserved in the commit.

## Why cherry-pick rather than merge #277

#277 has two commits that split cleanly along the approved/blocked line:

- `aa5875d` — the `--layers` fix + a regression test. **Wanted; this PR.**
- `5aeb716` — inserts cairosvg as the priority-1 rasterizer. **Blocked**: cairo's native DLL is absent on a stock Windows install, main is deliberately pymupdf-first (`board/view.py:22`), and `tests/test_cairo_dll_preload_windows.py` exists precisely because this already bit the project.

@stefangordon has been silent since 2026-07-01 across all four of his open PRs, and this half is both correct and blocking two other things: issue #235, and PR #324, which carries a duplicate of this exact edit as a drive-by (I have asked there for it to be dropped in favour of this one — #277's version is better, it also includes `B.SilkS` and comes with the test).

#277 stays open for the cairosvg half to be reworked.

## The bug

`get_board_2d_view` did `params.get("layers", [])` and then `if layers:` before appending `--layers`. With no caller-specified layers, the flag was omitted entirely.

Verified against real KiCad 10.0.0 on a minimal board:

```
$ kicad-cli pcb export svg --output no.svg lc.kicad_pcb
At least one layer must be specified
  -> no file written

$ kicad-cli pcb export svg --layers "F.Cu,B.Cu,F.SilkS,B.SilkS,Edge.Cuts" --output yes.svg lc.kicad_pcb
  -> SVG written
```

So the tool silently produced nothing whenever the caller omitted `layers`.

## The fix

Default to a readable 2D view — copper + both silkscreens + board outline — when the caller specifies none. Caller-supplied layers are unaffected.

Note the cherry-pick resolved cleanly against main's `resolve_kicad_cli()` refactor, which landed after this commit was authored; the surrounding CLI-resolution code is main's, not the PR's.

## Tests

`aa5875d` brings `test_board_svg_export_always_passes_layers`, which asserts `--layers` is present in the argv even when the caller passes none.

Full suite: 1450 passed, 4 skipped. `black --check python/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)