### PR TITLE
fix(project): preserve .kicad_pro net_settings + add board-origin tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 **Key Capabilities:**
 
-- 143 tools across 13 categories with JSON Schema validation
+- 145 tools across 13 categories with JSON Schema validation
 - Smart tool discovery with router pattern (reduces AI context by 70%)
 - 8 dynamic resources exposing project state
 - Complete schematic workflow with 27 tools and dynamic symbol loading (~10,000 symbols)

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -87,6 +87,24 @@ AttributeError: 'BOARD' object has no attribute 'LT_USER'
 
 ---
 
+### 6. `.kicad_pro` net_settings Must Be Edited via JSON Merge
+
+**Status:** BY DESIGN (guard added)
+
+Backend board saves are wrapped in `preserve_project_settings()`
+(`python/utils/project_settings_guard.py`): pcbnew serializes a possibly
+stale in-memory project model over `.kicad_pro` on every
+`SaveBoard`/`BOARD.Save`, so the guard restores the on-disk
+`net_settings` (and any dropped top-level keys) after each save.
+
+**Implication:** commands must persist net class / netclass_patterns
+changes via direct JSON read-modify-write of the `.kicad_pro` (the
+`persist_netclass_to_project` pattern in `python/commands/routing.py`),
+never through the pcbnew project model — model-side changes to
+`net_settings` are intentionally reverted by the guard.
+
+---
+
 ## Recently Fixed (v2.2.0 - v2.2.3)
 
 ### B.Cu Footprint Routing (Fixed v2.2.3)

