### PR TITLE
feat(pcb): import_pcb — wrap kicad-cli's native vendor-PCB importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,19 @@ both sides had green suites that never crossed it.
   resolves a different build per Python version (black >=25.12 requires
   > =3.10, so the 3.9 runner silently got 25.1.0 and disagreed on three files).
 
+### New Features
+
+- **`import_pcb`**: wraps KiCad 10's native `kicad-cli pcb import` so any MCP
+  consumer can convert a vendor PCB file (PADS, Altium, Eagle, CADSTAR,
+  Fabmaster, P-CAD, SolidWorks PCB, or a binary Cadence Allegro `.brd`) into
+  a `.kicad_pcb` file, with an optional structured import report
+  (`reportFormat: "json"|"text"`). Verified against a real 10 MB binary
+  Cadence Allegro `.brd` (581 footprints, thousands of net occurrences).
+  Binary Allegro `.brd` files must use `format: "auto"` — the CLI's
+  `--format` enum has no `"allegro"` literal, auto-detection by magic is the
+  only supported path. This tool imports PCB/layout data only; kicad-cli has
+  no Concept HDL / OrCAD schematic importer.
+
 ### Bug Fixes
 
 - **Saving to the board's own path was silently treated as a Save As, and

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 https://github.com/mixelpixx/arduino-ide
 
+## What's New (Unreleased)
+
+### Vendor PCB import
+
+- `import_pcb` wraps KiCad 10's native `kicad-cli pcb import` to convert a
+  vendor PCB file — PADS, Altium, Eagle, CADSTAR, Fabmaster, P-CAD,
+  SolidWorks PCB, or a binary Cadence Allegro `.brd` — into a `.kicad_pcb`
+  file. Use `format: "auto"` for binary Cadence Allegro `.brd` files: the CLI
+  auto-detects the Allegro binary format by magic and reports it on stdout
+  (there is no `"allegro"` literal in the `--format` enum — passing one
+  errors). Optionally pass `reportFormat: "json"` or `"text"` to capture
+  kicad-cli's structured import report (layer mapping, warnings, errors) in
+  the result. **PCB/layout data only** — kicad-cli has no importer for
+  Cadence Concept HDL / OrCAD Capture schematics, so this tool never produces
+  a schematic.
+
 ## What's New in v2.5.0
 
 ### 20 new board-lifecycle and geometry tools

