### PR TITLE
Follow-ups from #329: search-tool role distinction + README count self-check

### DIFF
--- a/src/tools/jlcpcb-api.ts
+++ b/src/tools/jlcpcb-api.ts
@@ -82,7 +82,9 @@ force=true to refresh.`,
 Searches the local JLCPCB database (must be downloaded first with download_jlcpcb_database).
 Provides real pricing, stock info, and library type (Basic parts = free assembly).
 
-Use this to find components with exact specifications and cost optimization.`,
+Use this to find components with exact specifications and cost optimization.
+
+For a verified, ready-to-use KiCAD footprint/symbol/3D bundle (rather than sourcing/stock data), use search_parts_registry instead.`,
     {
       query: z
         .string()

--- a/src/tools/parts-registry.ts
+++ b/src/tools/parts-registry.ts
@@ -199,7 +199,7 @@ export function registerPartsRegistryTools(server: McpServer): void {
   server.tool(
     "search_parts_registry",
     `Search an open, gate-verified parts registry for existing KiCAD parts BEFORE
-generating a custom footprint/symbol from scratch.
+generating a custom footprint/symbol from scratch. Complements search_jlcpcb_parts: use that tool for JLCPCB sourcing data (price, stock, assembly tier); use this one to fetch a verified existing footprint/symbol/3D bundle.
 
 Default registry: PartReel (https://partreel.com) — 18k+ verified parts, no auth.
 Override with the PARTREEL_API_BASE environment variable to point at any

--- a/tests-ts/readme-counts.test.ts
+++ b/tests-ts/readme-counts.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { getRegistryStats } from "../src/tools/registry.js";
+
+// The README's headline tool count is hand-maintained prose and has drifted
+// twice (see #329 review). Pin it to the registry so it self-corrects —
+// same trick as tests/test_interface_construction.py uses for schema/route parity.
+describe("README tool counts", () => {
+  it("headline count matches getRegistryStats()", () => {
+    const readme = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "..", "README.md"),
+      "utf-8",
+    );
+    const stats = getRegistryStats();
+    const m = readme.match(/(\d+) tools across (\d+) categories/);
+    expect(m, "README should state 'N tools across M categories'").toBeTruthy();
+    expect(Number(m![1]), "README tool count").toBe(stats.total_tools);
+    expect(Number(m![2]), "README category count").toBe(stats.total_categories);
+  });
+});


### PR DESCRIPTION
The two optional follow-ups you suggested in the #329 post-merge review:

1. **Search-tool disambiguation** — one sentence in each of `search_parts_registry` and `search_jlcpcb_parts` spelling out when to use which: verified existing footprint/symbol/3D bundle vs JLCPCB sourcing data (price, stock, assembly tier). No behavior change.
2. **README count self-check** — `tests-ts/readme-counts.test.ts` asserts the README's headline "N tools across M categories" matches `getRegistryStats()`, so the prose count self-corrects the next time it drifts — the same parity-test trick as `tests/test_interface_construction.py`.

Gates: `tsc` clean, `vitest run` 64/64 (63 existing + 1 new), prettier/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)