--- a/python/commands/board/origin.py
+++ b/python/commands/board/origin.py
@@ -1,0 +1,144 @@
+"""Board origin commands: set/get the auxiliary (drill/place) and grid origins.
+
+The aux origin is the datum consumed by export_drill's drillOrigin:"plot"
+option and by plot exports' useAuxOrigin, but nothing in the backend could
+set it headlessly. File-based (LoadBoard -> mutate -> SaveBoard), following
+the hierarchical_place pattern: pcbnew is imported inside the handler so the
+module loads without KiCad installed.
+"""
+
+import logging
+import os
+from typing import Any, Dict
+
+logger = logging.getLogger("kicad_interface")
+
+_UNIT_FACTORS = {
+    "mm": 1000000,
+    "mil": 25400,
+    "inch": 25400000,
+}
+
+_VALID_TYPES = ("aux", "grid", "both")
+
+
+class BoardOriginCommands:
+    """File-based handlers for the board's aux/grid origins."""
+
+    def set_board_origin(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Set the auxiliary (drill/place) origin and/or grid origin of a
+        .kicad_pcb via BOARD_DESIGN_SETTINGS and save the board."""
+        try:
+            board_path = params.get("boardPath")
+            if not board_path:
+                return {"success": False, "message": "boardPath is required"}
+            if not os.path.isfile(board_path):
+                return {
+                    "success": False,
+                    "message": f"Board file not found: {board_path}",
+                }
+
+            origin_type = params.get("type", "aux")
+            if origin_type not in _VALID_TYPES:
+                return {
+                    "success": False,
+                    "message": f"type must be one of: {', '.join(_VALID_TYPES)}",
+                }
+
+            x = params.get("x")
+            y = params.get("y")
+            if x is None or y is None:
+                return {"success": False, "message": "x and y are required"}
+            try:
+                x = float(x)
+                y = float(y)
+            except (TypeError, ValueError):
+                return {"success": False, "message": "x and y must be numeric"}
+
+            unit = params.get("unit", "mm")
+            if unit not in _UNIT_FACTORS:
+                return {
+                    "success": False,
+                    "message": f"unit must be one of: {', '.join(_UNIT_FACTORS)}",
+                }
+            factor = _UNIT_FACTORS[unit]
+
+            try:
+                import pcbnew
+            except ImportError as e:
+                return {"success": False, "message": f"pcbnew not available: {e}"}
+
+            from utils.project_settings_guard import preserve_project_settings
+
+            vec = pcbnew.VECTOR2I(int(round(x * factor)), int(round(y * factor)))
+            board = pcbnew.LoadBoard(board_path)
+            settings = board.GetDesignSettings()
+            if origin_type in ("aux", "both"):
+                settings.SetAuxOrigin(vec)
+            if origin_type in ("grid", "both"):
+                settings.SetGridOrigin(vec)
+            with preserve_project_settings(board_path):
+                pcbnew.SaveBoard(board_path, board)
+
+            x_mm = vec.x / 1000000.0
+            y_mm = vec.y / 1000000.0
+            label = {"aux": "aux origin", "grid": "grid origin", "both": "aux and grid origins"}[
+                origin_type
+            ]
+            logger.info(f"Set {label} to ({x_mm}, {y_mm}) mm in {board_path}")
+            return {
+                "success": True,
+                "message": (
+                    f"Set {label} to ({x_mm}, {y_mm}) mm in "
+                    f"{os.path.basename(board_path)}. Note: if this board is "
+                    f"open in the KiCad GUI, a later GUI save will overwrite "
+                    f"this file-based edit."
+                ),
+                "origin": {"type": origin_type, "x": x_mm, "y": y_mm, "unit": "mm"},
+            }
+        except Exception as e:
+            import traceback
+
+            logger.error(f"set_board_origin failed: {e}")
+            return {
+                "success": False,
+                "message": f"set_board_origin failed: {e}",
+                "errorDetails": traceback.format_exc(),
+            }
+
+    def get_board_origin(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Read back the aux and grid origins of a .kicad_pcb in mm."""
+        try:
+            board_path = params.get("boardPath")
+            if not board_path:
+                return {"success": False, "message": "boardPath is required"}
+            if not os.path.isfile(board_path):
+                return {
+                    "success": False,
+                    "message": f"Board file not found: {board_path}",
+                }
+
+            try:
+                import pcbnew
+            except ImportError as e:
+                return {"success": False, "message": f"pcbnew not available: {e}"}
+
+            board = pcbnew.LoadBoard(board_path)
+            settings = board.GetDesignSettings()
+            aux = settings.GetAuxOrigin()
+            grid = settings.GetGridOrigin()
+            return {
+                "success": True,
+                "aux": {"x": aux.x / 1000000.0, "y": aux.y / 1000000.0},
+                "grid": {"x": grid.x / 1000000.0, "y": grid.y / 1000000.0},
+                "unit": "mm",
+            }
+        except Exception as e:
+            import traceback
+
+            logger.error(f"get_board_origin failed: {e}")
+            return {
+                "success": False,
+                "message": f"get_board_origin failed: {e}",
+                "errorDetails": traceback.format_exc(),
+            }

--- a/python/commands/freerouting.py
+++ b/python/commands/freerouting.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from utils.project_netclasses import apply_net_classes_to_board, load_project_net_classes
+from utils.project_settings_guard import preserve_project_settings
 
 logger = logging.getLogger("kicad_interface")
 
@@ -645,7 +646,8 @@ class FreeroutingCommands:
 
         # Step 4: Save board
         try:
-            self.board.Save(board_path)
+            with preserve_project_settings(board_path):
+                self.board.Save(board_path)
         except Exception as e:
             logger.warning(f"Board save after autoroute failed: {e}")
 
@@ -842,7 +844,8 @@ class FreeroutingCommands:
         board_path = params.get("boardPath") or self.board.GetFileName()
         if board_path:
             try:
-                self.board.Save(board_path)
+                with preserve_project_settings(board_path):
+                    self.board.Save(board_path)
             except Exception as e:
                 logger.warning(f"Board save after SES import failed: {e}")
 

--- a/python/commands/project.py
+++ b/python/commands/project.py
@@ -10,6 +10,11 @@ from typing import Any, Dict, Optional
 
 import pcbnew  # type: ignore
 from utils.kicad_project import write_kicad_pro
+from utils.project_settings_guard import (
+    preserve_project_settings,
+    restore_project_file_if_changed,
+    snapshot_project_file,
+)
 
 logger = logging.getLogger("kicad_interface")
 
@@ -195,8 +200,13 @@ class ProjectCommands:
             else:
                 board_path = filename
 
-            # Load the board
+            # Load the board. Opening is a read operation: some KiCad builds
+            # rewrite the sibling .kicad_pro during/after LoadBoard from a
+            # stale in-memory project model, dropping hand-edited
+            # net_settings — snapshot and restore it verbatim if it changed.
+            pro_snapshot = snapshot_project_file(board_path)
             board = pcbnew.LoadBoard(board_path)
+            restore_project_file_if_changed(board_path, pro_snapshot)
             self.board = board
 
             return {
@@ -251,8 +261,11 @@ class ProjectCommands:
 
             # Save first, then switch the in-memory identity. A failed Save As
             # must not leave the BOARD claiming to own a destination that was
-            # never written successfully.
-            saved = pcbnew.SaveBoard(save_filename, self.board)
+            # never written successfully. Guarded: SaveBoard serializes project
+            # settings from a possibly stale model — preserve .kicad_pro
+            # net_settings around the write.
+            with preserve_project_settings(save_filename):
+                saved = pcbnew.SaveBoard(save_filename, self.board)
             if saved is False:
                 return {
                     "success": False,

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -25,8 +25,8 @@ from commands.schematic import SchematicManager
 from commands.wire_manager import WireManager
 from utils.interactive_schematic import reload_kicad_schematic
 from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
-from utils.sexpr_format import dumps as kicad_dumps
 from utils.project_settings_guard import preserve_project_settings
+from utils.sexpr_format import dumps as kicad_dumps
 
 logger = logging.getLogger("kicad_interface")
 

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -26,6 +26,7 @@ from commands.wire_manager import WireManager
 from utils.interactive_schematic import reload_kicad_schematic
 from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
 from utils.sexpr_format import dumps as kicad_dumps
+from utils.project_settings_guard import preserve_project_settings
 
 logger = logging.getLogger("kicad_interface")
 
@@ -2770,7 +2771,8 @@ class SchematicHandlersMixin:
                     else:
                         unmatched.append(f"{ref}/{pad_num}")
 
-            board.Save(board_path)
+            with preserve_project_settings(board_path):
+                board.Save(board_path)
 
             # If board was loaded fresh, update internal reference
             if params.get("boardPath"):

--- a/python/kicad_api/ipc_backend.py
+++ b/python/kicad_api/ipc_backend.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from kicad_api.base import APINotAvailableError, BoardAPI, ConnectionError, KiCADBackend
+from utils.project_settings_guard import preserve_project_settings
 
 logger = logging.getLogger(__name__)
 
@@ -776,7 +777,8 @@ class IPCBoardAPI(BoardAPI):
             pcb_board.Add(loaded_fp)
 
             # Save the board so IPC can see the changes
-            pcbnew.SaveBoard(board_path, pcb_board)
+            with preserve_project_settings(board_path):
+                pcbnew.SaveBoard(board_path, pcb_board)
 
             # Refresh IPC view
             try:

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -324,6 +324,7 @@ try:
     from commands.add_library_symbol_property import add_library_symbol_property
     from commands.add_symbol_property import add_symbol_property
     from commands.board import BoardCommands
+    from commands.board.origin import BoardOriginCommands
     from commands.component import ComponentCommands
     from commands.connection_schematic import ConnectionManager
     from commands.datasheet_manager import DatasheetManager
@@ -407,6 +408,7 @@ class KiCADInterface(SchematicHandlersMixin):
         # Initialize command handlers
         self.project_commands = ProjectCommands(self.board)
         self.board_commands = BoardCommands(self.board)
+        self.board_origin_commands = BoardOriginCommands()
         self.component_commands = ComponentCommands(self.board, self.footprint_library)
         self.routing_commands = RoutingCommands(self.board)
         self.freerouting_commands = FreeroutingCommands(self.board)
@@ -460,6 +462,8 @@ class KiCADInterface(SchematicHandlersMixin):
             "get_project_info": self.project_commands.get_project_info,
             # Board commands
             "set_board_size": self.board_commands.set_board_size,
+            "set_board_origin": self.board_origin_commands.set_board_origin,
+            "get_board_origin": self.board_origin_commands.get_board_origin,
             "add_layer": self.board_commands.add_layer,
             "set_active_layer": self.board_commands.set_active_layer,
             "get_board_info": self.board_commands.get_board_info,

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -183,6 +183,7 @@ if utils_dir not in sys.path:
 from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
 from utils.kicad_process import KiCADProcessManager, check_and_launch_kicad
 from utils.platform_helper import PlatformHelper
+from utils.project_settings_guard import preserve_project_settings
 
 logger.info(f"Detecting KiCAD Python paths for {PlatformHelper.get_platform_name()}...")
 paths_added = PlatformHelper.add_kicad_to_python_path()
@@ -1432,7 +1433,8 @@ class KiCADInterface(SchematicHandlersMixin):
 
         # Write the board.
         try:
-            pcbnew.SaveBoard(board_path, self.board)
+            with preserve_project_settings(board_path):
+                pcbnew.SaveBoard(board_path, self.board)
             logger.debug(f"Auto-saved board to: {board_path}")
             self._board_disk_signature = self._disk_signature(board_path)
         except Exception as e:
@@ -4801,7 +4803,8 @@ class KiCADInterface(SchematicHandlersMixin):
                     "success": False,
                     "message": "Board has no file path — save first",
                 }
-            self.board.Save(board_path)
+            with preserve_project_settings(board_path):
+                self.board.Save(board_path)
 
             zone_count = self.board.GetAreaCount() if hasattr(self.board, "GetAreaCount") else 0
 

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -235,6 +235,58 @@ BOARD_TOOLS = [
         },
     },
     {
+        "name": "set_board_origin",
+        "title": "Set Board Aux/Grid Origin",
+        "description": (
+            "Set the auxiliary (drill/place) origin and/or grid origin of a "
+            ".kicad_pcb. The aux origin is the datum used by export_drill's "
+            "drillOrigin:'plot' option and by pick-and-place / plot exports "
+            "with useAuxOrigin."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "boardPath": {
+                    "type": "string",
+                    "description": "Path to the .kicad_pcb file",
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["aux", "grid", "both"],
+                    "description": "Which origin to set (default: aux)",
+                    "default": "aux",
+                },
+                "x": {"type": "number", "description": "Origin X coordinate"},
+                "y": {"type": "number", "description": "Origin Y coordinate"},
+                "unit": {
+                    "type": "string",
+                    "enum": ["mm", "mil", "inch"],
+                    "description": "Coordinate unit (default: mm)",
+                    "default": "mm",
+                },
+            },
+            "required": ["boardPath", "x", "y"],
+        },
+    },
+    {
+        "name": "get_board_origin",
+        "title": "Get Board Aux/Grid Origin",
+        "description": (
+            "Read back the auxiliary (drill/place) origin and grid origin of a "
+            ".kicad_pcb in mm."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "boardPath": {
+                    "type": "string",
+                    "description": "Path to the .kicad_pcb file",
+                },
+            },
+            "required": ["boardPath"],
+        },
+    },
+    {
         "name": "add_board_outline",
         "title": "Add Board Outline",
         "description": "Adds a board outline shape (rectangle, rounded_rectangle, circle, or polygon) on the Edge.Cuts layer. By default the board top-left corner is placed at (0, 0) so all coordinates are positive. Use x/y to set a different top-left corner position.",

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -272,8 +272,7 @@ BOARD_TOOLS = [
         "name": "get_board_origin",
         "title": "Get Board Aux/Grid Origin",
         "description": (
-            "Read back the auxiliary (drill/place) origin and grid origin of a "
-            ".kicad_pcb in mm."
+            "Read back the auxiliary (drill/place) origin and grid origin of a " ".kicad_pcb in mm."
         ),
         "inputSchema": {
             "type": "object",

--- a/python/utils/project_settings_guard.py
+++ b/python/utils/project_settings_guard.py
@@ -1,0 +1,197 @@
+"""Preserve hand-edited ``.kicad_pro`` settings across backend board saves.
+
+In the long-lived backend process, pcbnew reuses a stale in-memory project
+model when a project is re-opened: ``pcbnew.LoadBoard`` does not re-read a
+hand-edited ``.kicad_pro``, and the next ``pcbnew.SaveBoard`` /
+``BOARD.Save()`` (default ``aSkipSettings=False`` — including the
+post-mutation auto-save) serializes that stale model over the file,
+reverting custom net classes and ``netclass_patterns`` to Default-only.
+
+The backend never legitimately mutates ``net_settings`` through the pcbnew
+model (``create_netclass`` persists via direct JSON read-modify-write), so
+it is always safe to restore the on-disk ``net_settings`` — and any dropped
+unknown top-level keys — after a save, while letting SaveBoard's legitimate
+updates (e.g. ``board.design_settings``) flow through.
+
+All helpers are best-effort and never raise: a guard failure must not fail
+the board operation it wraps.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger("kicad_interface")
+
+
+def _pro_path_for(board_path: str) -> Optional[str]:
+    try:
+        if not board_path:
+            return None
+        return str(Path(board_path).with_suffix(".kicad_pro"))
+    except Exception:
+        return None
+
+
+def merge_preserved_keys(
+    before: Dict[str, Any], after: Dict[str, Any]
+) -> Tuple[Dict[str, Any], bool]:
+    """Merge the pre-save project dict into the post-save one.
+
+    Rules:
+      * ``net_settings`` is restored wholesale from ``before`` (the backend
+        never mutates it through the pcbnew model).
+      * Top-level keys present in ``before`` but dropped by the save are
+        re-added.
+      * Every other value from ``after`` (e.g. ``board.design_settings``
+        updated by set_design_rules) is kept.
+
+    Returns ``(merged, changed)`` where ``changed`` is True when anything
+    had to be restored. Pure function — inputs are not mutated.
+    """
+    merged = dict(after)
+    changed = False
+
+    if "net_settings" in before and merged.get("net_settings") != before["net_settings"]:
+        merged["net_settings"] = before["net_settings"]
+        changed = True
+
+    for key, value in before.items():
+        if key not in merged:
+            merged[key] = value
+            changed = True
+
+    return merged, changed
+
+
+def _read_json(path: str) -> Optional[Dict[str, Any]]:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        return data if isinstance(data, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def _write_json_atomic(path: str, data: Dict[str, Any]) -> None:
+    directory = os.path.dirname(path) or "."
+    fd, tmp_path = tempfile.mkstemp(
+        dir=directory, prefix=".prosettings-", suffix=".kicad_pro"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+@contextmanager
+def preserve_project_settings(board_path: Optional[str]):
+    """Guard a board save so it cannot clobber ``.kicad_pro`` net_settings.
+
+    Snapshots ``<board>.kicad_pro`` before the wrapped save and afterwards
+    merges back ``net_settings`` plus any dropped top-level keys (atomic
+    write), only when something was lost. No-op when the project file does
+    not exist or cannot be parsed. Never raises.
+    """
+    pro_path = _pro_path_for(board_path or "")
+    before: Optional[Dict[str, Any]] = None
+    if pro_path and os.path.isfile(pro_path):
+        before = _read_json(pro_path)
+    try:
+        yield
+    finally:
+        if before is not None and pro_path:
+            try:
+                after = _read_json(pro_path)
+                if after is None:
+                    # Save produced no readable project file; restore snapshot.
+                    _write_json_atomic(pro_path, before)
+                    logger.warning(
+                        "Restored %s verbatim: unreadable after board save",
+                        pro_path,
+                    )
+                else:
+                    merged, changed = merge_preserved_keys(before, after)
+                    if changed:
+                        _write_json_atomic(pro_path, merged)
+                        logger.info(
+                            "Restored preserved .kicad_pro settings "
+                            "(net_settings/dropped keys) in %s",
+                            pro_path,
+                        )
+            except Exception as exc:  # never fail the wrapped operation
+                logger.warning(
+                    "Could not preserve project settings for %s: %s",
+                    pro_path,
+                    exc,
+                )
+
+
+def snapshot_project_file(board_path: Optional[str]) -> Optional[bytes]:
+    """Return the raw bytes of ``<board>.kicad_pro``, or None."""
+    pro_path = _pro_path_for(board_path or "")
+    if not pro_path or not os.path.isfile(pro_path):
+        return None
+    try:
+        with open(pro_path, "rb") as handle:
+            return handle.read()
+    except OSError:
+        return None
+
+
+def restore_project_file_if_changed(
+    board_path: Optional[str], snapshot: Optional[bytes]
+) -> bool:
+    """Restore ``<board>.kicad_pro`` verbatim if its content changed.
+
+    Used around read-only operations (opening a project must not rewrite
+    user settings on disk). Returns True when a restore happened. Never
+    raises.
+    """
+    if snapshot is None:
+        return False
+    pro_path = _pro_path_for(board_path or "")
+    if not pro_path:
+        return False
+    try:
+        current: Optional[bytes]
+        try:
+            with open(pro_path, "rb") as handle:
+                current = handle.read()
+        except OSError:
+            current = None
+        if current == snapshot:
+            return False
+        directory = os.path.dirname(pro_path) or "."
+        fd, tmp_path = tempfile.mkstemp(
+            dir=directory, prefix=".prosettings-", suffix=".kicad_pro"
+        )
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(snapshot)
+            os.replace(tmp_path, pro_path)
+        except Exception:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
+        logger.info(
+            "Restored %s verbatim: opening a project must not rewrite it",
+            pro_path,
+        )
+        return True
+    except Exception as exc:
+        logger.warning("Could not restore project file %s: %s", pro_path, exc)
+        return False

--- a/python/utils/project_settings_guard.py
+++ b/python/utils/project_settings_guard.py
@@ -79,9 +79,7 @@ def _read_json(path: str) -> Optional[Dict[str, Any]]:
 
 def _write_json_atomic(path: str, data: Dict[str, Any]) -> None:
     directory = os.path.dirname(path) or "."
-    fd, tmp_path = tempfile.mkstemp(
-        dir=directory, prefix=".prosettings-", suffix=".kicad_pro"
-    )
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".prosettings-", suffix=".kicad_pro")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             json.dump(data, handle, indent=2, sort_keys=True)
@@ -150,9 +148,7 @@ def snapshot_project_file(board_path: Optional[str]) -> Optional[bytes]:
         return None
 
 
-def restore_project_file_if_changed(
-    board_path: Optional[str], snapshot: Optional[bytes]
-) -> bool:
+def restore_project_file_if_changed(board_path: Optional[str], snapshot: Optional[bytes]) -> bool:
     """Restore ``<board>.kicad_pro`` verbatim if its content changed.
 
     Used around read-only operations (opening a project must not rewrite
@@ -174,9 +170,7 @@ def restore_project_file_if_changed(
         if current == snapshot:
             return False
         directory = os.path.dirname(pro_path) or "."
-        fd, tmp_path = tempfile.mkstemp(
-            dir=directory, prefix=".prosettings-", suffix=".kicad_pro"
-        )
+        fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".prosettings-", suffix=".kicad_pro")
         try:
             with os.fdopen(fd, "wb") as handle:
                 handle.write(snapshot)

--- a/src/tools/board.ts
+++ b/src/tools/board.ts
@@ -51,6 +51,58 @@ export function registerBoardTools(server: McpServer, callKicadScript: CommandFu
   );
 
   // ------------------------------------------------------
+  // Board Origin Tools (aux / grid origin)
+  // ------------------------------------------------------
+  server.tool(
+    "set_board_origin",
+    "Set the auxiliary (drill/place) origin and/or grid origin of a .kicad_pcb. " +
+      "The aux origin is the datum used by export_drill's drillOrigin:'plot' option and " +
+      "by pick-and-place / plot exports with useAuxOrigin. File-based (LoadBoard -> " +
+      "SaveBoard): if the board is open in the KiCad GUI, a later GUI save will overwrite " +
+      "this edit.",
+    {
+      boardPath: z.string().describe("Path to the .kicad_pcb file"),
+      type: z
+        .enum(["aux", "grid", "both"])
+        .optional()
+        .describe("Which origin to set (default: aux)"),
+      x: z.number().describe("Origin X coordinate"),
+      y: z.number().describe("Origin Y coordinate"),
+      unit: z.enum(["mm", "mil", "inch"]).optional().describe("Coordinate unit (default: mm)"),
+    },
+    async (args) => {
+      const result = await callKicadScript("set_board_origin", args);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "get_board_origin",
+    "Read back the auxiliary (drill/place) origin and grid origin of a .kicad_pcb in mm.",
+    {
+      boardPath: z.string().describe("Path to the .kicad_pcb file"),
+    },
+    async (args) => {
+      const result = await callKicadScript("get_board_origin", args);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result),
+          },
+        ],
+      };
+    },
+  );
+
+  // ------------------------------------------------------
   // Add Layer Tool
   // ------------------------------------------------------
   server.tool(

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -39,6 +39,8 @@ export const toolCategories: ToolCategory[] = [
       "add_zone",
       "get_board_extents",
       "get_board_2d_view",
+      "set_board_origin",
+      "get_board_origin",
       "launch_kicad_ui",
     ],
   },

--- a/tests/test_board_origin.py
+++ b/tests/test_board_origin.py
@@ -1,0 +1,210 @@
+"""
+Tests for set_board_origin / get_board_origin (python/commands/board/origin.py).
+
+Stub-mode tests validate parameters (conftest installs a MagicMock pcbnew).
+Real-mode tests (KICAD_USE_REAL_PCBNEW=1) round-trip the origins through a
+real board file and check the drill-origin offset via kicad-cli.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.board.origin import BoardOriginCommands  # noqa: E402
+
+
+@pytest.fixture()
+def commands():
+    return BoardOriginCommands()
+
+
+@pytest.fixture()
+def board_file(tmp_path):
+    p = tmp_path / "t.kicad_pcb"
+    p.write_text('(kicad_pcb (version 20240108) (generator "pcbnew"))')
+    return str(p)
+
+
+# ---------------------------------------------------------------------------
+# Stub-mode validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidation:
+    def test_missing_board_path(self, commands):
+        r = commands.set_board_origin({"x": 1, "y": 2})
+        assert r["success"] is False
+        assert "boardPath" in r["message"]
+        r = commands.get_board_origin({})
+        assert r["success"] is False
+        assert "boardPath" in r["message"]
+
+    def test_nonexistent_file(self, commands, tmp_path):
+        r = commands.set_board_origin(
+            {"boardPath": str(tmp_path / "nope.kicad_pcb"), "x": 1, "y": 2}
+        )
+        assert r["success"] is False
+        assert "not found" in r["message"]
+
+    def test_invalid_type(self, commands, board_file):
+        r = commands.set_board_origin(
+            {"boardPath": board_file, "type": "bogus", "x": 1, "y": 2}
+        )
+        assert r["success"] is False
+        assert "type must be one of" in r["message"]
+
+    def test_missing_coordinates(self, commands, board_file):
+        r = commands.set_board_origin({"boardPath": board_file})
+        assert r["success"] is False
+        assert "x and y" in r["message"]
+        r = commands.set_board_origin({"boardPath": board_file, "x": 1})
+        assert r["success"] is False
+
+    def test_non_numeric_coordinates(self, commands, board_file):
+        r = commands.set_board_origin(
+            {"boardPath": board_file, "x": "abc", "y": 2}
+        )
+        assert r["success"] is False
+        assert "numeric" in r["message"]
+
+    def test_invalid_unit(self, commands, board_file):
+        r = commands.set_board_origin(
+            {"boardPath": board_file, "x": 1, "y": 2, "unit": "furlong"}
+        )
+        assert r["success"] is False
+        assert "unit must be one of" in r["message"]
+
+
+# ---------------------------------------------------------------------------
+# Real pcbnew round trip (gated)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.real_pcbnew
+class TestRealPcbnew:
+    @pytest.fixture(autouse=True)
+    def _require_real_pcbnew(self):
+        if os.environ.get("KICAD_USE_REAL_PCBNEW") != "1":
+            pytest.skip("set KICAD_USE_REAL_PCBNEW=1 to run against real pcbnew")
+
+    def _make_board(self, tmp_path):
+        import pcbnew
+
+        board_path = str(tmp_path / "t.kicad_pcb")
+        board = pcbnew.BOARD()
+        pcbnew.SaveBoard(board_path, board)
+        return board_path
+
+    def test_aux_round_trip(self, commands, tmp_path):
+        board_path = self._make_board(tmp_path)
+        r = commands.set_board_origin(
+            {"boardPath": board_path, "type": "aux", "x": 10, "y": 20}
+        )
+        assert r["success"], r
+        # Nonzero origins are serialized as an aux_axis_origin token
+        text = Path(board_path).read_text(encoding="utf-8")
+        assert "aux_axis_origin" in text
+
+        g = commands.get_board_origin({"boardPath": board_path})
+        assert g["success"], g
+        assert g["aux"] == {"x": 10.0, "y": 20.0}
+
+    def test_grid_and_both(self, commands, tmp_path):
+        board_path = self._make_board(tmp_path)
+        r = commands.set_board_origin(
+            {"boardPath": board_path, "type": "grid", "x": 5, "y": 6}
+        )
+        assert r["success"], r
+        g = commands.get_board_origin({"boardPath": board_path})
+        assert g["grid"] == {"x": 5.0, "y": 6.0}
+        assert g["aux"] == {"x": 0.0, "y": 0.0}
+
+        r = commands.set_board_origin(
+            {"boardPath": board_path, "type": "both", "x": 7, "y": 8}
+        )
+        assert r["success"], r
+        g = commands.get_board_origin({"boardPath": board_path})
+        assert g["aux"] == {"x": 7.0, "y": 8.0}
+        assert g["grid"] == {"x": 7.0, "y": 8.0}
+
+    def test_unit_conversion_inch(self, commands, tmp_path):
+        import pcbnew
+
+        board_path = self._make_board(tmp_path)
+        r = commands.set_board_origin(
+            {"boardPath": board_path, "x": 1, "y": 0.5, "unit": "inch"}
+        )
+        assert r["success"], r
+        board = pcbnew.LoadBoard(board_path)
+        aux = board.GetDesignSettings().GetAuxOrigin()
+        assert aux.x == 25400000
+        assert aux.y == 12700000
+
+    def test_drill_origin_offset(self, commands, tmp_path):
+        """Setting the aux origin must shift kicad-cli's plot-origin drill
+        coordinates by exactly the origin vector."""
+        import pcbnew
+
+        if shutil.which("kicad-cli") is None:
+            pytest.skip("kicad-cli not available")
+
+        fp_lib = "/usr/share/kicad/footprints/Connector_PinHeader_2.54mm.pretty"
+        if not os.path.isdir(fp_lib):
+            pytest.skip("KiCad standard footprint library not installed")
+
+        board_path = str(tmp_path / "t.kicad_pcb")
+        board = pcbnew.BOARD()
+        fp = pcbnew.FootprintLoad(fp_lib, "PinHeader_1x01_P2.54mm_Vertical")
+        assert fp is not None
+        fp.SetPosition(pcbnew.VECTOR2I(30000000, 30000000))  # (30, 30) mm
+        board.Add(fp)
+        pcbnew.SaveBoard(board_path, board)
+
+        def _drill_coords(out_dir):
+            out_dir.mkdir()
+            subprocess.run(
+                [
+                    "kicad-cli",
+                    "pcb",
+                    "export",
+                    "drill",
+                    "--drill-origin",
+                    "plot",
+                    "--excellon-units",
+                    "mm",
+                    "-o",
+                    str(out_dir) + "/",
+                    board_path,
+                ],
+                check=True,
+                capture_output=True,
+                timeout=120,
+            )
+            coords = []
+            for drl in sorted(out_dir.glob("*.drl")):
+                for line in drl.read_text().splitlines():
+                    if line.startswith("X"):
+                        x_part, y_part = line[1:].split("Y")
+                        coords.append((float(x_part), float(y_part)))
+            return coords
+
+        before = _drill_coords(tmp_path / "before")
+        r = commands.set_board_origin(
+            {"boardPath": board_path, "type": "aux", "x": 30, "y": 30}
+        )
+        assert r["success"], r
+        after = _drill_coords(tmp_path / "after")
+
+        assert before and after
+        # Compare deltas rather than absolute strings (Excellon Y sign and
+        # zero formats vary between KiCad versions).
+        (bx, by), (ax, ay) = before[0], after[0]
+        assert abs(abs(bx - ax) - 30.0) < 0.01
+        assert abs(abs(by - ay) - 30.0) < 0.01

--- a/tests/test_board_origin.py
+++ b/tests/test_board_origin.py
@@ -54,9 +54,7 @@ class TestValidation:
         assert "not found" in r["message"]
 
     def test_invalid_type(self, commands, board_file):
-        r = commands.set_board_origin(
-            {"boardPath": board_file, "type": "bogus", "x": 1, "y": 2}
-        )
+        r = commands.set_board_origin({"boardPath": board_file, "type": "bogus", "x": 1, "y": 2})
         assert r["success"] is False
         assert "type must be one of" in r["message"]
 
@@ -68,16 +66,12 @@ class TestValidation:
         assert r["success"] is False
 
     def test_non_numeric_coordinates(self, commands, board_file):
-        r = commands.set_board_origin(
-            {"boardPath": board_file, "x": "abc", "y": 2}
-        )
+        r = commands.set_board_origin({"boardPath": board_file, "x": "abc", "y": 2})
         assert r["success"] is False
         assert "numeric" in r["message"]
 
     def test_invalid_unit(self, commands, board_file):
-        r = commands.set_board_origin(
-            {"boardPath": board_file, "x": 1, "y": 2, "unit": "furlong"}
-        )
+        r = commands.set_board_origin({"boardPath": board_file, "x": 1, "y": 2, "unit": "furlong"})
         assert r["success"] is False
         assert "unit must be one of" in r["message"]
 
@@ -104,9 +98,7 @@ class TestRealPcbnew:
 
     def test_aux_round_trip(self, commands, tmp_path):
         board_path = self._make_board(tmp_path)
-        r = commands.set_board_origin(
-            {"boardPath": board_path, "type": "aux", "x": 10, "y": 20}
-        )
+        r = commands.set_board_origin({"boardPath": board_path, "type": "aux", "x": 10, "y": 20})
         assert r["success"], r
         # Nonzero origins are serialized as an aux_axis_origin token
         text = Path(board_path).read_text(encoding="utf-8")
@@ -118,17 +110,13 @@ class TestRealPcbnew:
 
     def test_grid_and_both(self, commands, tmp_path):
         board_path = self._make_board(tmp_path)
-        r = commands.set_board_origin(
-            {"boardPath": board_path, "type": "grid", "x": 5, "y": 6}
-        )
+        r = commands.set_board_origin({"boardPath": board_path, "type": "grid", "x": 5, "y": 6})
         assert r["success"], r
         g = commands.get_board_origin({"boardPath": board_path})
         assert g["grid"] == {"x": 5.0, "y": 6.0}
         assert g["aux"] == {"x": 0.0, "y": 0.0}
 
-        r = commands.set_board_origin(
-            {"boardPath": board_path, "type": "both", "x": 7, "y": 8}
-        )
+        r = commands.set_board_origin({"boardPath": board_path, "type": "both", "x": 7, "y": 8})
         assert r["success"], r
         g = commands.get_board_origin({"boardPath": board_path})
         assert g["aux"] == {"x": 7.0, "y": 8.0}
@@ -138,9 +126,7 @@ class TestRealPcbnew:
         import pcbnew
 
         board_path = self._make_board(tmp_path)
-        r = commands.set_board_origin(
-            {"boardPath": board_path, "x": 1, "y": 0.5, "unit": "inch"}
-        )
+        r = commands.set_board_origin({"boardPath": board_path, "x": 1, "y": 0.5, "unit": "inch"})
         assert r["success"], r
         board = pcbnew.LoadBoard(board_path)
         aux = board.GetDesignSettings().GetAuxOrigin()
@@ -196,9 +182,7 @@ class TestRealPcbnew:
             return coords
 
         before = _drill_coords(tmp_path / "before")
-        r = commands.set_board_origin(
-            {"boardPath": board_path, "type": "aux", "x": 30, "y": 30}
-        )
+        r = commands.set_board_origin({"boardPath": board_path, "type": "aux", "x": 30, "y": 30})
         assert r["success"], r
         after = _drill_coords(tmp_path / "after")
 

--- a/tests/test_project_settings_preservation.py
+++ b/tests/test_project_settings_preservation.py
@@ -1,0 +1,272 @@
+"""
+Tests for .kicad_pro net_settings preservation across open/save.
+
+pcbnew reuses a stale in-memory project model when a project is re-opened
+in the long-lived backend process; the next SaveBoard/BOARD.Save then
+serializes that stale model over the hand-edited .kicad_pro, reverting
+custom net classes and netclass_patterns to Default-only. The
+utils.project_settings_guard helpers snapshot/merge/restore around every
+backend-initiated save so user settings survive.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from utils.project_settings_guard import (  # noqa: E402
+    merge_preserved_keys,
+    preserve_project_settings,
+    restore_project_file_if_changed,
+    snapshot_project_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_CUSTOM_NET_SETTINGS = {
+    "classes": [
+        {"name": "Default", "clearance": 0.2},
+        {"name": "CAN_DIFF", "clearance": 0.2, "track_width": 0.3},
+    ],
+    "meta": {"version": 4},
+    "netclass_patterns": [{"netclass": "CAN_DIFF", "pattern": "/CAN_*"}],
+}
+
+_DEFAULT_ONLY_NET_SETTINGS = {
+    "classes": [{"name": "Default", "clearance": 0.2}],
+    "meta": {"version": 4},
+    "netclass_patterns": [],
+}
+
+
+def _make_project(tmp_path, net_settings=None, extra=None, write_board=True):
+    board_path = tmp_path / "t.kicad_pcb"
+    if write_board:
+        board_path.write_text("(kicad_pcb)")
+    pro = {
+        "board": {"design_settings": {"defaults": {"track_width": 0.25}}},
+        "net_settings": net_settings or _CUSTOM_NET_SETTINGS,
+        "meta": {"filename": "t.kicad_pro", "version": 3},
+    }
+    if extra:
+        pro.update(extra)
+    pro_path = tmp_path / "t.kicad_pro"
+    pro_path.write_text(json.dumps(pro, indent=2))
+    return str(board_path), str(pro_path)
+
+
+def _clobber_pro(pro_path: str) -> None:
+    """Simulate a destructive pcbnew save: net_settings reverted to
+    Default-only, an unknown key dropped, design_settings updated."""
+    with open(pro_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    data["net_settings"] = json.loads(json.dumps(_DEFAULT_ONLY_NET_SETTINGS))
+    data.pop("custom_unknown_key", None)
+    data.setdefault("board", {}).setdefault("design_settings", {}).setdefault(
+        "defaults", {}
+    )["track_width"] = 0.42
+    with open(pro_path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# merge_preserved_keys (pure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMergePreservedKeys:
+    def test_net_settings_restored(self):
+        before = {"net_settings": _CUSTOM_NET_SETTINGS, "a": 1}
+        after = {"net_settings": _DEFAULT_ONLY_NET_SETTINGS, "a": 1}
+        merged, changed = merge_preserved_keys(before, after)
+        assert changed is True
+        assert merged["net_settings"] == _CUSTOM_NET_SETTINGS
+
+    def test_dropped_unknown_key_restored(self):
+        before = {"net_settings": {}, "custom_unknown_key": {"x": 1}}
+        after = {"net_settings": {}}
+        merged, changed = merge_preserved_keys(before, after)
+        assert changed is True
+        assert merged["custom_unknown_key"] == {"x": 1}
+
+    def test_legitimate_after_values_kept(self):
+        before = {
+            "net_settings": _CUSTOM_NET_SETTINGS,
+            "board": {"design_settings": {"defaults": {"track_width": 0.25}}},
+        }
+        after = {
+            "net_settings": _CUSTOM_NET_SETTINGS,
+            "board": {"design_settings": {"defaults": {"track_width": 0.42}}},
+        }
+        merged, changed = merge_preserved_keys(before, after)
+        assert changed is False
+        assert merged["board"]["design_settings"]["defaults"]["track_width"] == 0.42
+
+    def test_no_change_when_nothing_lost(self):
+        before = {"net_settings": _CUSTOM_NET_SETTINGS}
+        after = {"net_settings": json.loads(json.dumps(_CUSTOM_NET_SETTINGS))}
+        merged, changed = merge_preserved_keys(before, after)
+        assert changed is False
+        assert merged == after
+
+    def test_inputs_not_mutated(self):
+        before = {"net_settings": _CUSTOM_NET_SETTINGS, "gone": 1}
+        after = {"net_settings": _DEFAULT_ONLY_NET_SETTINGS}
+        after_copy = json.loads(json.dumps(after))
+        merge_preserved_keys(before, after)
+        assert after == after_copy
+
+
+# ---------------------------------------------------------------------------
+# preserve_project_settings context manager
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPreserveProjectSettings:
+    def test_clobbering_save_is_merged_back(self, tmp_path):
+        board_path, pro_path = _make_project(
+            tmp_path, extra={"custom_unknown_key": {"keep": True}}
+        )
+        with preserve_project_settings(board_path):
+            _clobber_pro(pro_path)
+
+        data = json.loads(Path(pro_path).read_text())
+        names = [c["name"] for c in data["net_settings"]["classes"]]
+        assert "CAN_DIFF" in names
+        assert data["net_settings"]["netclass_patterns"] == [
+            {"netclass": "CAN_DIFF", "pattern": "/CAN_*"}
+        ]
+        assert data["custom_unknown_key"] == {"keep": True}
+        # Legit design_settings change made by the save is kept
+        assert data["board"]["design_settings"]["defaults"]["track_width"] == 0.42
+
+    def test_noop_when_nothing_lost(self, tmp_path):
+        board_path, pro_path = _make_project(tmp_path)
+        original = Path(pro_path).read_text()
+        with preserve_project_settings(board_path):
+            pass
+        assert Path(pro_path).read_text() == original
+
+    def test_noop_without_project_file(self, tmp_path):
+        board_path = tmp_path / "lonely.kicad_pcb"
+        board_path.write_text("(kicad_pcb)")
+        with preserve_project_settings(str(board_path)):
+            pass  # must not raise or create a .kicad_pro
+        assert not (tmp_path / "lonely.kicad_pro").exists()
+
+    def test_never_raises_on_unparseable_project(self, tmp_path):
+        board_path, pro_path = _make_project(tmp_path)
+        Path(pro_path).write_text("{not json")
+        with preserve_project_settings(board_path):
+            pass  # snapshot unparseable -> guard is a no-op
+
+    def test_exception_in_body_still_merges(self, tmp_path):
+        board_path, pro_path = _make_project(tmp_path)
+        with pytest.raises(RuntimeError):
+            with preserve_project_settings(board_path):
+                _clobber_pro(pro_path)
+                raise RuntimeError("save blew up")
+        data = json.loads(Path(pro_path).read_text())
+        names = [c["name"] for c in data["net_settings"]["classes"]]
+        assert "CAN_DIFF" in names
+
+
+# ---------------------------------------------------------------------------
+# open_project verbatim restore (mocked pcbnew)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOpenProjectRestore:
+    def _commands(self) -> Any:
+        from commands.project import ProjectCommands
+
+        return ProjectCommands()
+
+    def test_open_project_restores_clobbered_pro(self, tmp_path):
+        board_path, pro_path = _make_project(tmp_path)
+        original = Path(pro_path).read_text()
+        commands = self._commands()
+
+        def destructive_load(path):
+            # Simulate a KiCad build whose LoadBoard rewrites .kicad_pro
+            _clobber_pro(pro_path)
+            return object()
+
+        with patch("commands.project.pcbnew.LoadBoard", side_effect=destructive_load):
+            result = commands.open_project({"filename": pro_path})
+
+        assert result["success"], result
+        assert Path(pro_path).read_text() == original
+
+    def test_open_project_untouched_pro_not_rewritten(self, tmp_path):
+        board_path, pro_path = _make_project(tmp_path)
+        commands = self._commands()
+        mtime = os.path.getmtime(pro_path)
+        with patch("commands.project.pcbnew.LoadBoard", return_value=object()):
+            result = commands.open_project({"filename": pro_path})
+        assert result["success"], result
+        assert os.path.getmtime(pro_path) == mtime
+
+    def test_snapshot_restore_helpers(self, tmp_path):
+        board_path, pro_path = _make_project(tmp_path)
+        snap = snapshot_project_file(board_path)
+        assert snap is not None
+        assert restore_project_file_if_changed(board_path, snap) is False
+        Path(pro_path).write_text("{}")
+        assert restore_project_file_if_changed(board_path, snap) is True
+        assert Path(pro_path).read_bytes() == snap
+        assert snapshot_project_file(str(tmp_path / "none.kicad_pcb")) is None
+
+
+# ---------------------------------------------------------------------------
+# Real-SWIG round trip (gated)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.real_pcbnew
+class TestRealPcbnewRoundTrip:
+    @pytest.fixture(autouse=True)
+    def _require_real_pcbnew(self):
+        if os.environ.get("KICAD_USE_REAL_PCBNEW") != "1":
+            pytest.skip("set KICAD_USE_REAL_PCBNEW=1 to run against real pcbnew")
+
+    def test_stale_model_sequence_preserves_net_settings(self, tmp_path):
+        import pcbnew
+
+        board_path = str(tmp_path / "t.kicad_pcb")
+        board = pcbnew.BOARD()
+        pcbnew.SaveBoard(board_path, board)
+
+        _, pro_path = _make_project(tmp_path, write_board=False)
+
+        # Replay the confirmed clobber sequence: load, hand-edit .kicad_pro,
+        # load again (stale in-memory project model), save via the guard.
+        # Keep the first board referenced: letting SWIG garbage-collect it
+        # mid-sequence can crash the interpreter.
+        board1 = pcbnew.LoadBoard(board_path)  # noqa: F841
+        data = json.loads(Path(pro_path).read_text())
+        data["net_settings"] = json.loads(json.dumps(_CUSTOM_NET_SETTINGS))
+        Path(pro_path).write_text(json.dumps(data, indent=2))
+
+        board2 = pcbnew.LoadBoard(board_path)
+        with preserve_project_settings(board_path):
+            pcbnew.SaveBoard(board_path, board2)
+
+        final = json.loads(Path(pro_path).read_text())
+        names = [c["name"] for c in final["net_settings"]["classes"]]
+        assert "CAN_DIFF" in names
+        assert {"netclass": "CAN_DIFF", "pattern": "/CAN_*"} in final[
+            "net_settings"
+        ]["netclass_patterns"]

--- a/tests/test_project_settings_preservation.py
+++ b/tests/test_project_settings_preservation.py
@@ -27,7 +27,6 @@ from utils.project_settings_guard import (  # noqa: E402
     snapshot_project_file,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -71,9 +70,9 @@ def _clobber_pro(pro_path: str) -> None:
         data = json.load(fh)
     data["net_settings"] = json.loads(json.dumps(_DEFAULT_ONLY_NET_SETTINGS))
     data.pop("custom_unknown_key", None)
-    data.setdefault("board", {}).setdefault("design_settings", {}).setdefault(
-        "defaults", {}
-    )["track_width"] = 0.42
+    data.setdefault("board", {}).setdefault("design_settings", {}).setdefault("defaults", {})[
+        "track_width"
+    ] = 0.42
     with open(pro_path, "w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
 
@@ -135,9 +134,7 @@ class TestMergePreservedKeys:
 @pytest.mark.unit
 class TestPreserveProjectSettings:
     def test_clobbering_save_is_merged_back(self, tmp_path):
-        board_path, pro_path = _make_project(
-            tmp_path, extra={"custom_unknown_key": {"keep": True}}
-        )
+        board_path, pro_path = _make_project(tmp_path, extra={"custom_unknown_key": {"keep": True}})
         with preserve_project_settings(board_path):
             _clobber_pro(pro_path)
 
@@ -267,6 +264,6 @@ class TestRealPcbnewRoundTrip:
         final = json.loads(Path(pro_path).read_text())
         names = [c["name"] for c in final["net_settings"]["classes"]]
         assert "CAN_DIFF" in names
-        assert {"netclass": "CAN_DIFF", "pattern": "/CAN_*"} in final[
-            "net_settings"
-        ]["netclass_patterns"]
+        assert {"netclass": "CAN_DIFF", "pattern": "/CAN_*"} in final["net_settings"][
+            "netclass_patterns"
+        ]


### PR DESCRIPTION
Part of splitting #314 à la carte (per the thread). Rebased on v2.5.0; `pre-commit run --all-files` green, CI-clean.

Grouped because both changes hinge on the same `.kicad_pro` write-safety helper (`utils/project_settings_guard.py`):

## fix: preserve `net_settings` across open/save
`open_project`/save rewrote `.kicad_pro` from a possibly-stale in-memory model and **silently dropped hand-edited `net_settings`** (custom netclasses/patterns). `preserve_project_settings()` snapshots + restores them around the save sites (project.py, freerouting, schematic export, ipc backend). Reproduced + verified on real pcbnew.

## feat: `set_board_origin` / `get_board_origin`
Aux (drill/place) + grid origins — the file-stored datums `export_drill`'s `drillOrigin:"plot"` and pick-and-place/plot exports consume. Real-pcbnew + drill-offset integration tested.

Note: the net_settings guard was originally also applied to `hierarchical_place.py`'s save site; that one hunk is deferred to the hierarchical_place PR (that tool isn't on main yet), so this PR is self-contained on current `main`.