--- a/python/commands/pcb_import.py
+++ b/python/commands/pcb_import.py
@@ -1,0 +1,132 @@
+"""
+Vendor PCB → KiCad (.kicad_pcb) import via KiCad 10's native ``kicad-cli pcb import``.
+
+KiCad 10.0 ships built-in importers for several non-KiCad PCB formats (PADS,
+Altium, Eagle, CADSTAR, Fabmaster, P-CAD, SolidWorks PCB, plus binary Cadence
+Allegro ``.brd`` files detected via ``--format auto``). This module exposes a
+single MCP command, ``import_pcb``, that shells out to that CLI subcommand.
+
+GOTCHA: the ``--format`` enum accepted by kicad-cli is
+``auto|pads|altium|eagle|cadstar|fabmaster|pcad|solidworks`` — there is no
+"allegro"/"cadence"/"brd" literal. Binary Cadence Allegro ``.brd`` files MUST
+be imported with ``--format auto`` (kicad-cli auto-detects Allegro's binary
+magic and reports "using Allegro format" on stdout); passing an explicit
+``--format allegro`` errors with "Invalid format: allegro".
+
+This only imports PCB/layout data. kicad-cli has no schematic-side importer
+for Cadence Concept HDL / OrCAD Capture schematics — only the PCB half of a
+proprietary-format board round-trips through this tool.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("kicad_interface")
+
+# Formats accepted by `kicad-cli pcb import --format`.
+VALID_FORMATS = {"auto", "pads", "altium", "eagle", "cadstar", "fabmaster", "pcad", "solidworks"}
+VALID_REPORT_FORMATS = {"none", "json", "text"}
+
+_USING_FORMAT_RE = re.compile(r"using (\S+) format", re.IGNORECASE)
+
+
+class PcbImportCommands:
+    """Handles the `import_pcb` MCP command (kicad-cli pcb import wrapper)."""
+
+    def __init__(self) -> None:
+        from utils.kicad_cli import resolve_kicad_cli
+
+        self._kicad_cli = resolve_kicad_cli()
+
+    def import_pcb(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Convert a vendor PCB file to a KiCad `.kicad_pcb` file.
+
+        Params
+        ------
+        inputFile    : path to the vendor board file (required)
+        outputFile   : destination .kicad_pcb path   (optional; defaults beside inputFile)
+        format       : auto|pads|altium|eagle|cadstar|fabmaster|pcad|solidworks (optional; default "auto")
+        reportFormat : none|json|text                (optional; default "none")
+        """
+        from utils.kicad_cli import kicad_cli_not_found_message
+
+        input_file: Optional[str] = params.get("inputFile")
+        output_file: Optional[str] = params.get("outputFile")
+        fmt: str = params.get("format") or "auto"
+        report_format: str = params.get("reportFormat") or "none"
+
+        if not input_file:
+            return {"success": False, "error": "inputFile is required"}
+        if not os.path.exists(input_file):
+            return {"success": False, "error": f"inputFile not found: {input_file}"}
+        if fmt not in VALID_FORMATS:
+            return {
+                "success": False,
+                "error": f"Invalid format: {fmt!r}. Must be one of {sorted(VALID_FORMATS)}",
+            }
+        if report_format not in VALID_REPORT_FORMATS:
+            return {
+                "success": False,
+                "error": f"Invalid reportFormat: {report_format!r}. Must be one of {sorted(VALID_REPORT_FORMATS)}",
+            }
+
+        cli = self._kicad_cli
+        if not cli:
+            return {"success": False, "error": kicad_cli_not_found_message()}
+
+        if not output_file:
+            input_stem = os.path.splitext(os.path.basename(input_file))[0]
+            output_file = os.path.join(os.path.dirname(os.path.abspath(input_file)), input_stem + ".kicad_pcb")
+
+        report_file: Optional[str] = None
+        if report_format != "none":
+            report_file = output_file + ".import-report." + ("json" if report_format == "json" else "txt")
+
+        cmd = [cli, "pcb", "import", "--format", fmt, "-o", output_file]
+        if report_format != "none":
+            cmd += ["--report-format", report_format, "--report-file", report_file]
+        cmd.append(input_file)
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+        except Exception as e:  # noqa: BLE001 - surface subprocess failures as tool errors
+            return {"success": False, "error": str(e)}
+
+        if result.returncode != 0 or not os.path.exists(output_file):
+            return {
+                "success": False,
+                "error": result.stderr.strip() or result.stdout.strip() or "kicad-cli exited non-zero",
+            }
+
+        detected_format = fmt
+        match = _USING_FORMAT_RE.search(result.stdout or "")
+        if match:
+            detected_format = match.group(1)
+
+        response: Dict[str, Any] = {
+            "success": True,
+            "outputFile": output_file,
+            "format": detected_format,
+        }
+
+        if report_file:
+            try:
+                with open(report_file, "r", encoding="utf-8", errors="replace") as fh:
+                    response["report"] = fh.read()
+            except OSError as e:
+                logger.warning("Could not read import report %s: %s", report_file, e)
+                response["report"] = None
+            finally:
+                try:
+                    if os.path.exists(report_file):
+                        os.remove(report_file)
+                except OSError:
+                    pass
+
+        return response

--- a/python/commands/pcb_import.py
+++ b/python/commands/pcb_import.py
@@ -82,14 +82,19 @@ class PcbImportCommands:
 
         if not output_file:
             input_stem = os.path.splitext(os.path.basename(input_file))[0]
-            output_file = os.path.join(os.path.dirname(os.path.abspath(input_file)), input_stem + ".kicad_pcb")
+            output_file = os.path.join(
+                os.path.dirname(os.path.abspath(input_file)), input_stem + ".kicad_pcb"
+            )
 
         report_file: Optional[str] = None
         if report_format != "none":
-            report_file = output_file + ".import-report." + ("json" if report_format == "json" else "txt")
+            report_file = (
+                output_file + ".import-report." + ("json" if report_format == "json" else "txt")
+            )
 
         cmd = [cli, "pcb", "import", "--format", fmt, "-o", output_file]
         if report_format != "none":
+            assert report_file is not None  # set above under the same condition
             cmd += ["--report-format", report_format, "--report-file", report_file]
         cmd.append(input_file)
 
@@ -101,7 +106,9 @@ class PcbImportCommands:
         if result.returncode != 0 or not os.path.exists(output_file):
             return {
                 "success": False,
-                "error": result.stderr.strip() or result.stdout.strip() or "kicad-cli exited non-zero",
+                "error": result.stderr.strip()
+                or result.stdout.strip()
+                or "kicad-cli exited non-zero",
             }
 
         detected_format = fmt

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -331,6 +331,7 @@ try:
     from commands.export import ExportCommands
     from commands.footprint import FootprintCreator
     from commands.freerouting import FreeroutingCommands
+    from commands.pcb_import import PcbImportCommands
     from commands.jlcpcb import JLCPCBClient, test_jlcpcb_connection
     from commands.jlcpcb_parts import JLCPCBPartsManager
     from commands.library import (
@@ -412,6 +413,7 @@ class KiCADInterface(SchematicHandlersMixin):
         self.eagle_commands = EagleCommands()
         self.symbol_schematic_commands = SymbolSchematicCommands()
         self.library_management_commands = LibraryManagementCommands()
+        self.pcb_import_commands = PcbImportCommands()
         self.design_rule_commands = DesignRuleCommands(self.board)
         self.export_commands = ExportCommands(self.board)
         self.library_commands = LibraryCommands(self.footprint_library)
@@ -680,6 +682,8 @@ class KiCADInterface(SchematicHandlersMixin):
             "import_symbol": self.library_management_commands.import_symbol,
             "export_symbol": self.library_management_commands.export_symbol,
             "rename_symbol": self.library_management_commands.rename_symbol,
+            # Vendor PCB import (kicad-cli pcb import wrapper)
+            "import_pcb": self.pcb_import_commands.import_pcb,
         }
 
         logger.info(f"KiCAD interface initialized (backend: {'IPC' if self.use_ipc else 'SWIG'})")

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -331,7 +331,6 @@ try:
     from commands.export import ExportCommands
     from commands.footprint import FootprintCreator
     from commands.freerouting import FreeroutingCommands
-    from commands.pcb_import import PcbImportCommands
     from commands.jlcpcb import JLCPCBClient, test_jlcpcb_connection
     from commands.jlcpcb_parts import JLCPCBPartsManager
     from commands.library import (
@@ -341,6 +340,7 @@ try:
     from commands.library_management import LibraryManagementCommands
     from commands.library_schematic import LibraryManager as SchematicLibraryManager
     from commands.library_symbol import SymbolLibraryCommands, SymbolLibraryManager
+    from commands.pcb_import import PcbImportCommands
     from commands.project import ProjectCommands
     from commands.routing import RoutingCommands
     from commands.schematic import SchematicManager

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,7 @@ import { registerSymbolCreatorTools } from "./tools/symbol-creator.js";
 import { registerUITools } from "./tools/ui.js";
 import { registerFreeroutingTools } from "./tools/freerouting.js";
 import { registerEagleTools } from "./tools/eagle.js";
+import { registerPcbImportTools } from "./tools/pcb-import.js";
 import { registerRouterTools } from "./tools/router.js";
 
 // Import resource registration functions
@@ -313,6 +314,7 @@ export class KiCADMcpServer {
     registerUITools(this.server, this.callKicadScript.bind(this));
     registerFreeroutingTools(this.server, this.callKicadScript.bind(this));
     registerEagleTools(this.server, this.callKicadScript.bind(this));
+    registerPcbImportTools(this.server, this.callKicadScript.bind(this));
 
     // Register all resources
     registerProjectResources(this.server, this.callKicadScript.bind(this));

--- a/src/tools/pcb-import.ts
+++ b/src/tools/pcb-import.ts
@@ -1,0 +1,42 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+export function registerPcbImportTools(server: McpServer, callKicadScript: Function) {
+  server.tool(
+    "import_pcb",
+    "Import a vendor PCB file (PADS, Altium, Eagle, CADSTAR, Fabmaster, P-CAD, SolidWorks PCB, " +
+      "or a binary Cadence Allegro .brd) and convert it to a KiCad .kicad_pcb file via kicad-cli's " +
+      "native pcb importer. Binary Cadence Allegro .brd files must use format 'auto' (kicad-cli " +
+      "auto-detects the Allegro binary format; there is no 'allegro' format literal). This only " +
+      "imports PCB/layout data — it does not import schematics.",
+    {
+      inputFile: z.string().describe("Absolute path to the vendor PCB file to import"),
+      outputFile: z
+        .string()
+        .optional()
+        .describe("Destination .kicad_pcb path (defaults beside inputFile, same basename)"),
+      format: z
+        .enum(["auto", "pads", "altium", "eagle", "cadstar", "fabmaster", "pcad", "solidworks"])
+        .optional()
+        .describe(
+          "Input format hint (default 'auto'). Use 'auto' for binary Cadence Allegro .brd files — " +
+            "there is no 'allegro' literal in this enum.",
+        ),
+      reportFormat: z
+        .enum(["none", "json", "text"])
+        .optional()
+        .describe("Capture a structured import report from kicad-cli (default 'none')"),
+    },
+    async (args: { inputFile: string; outputFile?: string; format?: string; reportFormat?: string }) => {
+      const result = await callKicadScript("import_pcb", args);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/pcb-import.ts
+++ b/src/tools/pcb-import.ts
@@ -27,7 +27,12 @@ export function registerPcbImportTools(server: McpServer, callKicadScript: Funct
         .optional()
         .describe("Capture a structured import report from kicad-cli (default 'none')"),
     },
-    async (args: { inputFile: string; outputFile?: string; format?: string; reportFormat?: string }) => {
+    async (args: {
+      inputFile: string;
+      outputFile?: string;
+      format?: string;
+      reportFormat?: string;
+    }) => {
       const result = await callKicadScript("import_pcb", args);
       return {
         content: [

--- a/tests/test_pcb_import.py
+++ b/tests/test_pcb_import.py
@@ -1,0 +1,209 @@
+"""Tests for vendor PCB import (commands/pcb_import.py — kicad-cli pcb import wrapper)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.pcb_import import PcbImportCommands  # noqa: E402
+from utils.kicad_cli import resolve_kicad_cli  # noqa: E402
+
+# Gate cli-dependent tests on the same resolver the importer uses, so they run
+# on any discoverable install, not only a hardcoded path.
+_KICAD_CLI = resolve_kicad_cli()
+
+_ALLEGRO_BRD = Path(
+    "/home/cycix/Desktop/fai-tuner/golden-box/pfdsc_carrier/references/"
+    "PolarFire_SoC_Discovery_Kit_Rev2_23_0954_PCB_091923.brd"
+)
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _make_commands(tmp_path: Path, cli: str = "/usr/bin/kicad-cli") -> PcbImportCommands:
+    """Build a PcbImportCommands with a fixed fake CLI path (bypasses resolver)."""
+    pic = PcbImportCommands.__new__(PcbImportCommands)
+    pic._kicad_cli = cli
+    return pic
+
+
+def test_missing_input_file_is_required() -> None:
+    pic = _make_commands(Path("."))
+    result = pic.import_pcb({})
+    assert result["success"] is False
+    assert "inputFile is required" in result["error"]
+
+
+def test_input_file_not_found(tmp_path: Path) -> None:
+    pic = _make_commands(tmp_path)
+    missing = tmp_path / "does_not_exist.brd"
+    result = pic.import_pcb({"inputFile": str(missing)})
+    assert result["success"] is False
+    assert "not found" in result["error"]
+
+
+def test_invalid_format_rejected_client_side(tmp_path: Path) -> None:
+    input_file = tmp_path / "board.brd"
+    input_file.write_bytes(b"fake")
+    pic = _make_commands(tmp_path)
+    result = pic.import_pcb({"inputFile": str(input_file), "format": "allegro"})
+    assert result["success"] is False
+    assert "Invalid format" in result["error"]
+
+
+def test_invalid_report_format_rejected_client_side(tmp_path: Path) -> None:
+    input_file = tmp_path / "board.brd"
+    input_file.write_bytes(b"fake")
+    pic = _make_commands(tmp_path)
+    result = pic.import_pcb({"inputFile": str(input_file), "reportFormat": "xml"})
+    assert result["success"] is False
+    assert "Invalid reportFormat" in result["error"]
+
+
+def test_default_format_is_auto_and_output_path_derived(tmp_path: Path) -> None:
+    input_file = tmp_path / "board.brd"
+    input_file.write_bytes(b"fake")
+    expected_out = tmp_path / "board.kicad_pcb"
+    pic = _make_commands(tmp_path)
+
+    def fake_run(cmd, capture_output, text, timeout):
+        # Simulate kicad-cli producing the output file.
+        Path(cmd[cmd.index("-o") + 1]).write_text("(kicad_pcb)")
+        return _FakeCompletedProcess(
+            returncode=0,
+            stdout=f"Importing '{input_file}' using Allegro format...\nSuccessfully saved imported board.",
+        )
+
+    with patch("commands.pcb_import.subprocess.run", side_effect=fake_run) as mock_run:
+        result = pic.import_pcb({"inputFile": str(input_file)})
+
+    cmd = mock_run.call_args.args[0]
+    assert cmd[0] == "/usr/bin/kicad-cli"
+    assert cmd[1:3] == ["pcb", "import"]
+    assert "--format" in cmd
+    assert cmd[cmd.index("--format") + 1] == "auto"
+    assert cmd[-1] == str(input_file)
+    assert cmd[cmd.index("-o") + 1] == str(expected_out)
+
+    assert result["success"] is True
+    assert result["outputFile"] == str(expected_out)
+    # Detected format is parsed from the "using X format" stdout phrase.
+    assert result["format"] == "Allegro"
+
+
+def test_explicit_format_passed_through(tmp_path: Path) -> None:
+    input_file = tmp_path / "board.pcb"
+    input_file.write_bytes(b"fake")
+    pic = _make_commands(tmp_path)
+
+    def fake_run(cmd, capture_output, text, timeout):
+        Path(cmd[cmd.index("-o") + 1]).write_text("(kicad_pcb)")
+        return _FakeCompletedProcess(returncode=0, stdout="Importing using PADS format...")
+
+    with patch("commands.pcb_import.subprocess.run", side_effect=fake_run) as mock_run:
+        result = pic.import_pcb({"inputFile": str(input_file), "format": "pads"})
+
+    cmd = mock_run.call_args.args[0]
+    assert cmd[cmd.index("--format") + 1] == "pads"
+    assert result["success"] is True
+
+
+def test_explicit_output_file_used(tmp_path: Path) -> None:
+    input_file = tmp_path / "board.brd"
+    input_file.write_bytes(b"fake")
+    custom_out = tmp_path / "nested" / "custom.kicad_pcb"
+    pic = _make_commands(tmp_path)
+
+    def fake_run(cmd, capture_output, text, timeout):
+        out = Path(cmd[cmd.index("-o") + 1])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text("(kicad_pcb)")
+        return _FakeCompletedProcess(returncode=0, stdout="using Allegro format")
+
+    with patch("commands.pcb_import.subprocess.run", side_effect=fake_run):
+        result = pic.import_pcb({"inputFile": str(input_file), "outputFile": str(custom_out)})
+
+    assert result["outputFile"] == str(custom_out)
+
+
+def test_report_format_requests_report_and_captures_contents(tmp_path: Path) -> None:
+    input_file = tmp_path / "board.brd"
+    input_file.write_bytes(b"fake")
+    pic = _make_commands(tmp_path)
+
+    def fake_run(cmd, capture_output, text, timeout):
+        Path(cmd[cmd.index("-o") + 1]).write_text("(kicad_pcb)")
+        report_file = Path(cmd[cmd.index("--report-file") + 1])
+        report_file.write_text('{"errors": []}')
+        return _FakeCompletedProcess(returncode=0, stdout="using Allegro format")
+
+    with patch("commands.pcb_import.subprocess.run", side_effect=fake_run) as mock_run:
+        result = pic.import_pcb({"inputFile": str(input_file), "reportFormat": "json"})
+
+    cmd = mock_run.call_args.args[0]
+    assert "--report-format" in cmd
+    assert cmd[cmd.index("--report-format") + 1] == "json"
+    assert "--report-file" in cmd
+    assert result["success"] is True
+    assert result["report"] == '{"errors": []}'
+    # The temp report file is cleaned up after being read.
+    report_file = Path(cmd[cmd.index("--report-file") + 1])
+    assert not report_file.exists()
+
+
+def test_kicad_cli_stderr_surfaced_on_failure(tmp_path: Path) -> None:
+    input_file = tmp_path / "board.brd"
+    input_file.write_bytes(b"fake")
+    pic = _make_commands(tmp_path)
+
+    def fake_run(cmd, capture_output, text, timeout):
+        return _FakeCompletedProcess(returncode=1, stderr="Invalid format: allegro")
+
+    with patch("commands.pcb_import.subprocess.run", side_effect=fake_run):
+        result = pic.import_pcb({"inputFile": str(input_file)})
+
+    assert result["success"] is False
+    assert "Invalid format: allegro" in result["error"]
+
+
+def test_kicad_cli_not_found() -> None:
+    pic = _make_commands(Path("."), cli=None)  # type: ignore[arg-type]
+    input_file_holder = Path(__file__)  # any existing file works for the exists() check
+    result = pic.import_pcb({"inputFile": str(input_file_holder)})
+    assert result["success"] is False
+    assert "kicad-cli" in result["error"].lower()
+
+
+# ── Real-file integration test ──────────────────────────────────────────────
+# Runs the actual `kicad-cli pcb import` against a real binary Cadence Allegro
+# .brd reference board when both preconditions hold: the fixture file exists
+# on disk and kicad-cli is resolvable. Skips cleanly otherwise so this suite
+# is portable across machines that don't have the (large, non-repo) fixture.
+@pytest.mark.skipif(_KICAD_CLI is None, reason="KiCad CLI not installed")
+@pytest.mark.skipif(not _ALLEGRO_BRD.exists(), reason="Allegro reference .brd fixture not present")
+@pytest.mark.integration
+def test_real_allegro_brd_import(tmp_path: Path) -> None:
+    pic = PcbImportCommands()
+    out_file = tmp_path / "discovery_kit.kicad_pcb"
+
+    result = pic.import_pcb({"inputFile": str(_ALLEGRO_BRD), "format": "auto", "outputFile": str(out_file)})
+
+    assert result["success"] is True, result
+    assert result["format"].lower() == "allegro"
+    assert out_file.exists()
+    # A trivial/empty import would be a handful of bytes; a real 581-footprint
+    # board is megabytes of S-expression data.
+    assert out_file.stat().st_size > 100_000
+    text = out_file.read_text(encoding="utf-8", errors="replace")
+    assert "(footprint" in text
+    assert "(net " in text

--- a/tests/test_pcb_import.py
+++ b/tests/test_pcb_import.py
@@ -196,7 +196,9 @@ def test_real_allegro_brd_import(tmp_path: Path) -> None:
     pic = PcbImportCommands()
     out_file = tmp_path / "discovery_kit.kicad_pcb"
 
-    result = pic.import_pcb({"inputFile": str(_ALLEGRO_BRD), "format": "auto", "outputFile": str(out_file)})
+    result = pic.import_pcb(
+        {"inputFile": str(_ALLEGRO_BRD), "format": "auto", "outputFile": str(out_file)}
+    )
 
     assert result["success"] is True, result
     assert result["format"].lower() == "allegro"


### PR DESCRIPTION
Part of splitting #314 into à la carte pieces, as offered in the thread. Rebased on v2.5.0; `pre-commit run --all-files` is green (black/isort/prettier/flake8/mypy/eslint) and CI-clean.

## What
`import_pcb` wraps KiCad 10's native `kicad-cli pcb import` to convert a vendor PCB (PADS, Altium, Eagle, CADSTAR, Fabmaster, P-CAD, SolidWorks, or a binary Cadence Allegro `.brd`) into `.kicad_pcb`. `format: "auto"` lets the CLI magic-detect the Allegro binary format (there is no `"allegro"` enum literal). Optional `reportFormat: "json"|"text"` captures the structured import report. **PCB/layout only** — kicad-cli has no schematic importer, so it never produces a schematic.

## Notes
- 2 commits: the tool + its tests (`tests/test_pcb_import.py`, 11 tests covering argv construction, output derivation, and error paths).
- Self-contained; touches only the pcb-import files plus the registration hooks (dispatch dict, schema, registry).

---

**Note on round-tripping imported boards (upstream, not this wrapper):** on KiCad 10.0.4, a board produced by `kicad-cli pcb import` is written in a newer file format (`20260206`) that the same 10.0.4 loader (`kicad-cli pcb drc`/`export`, `pcbnew.LoadBoard`) declines to reload. This reproduces with a **direct** `kicad-cli pcb import` call bypassing this tool entirely, so it's a KiCad importer/loader version gap rather than anything this wrapper does — `import_pcb` faithfully passes through and returns exactly what kicad-cli produces (verified: 22 footprints / 58 pads on a real Eagle board, byte-identical to the direct call). The imported board opens fine in the KiCad 10 GUI.