### PR TITLE
Hierarchical schematic tools: remove_hierarchical_sheet, set_sheet_property, hierarchical_place

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 **Key Capabilities:**
 
-- 143 tools across 13 categories with JSON Schema validation
+- 144 tools across 13 categories with JSON Schema validation
 - Smart tool discovery with router pattern (reduces AI context by 70%)
 - 8 dynamic resources exposing project state
 - Complete schematic workflow with 27 tools and dynamic symbol loading (~10,000 symbols)

--- a/docs/TOOL_INVENTORY.md
+++ b/docs/TOOL_INVENTORY.md
@@ -172,6 +172,8 @@ _Source: `src/tools/schematic.ts`_
 | ---------------------------------- | -------------------------------------------------- | ------------------ |
 | `add_schematic_hierarchical_label` | Add hierarchical label for multi-sheet connections | Routed (schematic) |
 | `add_sheet_pin`                    | Add a sheet pin to a hierarchical sheet symbol     | Routed (schematic) |
+| `set_sheet_property`               | Add/update a custom property on a hierarchical sheet (metadata, e.g. generator cell identity) | Routed (schematic) |
+| `get_sheet_properties`             | List hierarchical sheets with their full property maps | Routed (schematic) |
 
 ### Net Analysis (5)
 

--- a/docs/TOOL_INVENTORY.md
+++ b/docs/TOOL_INVENTORY.md
@@ -168,12 +168,12 @@ _Source: `src/tools/schematic.ts`_
 
 ### Hierarchical Schematics (2)
 
-| Tool                               | Description                                        | Access             |
-| ---------------------------------- | -------------------------------------------------- | ------------------ |
-| `add_schematic_hierarchical_label` | Add hierarchical label for multi-sheet connections | Routed (schematic) |
-| `add_sheet_pin`                    | Add a sheet pin to a hierarchical sheet symbol     | Routed (schematic) |
+| Tool                               | Description                                                                                   | Access             |
+| ---------------------------------- | --------------------------------------------------------------------------------------------- | ------------------ |
+| `add_schematic_hierarchical_label` | Add hierarchical label for multi-sheet connections                                            | Routed (schematic) |
+| `add_sheet_pin`                    | Add a sheet pin to a hierarchical sheet symbol                                                | Routed (schematic) |
 | `set_sheet_property`               | Add/update a custom property on a hierarchical sheet (metadata, e.g. generator cell identity) | Routed (schematic) |
-| `get_sheet_properties`             | List hierarchical sheets with their full property maps | Routed (schematic) |
+| `get_sheet_properties`             | List hierarchical sheets with their full property maps                                        | Routed (schematic) |
 
 ### Net Analysis (5)
 

--- a/python/commands/_hierplace.py
+++ b/python/commands/_hierplace.py
@@ -1,0 +1,330 @@
+# -*- coding: utf-8 -*-
+
+# MIT license
+#
+# Copyright (C) 2018-2021 by Dave Vandenbout.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+Arrange footprints based on the schematic hierarchy of the design.
+
+Vendored from HierPlace v1.1.0 by Dave Vandenbout (MIT) --
+https://github.com/devbisme/HierPlace -- with the following changes for
+headless use inside an MCP server:
+  * removed the hardcoded `sys.path.append('/usr/lib/python3/dist-packages')`
+  * removed the pcbnew GUI `ActionPlugin` subclass + `.register()` call
+    (it asserts `PgmOrNull()` when imported outside the pcbnew GUI)
+  * guarded the trailing `Refresh()` so it is a no-op headless
+
+The placement algorithm (group_modules / pack / hier_place) is unchanged.
+"""
+
+from collections import defaultdict
+
+import builtins
+
+from pcbnew import *  # noqa: F401,F403  (Module/board API used unqualified, as upstream)
+
+try:
+    KICAD_VERSION = int(Version().split(".")[0])
+except NameError:
+    # No version function, so assume this is KiCad 5.
+    KICAD_VERSION = 5
+
+# Extra spacing placed around bounding boxes of modules and groups of modules
+# to provide visual separation.
+MODULE_SPACING = 350000
+GROUP_SPACING = 5 * MODULE_SPACING
+
+
+class Module(object):
+    '''A class to provide extra functions for PCBNEW MODULES.'''
+
+    def __init__(self, pcbnew_module):
+        '''Create a Module instance that stores a PCBNEW MODULE instance.'''
+        self.m = pcbnew_module
+
+    @property
+    def ref(self):
+        '''Return a string with the module's reference id, such as "R3".'''
+        return self.m.GetReference()
+
+    @property
+    def hier_level(self):
+        '''Return a string with the hierarchical level of the module.'''
+        try:
+            path_parts = self.m.GetPath().AsString().split('/')
+        except AttributeError:
+            path_parts = self.m.GetPath().split('/')
+        return '/'.join(path_parts[:-1])
+
+    @property
+    def bbox(self):
+        '''Return an EDA_RECT or BOX2I with the bounding box of the module.'''
+        try:
+            bb = self.m.GetBoundingBox()
+        except AttributeError:
+            bb = self.m.GetFootprintRect()
+        bb.Inflate(MODULE_SPACING)
+        return bb
+
+    def touches(self, module):
+        '''Return True if the given module intersects this module.'''
+        bb1 = self.bbox
+        # Slightly shrink the bounding box so two modules that abut each other
+        # won't be reported as touching.
+        bb1.Inflate(-1)
+        return bb1.Intersects(module.bbox)
+
+    @property
+    def center(self):
+        '''Return wxPoint containing the centroid of the module.'''
+        return self.bbox.GetCenter()
+
+    @property
+    def tl_corner(self):
+        '''Return wxPoint containing the top-left corner of the module.'''
+        bb = self.bbox
+        return wxPoint(bb.GetLeft(), bb.GetTop())
+
+    @property
+    def br_corner(self):
+        '''Return wxPoint containing the bottom-right corner of the module.'''
+        bb = self.bbox
+        return wxPoint(bb.GetRight(), bb.GetBottom())
+
+    @property
+    def bl_corner(self):
+        '''Return wxPoint containing the bottom-left corner of the module.'''
+        bb = self.bbox
+        return wxPoint(bb.GetLeft(), bb.GetBottom())
+
+    @property
+    def w(self):
+        '''Return the width of the module.'''
+        return self.bbox.GetWidth()
+
+    @property
+    def h(self):
+        '''Return the height of the module.'''
+        return self.bbox.GetHeight()
+
+    @property
+    def area(self):
+        '''Return the area of the module's bounding box.'''
+        return self.bbox.GetArea()
+
+    @property
+    def selected(self):
+        return self.m.IsSelected()
+
+    @property
+    def locked(self):
+        '''Return True if the module is locked in place.'''
+        return self.m.IsLocked()
+
+    def move(self, dx, dy):
+        '''Move a module by the given distance in the X and Y directions.'''
+        if not self.locked:
+            if KICAD_VERSION >= 7:
+                self.m.Move(VECTOR2I(dx, dy))
+            else:
+                self.m.Move(wxPoint(dx, dy))
+
+    def set_bl_position(self, point):
+        '''Set the position of the module's bottom-left corner to the given (X,Y) coordinate.'''
+        if not self.locked:
+            mv = point - self.bl_corner  # Get vector from BL corner to desired point.
+            self.move(mv.x, mv.y)
+
+
+class ModuleGroup(list, Module):
+    '''A class that stores modules or module-groups as a list and also acts like a module.'''
+
+    def __init__(self, *args):
+        super(ModuleGroup, self).__init__(*args)
+
+    @property
+    def ref(self):
+        '''Return a string composed of the reference ids of the modules it contains.'''
+        return '[' + ','.join([m.ref for m in self]) + ']'
+
+    @property
+    def hier_level(self):
+        '''Return a string with the hierarchical level of the module group.'''
+        return '/'.join((self[0].hier_level.split('/'))[:-1])
+
+    @property
+    def bbox(self):
+        '''Return an EDA_RECT or BOX2I with the bounding box of the group of modules.'''
+        try:
+            bbox = BOX2I()
+        except NameError:
+            bbox = EDA_RECT()
+        bbox.Move(self[0].center)
+        for module in self:
+            bbox.Merge(module.bbox)
+        bbox.Inflate(GROUP_SPACING)
+        return bbox
+
+    @property
+    def locked(self):
+        '''Alsways return False because a module group never contains any locked modules.'''
+        return False
+
+    def move(self, dx, dy):
+        '''Move all the modules in a group by the given distance in the X and Y directions.'''
+        if not self.locked:
+            for m in self:
+                m.move(dx, dy)
+
+
+def group_modules(modules):
+    '''
+    Create a dictionary where each entry contains the modules at that level of the hierarchy.
+    '''
+    groups = defaultdict(ModuleGroup)
+    for m in modules:
+        if not m.locked:
+            # Add each unlocked module to the group at the same position of the hierarchy.
+            groups[m.hier_level].append(m)
+    return groups
+
+
+def pack(group):
+    '''
+    Pack a group of modules into a tight formation.
+    '''
+
+    # Packing starts with the module that's largest in area. The top-left (TL)
+    # and bottom-right (BR) corners of that module become potential points where
+    # the lower-left corner of the next-largest module can be placed.
+    # The point is chosen based upon how much the bounding box of the
+    # currently-placed modules will expand. When a module is placed,
+    # the placement point is removed and the TL and BR corners
+    # of the just-placed module are added to the list of points.
+    # This proceeds until all the modules are placed in order of decreasing area.
+
+    # Create an empty group to store the modules as they are packed.
+    packed_modules = ModuleGroup()
+
+    # Storage for the potential places where a module can be inserted.
+    placement_pts = []  # Starts off empty.
+
+    # Iterate through the modules in order of decreasing area, placing each one
+    # where it will keep the group within a small area.
+    for module in sorted(group, key=lambda m: -m.area):
+
+        # Skip over locked modules since they can't be moved.
+        if module.locked:
+            continue
+
+        # Add the module to the packed group. (It still needs to be positioned.)
+        packed_modules.append(module)
+
+        # If there are potential placement points, then go through them looking
+        # for the one that gives the best packing of the currently-placed modules.
+        # The only time this is not done will be for the very first module in the
+        # group which will serve as the anchor the others will gather around.
+        if placement_pts:
+
+            # Iterate through the potential placement points and pick the one that
+            # least expands the total bounding box.
+            best_pt, smallest_size = None, float('inf')
+            for pt in placement_pts:
+
+                # Move module bottom-left corner to the placement point.
+                module.set_bl_position(pt)
+
+                # Check to see if the module touches any of the other modules in the packed group.
+                for pm in packed_modules:
+                    if pm is module:
+                        # Don't check for intersections between the module and itself.
+                        continue
+                    if module.touches(pm):
+                        # Discard this placement point if the module touches one of the others.
+                        break
+                else:
+                    # If we got here, the placement point doesn't cause this module
+                    # to touch any of the others. Now check the size of the resulting
+                    # group of modules. The size is the sum of the height and width
+                    # plus the difference between the height and width. This
+                    # measure will attempt to keep the area small and square-like.
+                    size = packed_modules.h + packed_modules.w + builtins.abs(
+                        packed_modules.h - packed_modules.w)
+
+                    # If this configuration is the smallest so far, store it.
+                    if size <= smallest_size:
+                        smallest_size = size
+                        best_pt = pt
+
+            # Place the module at the best placement point that was found.
+            module.set_bl_position(best_pt)
+
+            # Remove the placement point since no other module can be placed there, now.
+            placement_pts.remove(best_pt)
+
+        # Add the top-left and bottom-right corners of the just-placed module
+        # to the list of potential placement points.
+        placement_pts.extend([module.tl_corner, module.br_corner])
+
+
+def hier_place(brd=None):
+    '''
+    Remove overlaps of board parts while respecting their hierarchy.
+    '''
+
+    brd = brd or GetBoard()
+    try:
+        modules = [Module(m) for m in brd.GetFootprints()]
+    except AttributeError:
+        modules = [Module(m) for m in brd.GetModules()]
+
+    # Get modules in the PCB that are selected.
+    # If no modules are selected, then operate on all the modules in the PCB.
+    selected_modules = [m for m in modules if m.selected] or modules
+
+    # Place the modules into groups based on hierarchy.
+    groups = group_modules(selected_modules)
+
+    # Pack all the modules in each group. Then move up a level in the hierarchy
+    # and pack a group of packed modules into another packing. Proceed upward
+    # until all the levels of the hierarchy have been packed.
+    while True:
+
+        # Pack the members of each group.
+        for group in groups.values():
+            pack(group)
+
+        # If there's only one group left, then all the hierarchical levels have
+        # been packed, so we're done.
+        if len(groups) <= 1:
+            break
+
+        # Otherwise, collect the packed groups into groups at the next level
+        # of hierarchy and repeat the loop.
+        groups = group_modules(groups.values())
+
+    # Refresh the GUI if one is attached; a no-op when running headless.
+    try:
+        Refresh()
+    except Exception:
+        pass
+
+    return len(selected_modules)

--- a/python/commands/_hierplace.py
+++ b/python/commands/_hierplace.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa: F405
 
 # MIT license
 #
@@ -35,14 +36,13 @@ headless use inside an MCP server:
 The placement algorithm (group_modules / pack / hier_place) is unchanged.
 """
 
-from collections import defaultdict
-
 import builtins
+from collections import defaultdict
 
 from pcbnew import *  # noqa: F401,F403  (Module/board API used unqualified, as upstream)
 
 try:
-    KICAD_VERSION = int(Version().split(".")[0])
+    KICAD_VERSION = int(Version().split(".")[0])  # type: ignore[name-defined]
 except NameError:
     # No version function, so assume this is KiCad 5.
     KICAD_VERSION = 5
@@ -54,29 +54,29 @@ GROUP_SPACING = 5 * MODULE_SPACING
 
 
 class Module(object):
-    '''A class to provide extra functions for PCBNEW MODULES.'''
+    """A class to provide extra functions for PCBNEW MODULES."""
 
     def __init__(self, pcbnew_module):
-        '''Create a Module instance that stores a PCBNEW MODULE instance.'''
+        """Create a Module instance that stores a PCBNEW MODULE instance."""
         self.m = pcbnew_module
 
     @property
     def ref(self):
-        '''Return a string with the module's reference id, such as "R3".'''
+        """Return a string with the module's reference id, such as "R3"."""
         return self.m.GetReference()
 
     @property
     def hier_level(self):
-        '''Return a string with the hierarchical level of the module.'''
+        """Return a string with the hierarchical level of the module."""
         try:
-            path_parts = self.m.GetPath().AsString().split('/')
+            path_parts = self.m.GetPath().AsString().split("/")
         except AttributeError:
-            path_parts = self.m.GetPath().split('/')
-        return '/'.join(path_parts[:-1])
+            path_parts = self.m.GetPath().split("/")
+        return "/".join(path_parts[:-1])
 
     @property
     def bbox(self):
-        '''Return an EDA_RECT or BOX2I with the bounding box of the module.'''
+        """Return an EDA_RECT or BOX2I with the bounding box of the module."""
         try:
             bb = self.m.GetBoundingBox()
         except AttributeError:
@@ -85,7 +85,7 @@ class Module(object):
         return bb
 
     def touches(self, module):
-        '''Return True if the given module intersects this module.'''
+        """Return True if the given module intersects this module."""
         bb1 = self.bbox
         # Slightly shrink the bounding box so two modules that abut each other
         # won't be reported as touching.
@@ -94,40 +94,40 @@ class Module(object):
 
     @property
     def center(self):
-        '''Return wxPoint containing the centroid of the module.'''
+        """Return wxPoint containing the centroid of the module."""
         return self.bbox.GetCenter()
 
     @property
     def tl_corner(self):
-        '''Return wxPoint containing the top-left corner of the module.'''
+        """Return wxPoint containing the top-left corner of the module."""
         bb = self.bbox
         return wxPoint(bb.GetLeft(), bb.GetTop())
 
     @property
     def br_corner(self):
-        '''Return wxPoint containing the bottom-right corner of the module.'''
+        """Return wxPoint containing the bottom-right corner of the module."""
         bb = self.bbox
         return wxPoint(bb.GetRight(), bb.GetBottom())
 
     @property
     def bl_corner(self):
-        '''Return wxPoint containing the bottom-left corner of the module.'''
+        """Return wxPoint containing the bottom-left corner of the module."""
         bb = self.bbox
         return wxPoint(bb.GetLeft(), bb.GetBottom())
 
     @property
     def w(self):
-        '''Return the width of the module.'''
+        """Return the width of the module."""
         return self.bbox.GetWidth()
 
     @property
     def h(self):
-        '''Return the height of the module.'''
+        """Return the height of the module."""
         return self.bbox.GetHeight()
 
     @property
     def area(self):
-        '''Return the area of the module's bounding box.'''
+        """Return the area of the module's bounding box."""
         return self.bbox.GetArea()
 
     @property
@@ -136,11 +136,11 @@ class Module(object):
 
     @property
     def locked(self):
-        '''Return True if the module is locked in place.'''
+        """Return True if the module is locked in place."""
         return self.m.IsLocked()
 
     def move(self, dx, dy):
-        '''Move a module by the given distance in the X and Y directions.'''
+        """Move a module by the given distance in the X and Y directions."""
         if not self.locked:
             if KICAD_VERSION >= 7:
                 self.m.Move(VECTOR2I(dx, dy))
@@ -148,31 +148,31 @@ class Module(object):
                 self.m.Move(wxPoint(dx, dy))
 
     def set_bl_position(self, point):
-        '''Set the position of the module's bottom-left corner to the given (X,Y) coordinate.'''
+        """Set the position of the module's bottom-left corner to the given (X,Y) coordinate."""
         if not self.locked:
             mv = point - self.bl_corner  # Get vector from BL corner to desired point.
             self.move(mv.x, mv.y)
 
 
 class ModuleGroup(list, Module):
-    '''A class that stores modules or module-groups as a list and also acts like a module.'''
+    """A class that stores modules or module-groups as a list and also acts like a module."""
 
     def __init__(self, *args):
         super(ModuleGroup, self).__init__(*args)
 
     @property
     def ref(self):
-        '''Return a string composed of the reference ids of the modules it contains.'''
-        return '[' + ','.join([m.ref for m in self]) + ']'
+        """Return a string composed of the reference ids of the modules it contains."""
+        return "[" + ",".join([m.ref for m in self]) + "]"
 
     @property
     def hier_level(self):
-        '''Return a string with the hierarchical level of the module group.'''
-        return '/'.join((self[0].hier_level.split('/'))[:-1])
+        """Return a string with the hierarchical level of the module group."""
+        return "/".join((self[0].hier_level.split("/"))[:-1])
 
     @property
     def bbox(self):
-        '''Return an EDA_RECT or BOX2I with the bounding box of the group of modules.'''
+        """Return an EDA_RECT or BOX2I with the bounding box of the group of modules."""
         try:
             bbox = BOX2I()
         except NameError:
@@ -185,20 +185,20 @@ class ModuleGroup(list, Module):
 
     @property
     def locked(self):
-        '''Alsways return False because a module group never contains any locked modules.'''
+        """Alsways return False because a module group never contains any locked modules."""
         return False
 
     def move(self, dx, dy):
-        '''Move all the modules in a group by the given distance in the X and Y directions.'''
+        """Move all the modules in a group by the given distance in the X and Y directions."""
         if not self.locked:
             for m in self:
                 m.move(dx, dy)
 
 
 def group_modules(modules):
-    '''
+    """
     Create a dictionary where each entry contains the modules at that level of the hierarchy.
-    '''
+    """
     groups = defaultdict(ModuleGroup)
     for m in modules:
         if not m.locked:
@@ -208,9 +208,9 @@ def group_modules(modules):
 
 
 def pack(group):
-    '''
+    """
     Pack a group of modules into a tight formation.
-    '''
+    """
 
     # Packing starts with the module that's largest in area. The top-left (TL)
     # and bottom-right (BR) corners of that module become potential points where
@@ -246,7 +246,7 @@ def pack(group):
 
             # Iterate through the potential placement points and pick the one that
             # least expands the total bounding box.
-            best_pt, smallest_size = None, float('inf')
+            best_pt, smallest_size = None, float("inf")
             for pt in placement_pts:
 
                 # Move module bottom-left corner to the placement point.
@@ -266,8 +266,11 @@ def pack(group):
                     # group of modules. The size is the sum of the height and width
                     # plus the difference between the height and width. This
                     # measure will attempt to keep the area small and square-like.
-                    size = packed_modules.h + packed_modules.w + builtins.abs(
-                        packed_modules.h - packed_modules.w)
+                    size = (
+                        packed_modules.h
+                        + packed_modules.w
+                        + builtins.abs(packed_modules.h - packed_modules.w)
+                    )
 
                     # If this configuration is the smallest so far, store it.
                     if size <= smallest_size:
@@ -286,9 +289,9 @@ def pack(group):
 
 
 def hier_place(brd=None):
-    '''
+    """
     Remove overlaps of board parts while respecting their hierarchy.
-    '''
+    """
 
     brd = brd or GetBoard()
     try:

--- a/python/commands/hierarchical_place.py
+++ b/python/commands/hierarchical_place.py
@@ -1,0 +1,72 @@
+"""Hierarchy-aware footprint placement command.
+
+A thin MCP wrapper around the vendored HierPlace algorithm (see _hierplace.py).
+It clusters a board's footprints by their schematic-sheet hierarchy, so that
+after sync_schematic_to_board dumps every footprint at the origin, each
+functional block lands together -- a sane starting point for manual placement.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger("kicad_interface")
+
+
+class HierarchicalPlaceCommands:
+    """Handler for hierarchy-aware footprint placement on a .kicad_pcb file."""
+
+    def hierarchical_place(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Cluster a board's footprints by schematic hierarchy (HierPlace).
+
+        File-based: reads boardPath, repacks the footprints, writes boardPath
+        back to disk. Save any in-memory board edits first. Locked footprints
+        are left untouched.
+        """
+        logger.info("Hierarchical place: clustering footprints by schematic hierarchy")
+        try:
+            board_path = params.get("boardPath")
+            if not board_path:
+                return {"success": False, "message": "boardPath is required"}
+            path = Path(board_path)
+            if not path.exists():
+                return {"success": False, "message": f"board file not found: {board_path}"}
+
+            try:
+                import pcbnew
+            except Exception as e:
+                return {"success": False, "message": f"pcbnew not available: {e}"}
+            try:
+                from commands._hierplace import hier_place
+            except Exception as e:
+                return {"success": False, "message": f"failed to load HierPlace algorithm: {e}"}
+
+            brd = pcbnew.LoadBoard(str(path))
+            footprint_count = len(list(brd.GetFootprints()))
+            if footprint_count == 0:
+                return {
+                    "success": True,
+                    "placed_count": 0,
+                    "footprint_count": 0,
+                    "message": "no footprints on the board (run sync_schematic_to_board first)",
+                }
+
+            placed = hier_place(brd)
+            pcbnew.SaveBoard(str(path), brd)
+
+            return {
+                "success": True,
+                "placed_count": placed,
+                "footprint_count": footprint_count,
+                "message": (
+                    f"Hierarchically placed {placed} footprint(s) in {path.name}; "
+                    "clustered by schematic sheet"
+                ),
+            }
+
+        except Exception as e:
+            logger.error(f"Error in hierarchical_place: {e}")
+            import traceback
+
+            logger.error(traceback.format_exc())
+            return {"success": False, "message": str(e)}

--- a/python/commands/schematic_hierarchy.py
+++ b/python/commands/schematic_hierarchy.py
@@ -232,9 +232,7 @@ class SchematicHierarchyCommands:
                 "removed_sheet": sheet_name or target_base,
                 "sheet_uuid": sheet_uuid,
                 "removed_instance_path": removed_instance,
-                "message": (
-                    f"Removed sheet '{sheet_name or target_base}' from {parent_file.name}"
-                ),
+                "message": (f"Removed sheet '{sheet_name or target_base}' from {parent_file.name}"),
             }
 
         except Exception as e:
@@ -323,8 +321,7 @@ class SchematicHierarchyCommands:
         for start, end in self._find_sheet_blocks(content):
             block = content[start:end]
             if sheet_name and (
-                f'"Sheetname" "{sheet_name}"' in block
-                or f'"Sheet name" "{sheet_name}"' in block
+                f'"Sheetname" "{sheet_name}"' in block or f'"Sheet name" "{sheet_name}"' in block
             ):
                 return start, end
             if (
@@ -399,16 +396,12 @@ class SchematicHierarchyCommands:
                 block,
             )
             if existing:
-                new_block = (
-                    block[: existing.start(2)] + escaped_value + block[existing.end(2) :]
-                )
+                new_block = block[: existing.start(2)] + escaped_value + block[existing.end(2) :]
                 created = False
             else:
                 # Anchor the new property at the sheet origin; created hidden
                 # (it is metadata, not display text).
-                at_match = re.search(
-                    r"\(at\s+(-?[\d.]+)\s+(-?[\d.]+)", block
-                )
+                at_match = re.search(r"\(at\s+(-?[\d.]+)\s+(-?[\d.]+)", block)
                 x = float(at_match.group(1)) if at_match else 0.0
                 y = float(at_match.group(2)) if at_match else 0.0
                 property_block = (
@@ -422,12 +415,12 @@ class SchematicHierarchyCommands:
                 insert_at = len(block) - 1
                 while insert_at > 0 and block[insert_at - 1] in (" ", "\t", "\n"):
                     insert_at -= 1
-                new_block = block[:insert_at] + "\n" + property_block + block[insert_at:].lstrip(" \t")
+                new_block = (
+                    block[:insert_at] + "\n" + property_block + block[insert_at:].lstrip(" \t")
+                )
                 created = True
 
-            parent_file.write_text(
-                content[:start] + new_block + content[end:], encoding="utf-8"
-            )
+            parent_file.write_text(content[:start] + new_block + content[end:], encoding="utf-8")
             return {
                 "success": True,
                 "key": key,
@@ -484,16 +477,17 @@ class SchematicHierarchyCommands:
                 for m in re.finditer(
                     r'\(property\s+"((?:[^"\\]|\\.)*)"\s+"((?:[^"\\]|\\.)*)"', block
                 ):
-                    unescape = lambda s: s.replace('\\"', '"').replace("\\\\", "\\")
+
+                    def unescape(s: str) -> str:
+                        return s.replace('\\"', '"').replace("\\\\", "\\")
+
                     properties[unescape(m.group(1))] = unescape(m.group(2))
                 uuid_match = re.search(r'\(uuid\s+"?([0-9a-fA-F-]+)"?\)', block)
                 at_match = re.search(r"\(at\s+(-?[\d.]+)\s+(-?[\d.]+)", block)
                 sheets.append(
                     {
-                        "name": properties.get("Sheet name")
-                        or properties.get("Sheetname"),
-                        "file": properties.get("Sheet file")
-                        or properties.get("Sheetfile"),
+                        "name": properties.get("Sheet name") or properties.get("Sheetname"),
+                        "file": properties.get("Sheet file") or properties.get("Sheetfile"),
                         "uuid": uuid_match.group(1) if uuid_match else None,
                         "position": {
                             "x": float(at_match.group(1)) if at_match else None,

--- a/python/commands/schematic_hierarchy.py
+++ b/python/commands/schematic_hierarchy.py
@@ -305,6 +305,208 @@ class SchematicHierarchyCommands:
             logger.error(traceback.format_exc())
             return {"success": False, "message": str(e)}
 
+    _BUILTIN_SHEET_PROPERTIES = ("Sheet name", "Sheetname", "Sheet file", "Sheetfile")
+
+    @staticmethod
+    def _escape_sexpr_string(value: str) -> str:
+        """Escape a string for a double-quoted s-expression token."""
+        return value.replace("\\", "\\\\").replace('"', '\\"')
+
+    def _match_sheet_block(self, content, sheet_name, subsheet_path):
+        """Find the (sheet ...) block identified by sheetName or subsheetPath.
+
+        Matching mirrors remove_hierarchical_sheet: sheetName against the
+        modern 'Sheet name' or legacy 'Sheetname' property, subsheetPath by
+        'Sheet file'/'Sheetfile' basename. Returns (start, end) or None.
+        """
+        target_base = Path(subsheet_path).name if subsheet_path else None
+        for start, end in self._find_sheet_blocks(content):
+            block = content[start:end]
+            if sheet_name and (
+                f'"Sheetname" "{sheet_name}"' in block
+                or f'"Sheet name" "{sheet_name}"' in block
+            ):
+                return start, end
+            if (
+                target_base
+                and f'"{target_base}"' in block
+                and ("Sheetfile" in block or "Sheet file" in block)
+            ):
+                return start, end
+        return None
+
+    def set_sheet_property(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Add or update a custom property on a hierarchical sheet.
+
+        Text-surgery insertion into the (sheet ...) block, preserving the
+        file's formatting. The property is created (hidden by default) if it
+        does not exist, otherwise its value is updated in place. The built-in
+        "Sheet name"/"Sheet file" properties cannot be set here — use
+        add/remove_hierarchical_sheet to manage the sheet link itself.
+        """
+        logger.info("Setting hierarchical sheet property")
+        try:
+            schematic_path = params.get("schematicPath")
+            sheet_name = params.get("sheetName")
+            subsheet_path = params.get("sheetPath") or params.get("subsheetPath")
+            key = params.get("key")
+            value = params.get("value")
+
+            if not schematic_path:
+                return {"success": False, "message": "schematicPath is required"}
+            if not sheet_name and not subsheet_path:
+                return {
+                    "success": False,
+                    "message": "provide sheetName or sheetPath to identify the sheet",
+                }
+            if not isinstance(key, str) or not key:
+                return {"success": False, "message": "key is required"}
+            if value is None:
+                return {"success": False, "message": "value is required"}
+            if key in self._BUILTIN_SHEET_PROPERTIES:
+                return {
+                    "success": False,
+                    "message": (
+                        f"'{key}' is a built-in sheet property; use "
+                        "add_hierarchical_sheet / remove_hierarchical_sheet to "
+                        "manage the sheet link"
+                    ),
+                }
+
+            parent_file = Path(schematic_path)
+            if not parent_file.exists():
+                return {
+                    "success": False,
+                    "message": f"Schematic not found: {schematic_path}",
+                }
+            content = parent_file.read_text(encoding="utf-8")
+
+            match = self._match_sheet_block(content, sheet_name, subsheet_path)
+            if match is None:
+                ident = sheet_name or Path(subsheet_path).name
+                return {
+                    "success": False,
+                    "message": f"no (sheet ...) block matching '{ident}' found in {parent_file.name}",
+                }
+            start, end = match
+            block = content[start:end]
+
+            value_str = str(value)
+            escaped_key = re.escape(key)
+            escaped_value = self._escape_sexpr_string(value_str)
+            existing = re.search(
+                r'(\(property\s+"' + escaped_key + r'"\s+")((?:[^"\\]|\\.)*)(")',
+                block,
+            )
+            if existing:
+                new_block = (
+                    block[: existing.start(2)] + escaped_value + block[existing.end(2) :]
+                )
+                created = False
+            else:
+                # Anchor the new property at the sheet origin; created hidden
+                # (it is metadata, not display text).
+                at_match = re.search(
+                    r"\(at\s+(-?[\d.]+)\s+(-?[\d.]+)", block
+                )
+                x = float(at_match.group(1)) if at_match else 0.0
+                y = float(at_match.group(2)) if at_match else 0.0
+                property_block = (
+                    f'    (property "{self._escape_sexpr_string(key)}" "{escaped_value}" '
+                    f"(at {x} {y} 0)\n"
+                    f"      (effects (font (size 1.27 1.27)) (hide yes))\n"
+                    f"    )\n  "
+                )
+                # Insert before the block's closing paren, after any trailing
+                # whitespace, keeping the original bytes otherwise intact.
+                insert_at = len(block) - 1
+                while insert_at > 0 and block[insert_at - 1] in (" ", "\t", "\n"):
+                    insert_at -= 1
+                new_block = block[:insert_at] + "\n" + property_block + block[insert_at:].lstrip(" \t")
+                created = True
+
+            parent_file.write_text(
+                content[:start] + new_block + content[end:], encoding="utf-8"
+            )
+            return {
+                "success": True,
+                "key": key,
+                "value": value_str,
+                "created": created,
+                "message": (
+                    f"{'Created' if created else 'Updated'} sheet property "
+                    f"'{key}' on sheet "
+                    f"'{sheet_name or Path(subsheet_path).name}'"
+                ),
+            }
+        except Exception as e:
+            logger.error(f"Error setting sheet property: {e}")
+            return {"success": False, "message": str(e)}
+
+    def get_sheet_properties(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """List hierarchical sheets and their properties.
+
+        With sheetName/sheetPath, returns that sheet only; otherwise every
+        sheet in the schematic. Each entry carries name, file, uuid,
+        position, and the full property map (built-ins included).
+        """
+        logger.info("Getting hierarchical sheet properties")
+        try:
+            schematic_path = params.get("schematicPath")
+            sheet_name = params.get("sheetName")
+            subsheet_path = params.get("sheetPath") or params.get("subsheetPath")
+
+            if not schematic_path:
+                return {"success": False, "message": "schematicPath is required"}
+            parent_file = Path(schematic_path)
+            if not parent_file.exists():
+                return {
+                    "success": False,
+                    "message": f"Schematic not found: {schematic_path}",
+                }
+            content = parent_file.read_text(encoding="utf-8")
+
+            spans = self._find_sheet_blocks(content)
+            if sheet_name or subsheet_path:
+                match = self._match_sheet_block(content, sheet_name, subsheet_path)
+                if match is None:
+                    ident = sheet_name or Path(subsheet_path).name
+                    return {
+                        "success": False,
+                        "message": f"no (sheet ...) block matching '{ident}' found in {parent_file.name}",
+                    }
+                spans = [match]
+
+            sheets = []
+            for start, end in spans:
+                block = content[start:end]
+                properties: Dict[str, str] = {}
+                for m in re.finditer(
+                    r'\(property\s+"((?:[^"\\]|\\.)*)"\s+"((?:[^"\\]|\\.)*)"', block
+                ):
+                    unescape = lambda s: s.replace('\\"', '"').replace("\\\\", "\\")
+                    properties[unescape(m.group(1))] = unescape(m.group(2))
+                uuid_match = re.search(r'\(uuid\s+"?([0-9a-fA-F-]+)"?\)', block)
+                at_match = re.search(r"\(at\s+(-?[\d.]+)\s+(-?[\d.]+)", block)
+                sheets.append(
+                    {
+                        "name": properties.get("Sheet name")
+                        or properties.get("Sheetname"),
+                        "file": properties.get("Sheet file")
+                        or properties.get("Sheetfile"),
+                        "uuid": uuid_match.group(1) if uuid_match else None,
+                        "position": {
+                            "x": float(at_match.group(1)) if at_match else None,
+                            "y": float(at_match.group(2)) if at_match else None,
+                        },
+                        "properties": properties,
+                    }
+                )
+            return {"success": True, "sheets": sheets, "count": len(sheets)}
+        except Exception as e:
+            logger.error(f"Error getting sheet properties: {e}")
+            return {"success": False, "message": str(e)}
+
     def fix_subsheet_instances(self, parent_path: str, parent_content: str) -> List[str]:
         """Ensure every component in each referenced sub-sheet has an instances entry for the
         sheet-block UUID, so ERC resolves references correctly. Returns modified sub-sheet paths.

--- a/python/commands/schematic_hierarchy.py
+++ b/python/commands/schematic_hierarchy.py
@@ -3,6 +3,7 @@ Schematic hierarchical-sheet commands.
 
 Tools:
   - add_hierarchical_sheet:       insert a hierarchical-sheet reference into a parent schematic
+  - remove_hierarchical_sheet:    remove a hierarchical-sheet reference (reverse of add)
   - create_hierarchical_subsheet: create a sub-sheet file and link it in one call
 
 The command class holds a back-reference to KiCADInterface so it can reuse the existing
@@ -129,6 +130,115 @@ class SchematicHierarchyCommands:
 
         except Exception as e:
             logger.error(f"Error adding hierarchical sheet: {e}")
+            import traceback
+
+            logger.error(traceback.format_exc())
+            return {"success": False, "message": str(e)}
+
+    @staticmethod
+    def _find_sheet_blocks(content: str) -> List[tuple]:
+        """Return (start, end) spans of every top-level (sheet ...) block.
+
+        Matches '(sheet ' (with whitespace) so it never catches '(sheet_instances'.
+        """
+        spans: List[tuple] = []
+        for m in re.finditer(r"\(sheet\s", content):
+            start = m.start()
+            depth = 0
+            for i in range(start, len(content)):
+                if content[i] == "(":
+                    depth += 1
+                elif content[i] == ")":
+                    depth -= 1
+                    if depth == 0:
+                        spans.append((start, i + 1))
+                        break
+        return spans
+
+    def remove_hierarchical_sheet(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Remove a hierarchical-sheet reference from a parent schematic.
+
+        Identify the sheet by sheetName (matches the 'Sheetname'/'Sheet name'
+        property) or by subsheetPath (matches the 'Sheetfile'/'Sheet file'
+        property basename). Removes the (sheet ...) block and any matching
+        (path .../<uuid>) entry in (sheet_instances). The reverse of
+        add_hierarchical_sheet. Does NOT delete the sub-sheet file on disk.
+        """
+        logger.info("Removing hierarchical sheet")
+        try:
+            schematic_path = params.get("schematicPath")
+            sheet_name = params.get("sheetName")
+            subsheet_path = params.get("subsheetPath")
+
+            if not schematic_path:
+                return {"success": False, "message": "schematicPath is required"}
+            if not sheet_name and not subsheet_path:
+                return {
+                    "success": False,
+                    "message": "provide sheetName or subsheetPath to identify the sheet to remove",
+                }
+
+            parent_file = Path(schematic_path)
+            content = parent_file.read_text(encoding="utf-8")
+            target_base = Path(subsheet_path).name if subsheet_path else None
+
+            match = None
+            for start, end in self._find_sheet_blocks(content):
+                block = content[start:end]
+                if sheet_name and (
+                    f'"Sheetname" "{sheet_name}"' in block
+                    or f'"Sheet name" "{sheet_name}"' in block
+                ):
+                    match = (start, end, block)
+                    break
+                if (
+                    target_base
+                    and f'"{target_base}"' in block
+                    and ("Sheetfile" in block or "Sheet file" in block)
+                ):
+                    match = (start, end, block)
+                    break
+
+            if not match:
+                ident = sheet_name or target_base
+                return {
+                    "success": False,
+                    "message": f"no (sheet ...) block matching '{ident}' found in {parent_file.name}",
+                }
+
+            start, end, block = match
+            uuid_match = re.search(r'\(uuid\s+"?([0-9a-fA-F-]+)"?\)', block)
+            sheet_uuid = uuid_match.group(1) if uuid_match else None
+
+            # Drop the (sheet ...) block plus the blank line it leaves behind.
+            new_content = content[:start] + content[end:]
+            new_content = re.sub(r"\n[ \t]*\n[ \t]*\n", "\n\n", new_content)
+
+            removed_instance = False
+            if sheet_uuid:
+                new_content, n = re.subn(
+                    r'[ \t]*\(path\s+"[^"]*'
+                    + re.escape(sheet_uuid)
+                    + r'[^"]*"\s+\(page\s+"[^"]*"\)\)[ \t]*\n?',
+                    "",
+                    new_content,
+                )
+                removed_instance = n > 0
+
+            parent_file.write_text(new_content, encoding="utf-8")
+
+            return {
+                "success": True,
+                "removed_sheet": sheet_name or target_base,
+                "sheet_uuid": sheet_uuid,
+                "removed_instance_path": removed_instance,
+                "message": (
+                    f"Removed sheet '{sheet_name or target_base}' from {parent_file.name}"
+                ),
+            }
+
+        except Exception as e:
+            logger.error(f"Error removing hierarchical sheet: {e}")
             import traceback
 
             logger.error(traceback.format_exc())

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -331,6 +331,7 @@ try:
     from commands.export import ExportCommands
     from commands.footprint import FootprintCreator
     from commands.freerouting import FreeroutingCommands
+    from commands.hierarchical_place import HierarchicalPlaceCommands
     from commands.jlcpcb import JLCPCBClient, test_jlcpcb_connection
     from commands.jlcpcb_parts import JLCPCBPartsManager
     from commands.library import (
@@ -340,7 +341,6 @@ try:
     from commands.library_management import LibraryManagementCommands
     from commands.library_schematic import LibraryManager as SchematicLibraryManager
     from commands.library_symbol import SymbolLibraryCommands, SymbolLibraryManager
-    from commands.hierarchical_place import HierarchicalPlaceCommands
     from commands.project import ProjectCommands
     from commands.routing import RoutingCommands
     from commands.schematic import SchematicManager

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -546,6 +546,8 @@ class KiCADInterface(SchematicHandlersMixin):
             # Schematic hierarchy commands (sheet insertion + subsheet scaffolding)
             "add_hierarchical_sheet": self.hierarchy_commands.add_hierarchical_sheet,
             "remove_hierarchical_sheet": self.hierarchy_commands.remove_hierarchical_sheet,
+            "set_sheet_property": self.hierarchy_commands.set_sheet_property,
+            "get_sheet_properties": self.hierarchy_commands.get_sheet_properties,
             "create_hierarchical_subsheet": self.hierarchy_commands.create_hierarchical_subsheet,
             # Schematic field placement commands
             "set_schematic_property_position": self.field_layout_commands.set_schematic_property_position,

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -545,6 +545,7 @@ class KiCADInterface(SchematicHandlersMixin):
             "batch_list_symbol_pins": self.symbol_pin_commands.batch_list_symbol_pins,
             # Schematic hierarchy commands (sheet insertion + subsheet scaffolding)
             "add_hierarchical_sheet": self.hierarchy_commands.add_hierarchical_sheet,
+            "remove_hierarchical_sheet": self.hierarchy_commands.remove_hierarchical_sheet,
             "create_hierarchical_subsheet": self.hierarchy_commands.create_hierarchical_subsheet,
             # Schematic field placement commands
             "set_schematic_property_position": self.field_layout_commands.set_schematic_property_position,

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -340,6 +340,7 @@ try:
     from commands.library_management import LibraryManagementCommands
     from commands.library_schematic import LibraryManager as SchematicLibraryManager
     from commands.library_symbol import SymbolLibraryCommands, SymbolLibraryManager
+    from commands.hierarchical_place import HierarchicalPlaceCommands
     from commands.project import ProjectCommands
     from commands.routing import RoutingCommands
     from commands.schematic import SchematicManager
@@ -414,6 +415,7 @@ class KiCADInterface(SchematicHandlersMixin):
         self.library_management_commands = LibraryManagementCommands()
         self.design_rule_commands = DesignRuleCommands(self.board)
         self.export_commands = ExportCommands(self.board)
+        self.hierarchical_place_commands = HierarchicalPlaceCommands()
         self.library_commands = LibraryCommands(self.footprint_library)
         self._current_project_path: Optional[Path] = None  # set when boardPath is known
 
@@ -472,6 +474,7 @@ class KiCADInterface(SchematicHandlersMixin):
             "delete_graphic": self.board_commands.delete_graphic,
             "update_graphic": self.board_commands.update_graphic,
             "add_mounting_hole": self.board_commands.add_mounting_hole,
+            "hierarchical_place": self.hierarchical_place_commands.hierarchical_place,
             "add_text": self.board_commands.add_text,
             "add_board_text": self.board_commands.add_text,  # Alias for TypeScript tool
             # Component commands

--- a/src/tools/component.ts
+++ b/src/tools/component.ts
@@ -946,5 +946,23 @@ export function registerComponentTools(server: McpServer, callKicadScript: Comma
     },
   );
 
+  // ------------------------------------------------------
+  // Hierarchical Place Tool (footprint clustering by schematic sheet)
+  // ------------------------------------------------------
+  server.tool(
+    "hierarchical_place",
+    "Cluster a board's footprints by their schematic-sheet hierarchy (the HierPlace algorithm). After sync_schematic_to_board piles every footprint at the origin, this packs each functional block together as a starting point for manual placement. File-based: reads and rewrites the .kicad_pcb on disk, so save any in-memory board edits first. Locked footprints are left in place.",
+    {
+      boardPath: z.string().describe("Absolute path to the .kicad_pcb file to re-place"),
+    },
+    async ({ boardPath }) => {
+      logger.debug(`Hierarchical place on board: ${boardPath}`);
+      const result = await callKicadScript("hierarchical_place", { boardPath });
+      if (result.success === false && result.message)
+        return { content: [{ type: "text", text: `Failed: ${result.message}` }] };
+      return { content: [{ type: "text", text: result.message || JSON.stringify(result) }] };
+    },
+  );
+
   logger.info("Component management tools registered");
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -60,6 +60,7 @@ export const toolCategories: ToolCategory[] = [
       "add_component_annotation",
       "group_components",
       "replace_component",
+      "hierarchical_place",
     ],
   },
   {

--- a/src/tools/schematic-hierarchy.ts
+++ b/src/tools/schematic-hierarchy.ts
@@ -60,6 +60,53 @@ export function registerSchematicHierarchyTools(server: McpServer, callKicadScri
     },
   );
 
+  // Set a custom property on a hierarchical sheet
+  server.tool(
+    "set_sheet_property",
+    "Add or update a custom property on a hierarchical sheet's (sheet ...) block — e.g. cell identity or generator parameters carried as sheet metadata. Identify the sheet by sheetName or sheetPath (basename match against the sheet's file property). The property is created hidden if absent, otherwise its value is updated in place; the file's formatting is preserved. The built-in 'Sheet name'/'Sheet file' properties cannot be set here — use add/remove_hierarchical_sheet to manage the sheet link.",
+    {
+      schematicPath: z.string().describe("Path to the parent .kicad_sch"),
+      sheetName: z
+        .string()
+        .optional()
+        .describe("Sheet display name (matches the Sheetname/Sheet name property)"),
+      sheetPath: z
+        .string()
+        .optional()
+        .describe("Sub-sheet file (matched by basename against the Sheetfile property)"),
+      key: z.string().describe("Property name (e.g. 'IS.Cell')"),
+      value: z.string().describe("Property value"),
+    },
+    async (args: any) => {
+      const r = await callKicadScript("set_sheet_property", args);
+      if (!r.success)
+        return { content: [{ type: "text", text: `Failed: ${r.message || "Unknown error"}` }] };
+      return { content: [{ type: "text", text: r.message }] };
+    },
+  );
+
+  // List hierarchical sheets and their properties
+  server.tool(
+    "get_sheet_properties",
+    "List hierarchical sheets in a schematic with their name, file, uuid, position, and full property map (built-ins plus custom properties set via set_sheet_property). With sheetName or sheetPath, returns just that sheet.",
+    {
+      schematicPath: z.string().describe("Path to the parent .kicad_sch"),
+      sheetName: z.string().optional().describe("Only this sheet (by display name)"),
+      sheetPath: z
+        .string()
+        .optional()
+        .describe("Only this sheet (by file basename)"),
+    },
+    async (args: any) => {
+      const r = await callKicadScript("get_sheet_properties", args);
+      if (!r.success)
+        return { content: [{ type: "text", text: `Failed: ${r.message || "Unknown error"}` }] };
+      return {
+        content: [{ type: "text", text: JSON.stringify(r.sheets, null, 2) }],
+      };
+    },
+  );
+
   // Create a sub-sheet file AND link it in one call
   server.tool(
     "create_hierarchical_subsheet",

--- a/src/tools/schematic-hierarchy.ts
+++ b/src/tools/schematic-hierarchy.ts
@@ -37,6 +37,29 @@ export function registerSchematicHierarchyTools(server: McpServer, callKicadScri
     },
   );
 
+  // Remove a hierarchical sheet reference from a parent
+  server.tool(
+    "remove_hierarchical_sheet",
+    "Remove a hierarchical-sheet reference from a parent schematic (the reverse of add_hierarchical_sheet). Identify the sheet by sheetName (matches the sheet's name property) or by subsheetPath (matched by basename against the sheet's file property). Deletes the (sheet ...) block and any matching (sheet_instances) page entry. Does NOT delete the sub-sheet .kicad_sch file on disk.",
+    {
+      schematicPath: z.string().describe("Path to the parent .kicad_sch"),
+      sheetName: z
+        .string()
+        .optional()
+        .describe("Sheet display name to remove (matches the Sheetname/Sheet name property)"),
+      subsheetPath: z
+        .string()
+        .optional()
+        .describe("Sub-sheet file to remove (matched by basename against the Sheetfile property)"),
+    },
+    async (args: any) => {
+      const r = await callKicadScript("remove_hierarchical_sheet", args);
+      if (!r.success)
+        return { content: [{ type: "text", text: `Failed: ${r.message || "Unknown error"}` }] };
+      return { content: [{ type: "text", text: r.message }] };
+    },
+  );
+
   // Create a sub-sheet file AND link it in one call
   server.tool(
     "create_hierarchical_subsheet",

--- a/src/tools/schematic-hierarchy.ts
+++ b/src/tools/schematic-hierarchy.ts
@@ -92,10 +92,7 @@ export function registerSchematicHierarchyTools(server: McpServer, callKicadScri
     {
       schematicPath: z.string().describe("Path to the parent .kicad_sch"),
       sheetName: z.string().optional().describe("Only this sheet (by display name)"),
-      sheetPath: z
-        .string()
-        .optional()
-        .describe("Only this sheet (by file basename)"),
+      sheetPath: z.string().optional().describe("Only this sheet (by file basename)"),
     },
     async (args: any) => {
       const r = await callKicadScript("get_sheet_properties", args);

--- a/tests/test_hierarchical_place.py
+++ b/tests/test_hierarchical_place.py
@@ -1,0 +1,80 @@
+"""Tests for hierarchical_place (commands/hierarchical_place.py).
+
+Parameter validation runs against the stubbed pcbnew from conftest. The real
+placement round-trip needs the actual pcbnew module and is gated on
+KICAD_USE_REAL_PCBNEW=1 (same convention as test_real_pcbnew_matrix.py).
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.hierarchical_place import HierarchicalPlaceCommands  # noqa: E402
+
+
+def test_requires_board_path():
+    r = HierarchicalPlaceCommands().hierarchical_place({})
+    assert r["success"] is False
+    assert "boardPath" in r["message"]
+
+
+def test_missing_file():
+    r = HierarchicalPlaceCommands().hierarchical_place(
+        {"boardPath": "/no/such/board.kicad_pcb"}
+    )
+    assert r["success"] is False
+    assert "not found" in r["message"]
+
+
+class TestRealPcbnew:
+    @pytest.fixture(autouse=True)
+    def require_real_pcbnew(self):
+        if os.environ.get("KICAD_USE_REAL_PCBNEW") != "1":
+            pytest.skip("requires real pcbnew (set KICAD_USE_REAL_PCBNEW=1)")
+
+    def test_deoverlaps_real_board(self, tmp_path):
+        import pcbnew
+
+        fp_lib = "/usr/share/kicad/footprints/Resistor_SMD.pretty"
+        if not Path(fp_lib).exists():
+            pytest.skip("stock footprint library not installed")
+
+        brd = pcbnew.BOARD()
+        for ref in ["R1", "R2", "R3"]:
+            fp = pcbnew.FootprintLoad(fp_lib, "R_0805_2012Metric")
+            if fp is None:
+                pytest.skip("could not load test footprint")
+            fp.SetParent(brd)
+            fp.SetReference(ref)
+            fp.SetPosition(pcbnew.VECTOR2I(pcbnew.FromMM(10), pcbnew.FromMM(10)))  # all overlap
+            brd.Add(fp)
+        board_path = tmp_path / "b.kicad_pcb"
+        pcbnew.SaveBoard(str(board_path), brd)
+
+        r = HierarchicalPlaceCommands().hierarchical_place({"boardPath": str(board_path)})
+        assert r["success"] is True, r
+        assert r["footprint_count"] == 3
+        assert r["placed_count"] == 3
+
+        reloaded = pcbnew.LoadBoard(str(board_path))
+        positions = {
+            f.GetReference(): (f.GetPosition().x, f.GetPosition().y)
+            for f in reloaded.GetFootprints()
+        }
+        assert len(positions) == 3
+        # The three no longer share a single coordinate -> they were de-overlapped.
+        assert len(set(positions.values())) > 1
+
+    def test_empty_board(self, tmp_path):
+        import pcbnew
+
+        brd = pcbnew.BOARD()
+        board_path = tmp_path / "empty.kicad_pcb"
+        pcbnew.SaveBoard(str(board_path), brd)
+        r = HierarchicalPlaceCommands().hierarchical_place({"boardPath": str(board_path)})
+        assert r["success"] is True, r
+        assert r["placed_count"] == 0

--- a/tests/test_hierarchical_place.py
+++ b/tests/test_hierarchical_place.py
@@ -23,9 +23,7 @@ def test_requires_board_path():
 
 
 def test_missing_file():
-    r = HierarchicalPlaceCommands().hierarchical_place(
-        {"boardPath": "/no/such/board.kicad_pcb"}
-    )
+    r = HierarchicalPlaceCommands().hierarchical_place({"boardPath": "/no/such/board.kicad_pcb"})
     assert r["success"] is False
     assert "not found" in r["message"]
 

--- a/tests/test_schematic_hierarchy.py
+++ b/tests/test_schematic_hierarchy.py
@@ -120,6 +120,92 @@ class TestCreateHierarchicalSubsheet:
         )
 
 
+class TestRemoveHierarchicalSheet:
+    # A two-sheet parent in the legacy (kiutils) format: 'Sheetname'/'Sheetfile'
+    # with a per-sheet (instances (project (path ...))) block; top-level
+    # sheet_instances carries only the root page.
+    LEGACY_PARENT = (
+        "(kicad_sch (uuid root-uuid)\n"
+        "  (sheet (at 38 114) (size 45 15)\n"
+        "    (uuid 11111111-1111-1111-1111-111111111111)\n"
+        '    (property "Sheetname" "Discovery Interface" (at 1 1 0))\n'
+        '    (property "Sheetfile" "interface.kicad_sch" (at 1 2 0))\n'
+        '    (instances (project "p" (path "/11111111-1111-1111-1111-111111111111" (page "2"))))\n'
+        "  )\n"
+        "  (sheet (at 101 114) (size 45 15)\n"
+        "    (uuid 22222222-2222-2222-2222-222222222222)\n"
+        '    (property "Sheetname" "Analog Mux" (at 1 1 0))\n'
+        '    (property "Sheetfile" "mux.kicad_sch" (at 1 2 0))\n'
+        '    (instances (project "p" (path "/22222222-2222-2222-2222-222222222222" (page "8"))))\n'
+        "  )\n"
+        '  (sheet_instances (path "/" (page "1")))\n'
+        ")\n"
+    )
+
+    def test_requires_identifier(self, tmp_path):
+        parent = tmp_path / "top.kicad_sch"
+        parent.write_text(self.LEGACY_PARENT)
+        r = _cmds().remove_hierarchical_sheet({"schematicPath": str(parent)})
+        assert r["success"] is False
+
+    def test_remove_by_name_legacy_keeps_siblings(self, tmp_path):
+        parent = tmp_path / "top.kicad_sch"
+        parent.write_text(self.LEGACY_PARENT)
+        r = _cmds().remove_hierarchical_sheet(
+            {"schematicPath": str(parent), "sheetName": "Analog Mux"}
+        )
+        assert r["success"] is True
+        assert r["sheet_uuid"] == "22222222-2222-2222-2222-222222222222"
+        content = parent.read_text()
+        assert "mux.kicad_sch" not in content  # removed
+        assert "Analog Mux" not in content
+        assert "interface.kicad_sch" in content  # sibling preserved
+        assert content.count("(sheet ") == 1
+
+    def test_remove_by_subsheet_path_basename(self, tmp_path):
+        parent = tmp_path / "top.kicad_sch"
+        parent.write_text(self.LEGACY_PARENT)
+        r = _cmds().remove_hierarchical_sheet(
+            {"schematicPath": str(parent), "subsheetPath": "/anywhere/mux.kicad_sch"}
+        )
+        assert r["success"] is True
+        assert "mux.kicad_sch" not in parent.read_text()
+
+    def test_no_match_fails(self, tmp_path):
+        parent = tmp_path / "top.kicad_sch"
+        parent.write_text(self.LEGACY_PARENT)
+        r = _cmds().remove_hierarchical_sheet(
+            {"schematicPath": str(parent), "sheetName": "Nonexistent"}
+        )
+        assert r["success"] is False
+
+    def test_roundtrip_add_then_remove_modern(self, tmp_path):
+        # add_hierarchical_sheet writes the modern format with a top-level
+        # sheet_instances path entry; remove must clean both the block and that entry.
+        parent = tmp_path / "top.kicad_sch"
+        parent.write_text(
+            '(kicad_sch (uuid abcd-1234)\n  (sheet_instances (path "/" (page "1")))\n)'
+        )
+        c = _cmds()
+        add = c.add_hierarchical_sheet(
+            {
+                "schematicPath": str(parent),
+                "subsheetPath": str(tmp_path / "power.kicad_sch"),
+                "sheetName": "Power",
+            }
+        )
+        assert add["success"] is True
+        assert add["sheet_uuid"] in parent.read_text()
+
+        rem = c.remove_hierarchical_sheet({"schematicPath": str(parent), "sheetName": "Power"})
+        assert rem["success"] is True
+        assert rem["removed_instance_path"] is True
+        content = parent.read_text()
+        assert "power.kicad_sch" not in content
+        assert add["sheet_uuid"] not in content  # sheet_instances path entry gone too
+        assert '(path "/" (page "1"))' in content  # root page entry preserved
+
+
 class TestFixSubsheetInstances:
     def test_adds_path_entry(self, tmp_path):
         sub = tmp_path / "sub.kicad_sch"

--- a/tests/test_schematic_hierarchy.py
+++ b/tests/test_schematic_hierarchy.py
@@ -228,3 +228,209 @@ class TestFixSubsheetInstances:
         sub_after = sub.read_text()
         assert "/abcd-1234/sheet-blk-1" in sub_after
         assert '(reference "R1")' in sub_after
+
+
+class TestSheetProperties:
+    """set_sheet_property / get_sheet_properties — custom metadata on
+    (sheet ...) blocks (e.g. generator cell identity/params)."""
+
+    def _parent_with_sheet(self, tmp_path, name="Power"):
+        parent = tmp_path / "top.kicad_sch"
+        parent.write_text(
+            '(kicad_sch (uuid abcd-1234)\n  (sheet_instances (path "/" (page "1")))\n)'
+        )
+        r = _cmds().add_hierarchical_sheet(
+            {
+                "schematicPath": str(parent),
+                "subsheetPath": str(tmp_path / "sub.kicad_sch"),
+                "sheetName": name,
+            }
+        )
+        assert r["success"] is True
+        return parent
+
+    def test_requires_params(self, tmp_path):
+        c = _cmds()
+        assert c.set_sheet_property({})["success"] is False
+        assert c.set_sheet_property({"schematicPath": "/x"})["success"] is False
+        assert (
+            c.set_sheet_property({"schematicPath": "/x", "sheetName": "A"})["success"]
+            is False
+        )
+        assert (
+            c.set_sheet_property(
+                {"schematicPath": "/x", "sheetName": "A", "key": "K"}
+            )["success"]
+            is False
+        )
+        assert c.get_sheet_properties({})["success"] is False
+
+    def test_builtin_keys_rejected(self, tmp_path):
+        parent = self._parent_with_sheet(tmp_path)
+        for key in ("Sheet name", "Sheet file", "Sheetname", "Sheetfile"):
+            r = _cmds().set_sheet_property(
+                {
+                    "schematicPath": str(parent),
+                    "sheetName": "Power",
+                    "key": key,
+                    "value": "x",
+                }
+            )
+            assert r["success"] is False
+            assert "built-in" in r["message"]
+
+    def test_create_update_round_trip(self, tmp_path):
+        parent = self._parent_with_sheet(tmp_path)
+        before = parent.read_text()
+        c = _cmds()
+
+        r = c.set_sheet_property(
+            {
+                "schematicPath": str(parent),
+                "sheetName": "Power",
+                "key": "IS.Cell",
+                "value": "vca_2164",
+            }
+        )
+        assert r["success"] is True
+        assert r["created"] is True
+
+        # Formatting preserved: every original line still present verbatim
+        after = parent.read_text()
+        for line in before.splitlines():
+            assert line in after, f"original line lost: {line!r}"
+
+        g = c.get_sheet_properties({"schematicPath": str(parent), "sheetName": "Power"})
+        assert g["success"] is True
+        assert g["count"] == 1
+        sheet = g["sheets"][0]
+        assert sheet["name"] == "Power"
+        assert sheet["properties"]["IS.Cell"] == "vca_2164"
+
+        # Update in place: no duplicate property block
+        r = c.set_sheet_property(
+            {
+                "schematicPath": str(parent),
+                "sheetName": "Power",
+                "key": "IS.Cell",
+                "value": "svf_2164",
+            }
+        )
+        assert r["success"] is True
+        assert r["created"] is False
+        content = parent.read_text()
+        assert content.count('"IS.Cell"') == 1
+        assert "svf_2164" in content and "vca_2164" not in content
+
+    def test_identify_by_sheet_path(self, tmp_path):
+        parent = self._parent_with_sheet(tmp_path)
+        c = _cmds()
+        r = c.set_sheet_property(
+            {
+                "schematicPath": str(parent),
+                "sheetPath": "sub.kicad_sch",
+                "key": "IS.Param.freq",
+                "value": "440",
+            }
+        )
+        assert r["success"] is True
+        g = c.get_sheet_properties(
+            {"schematicPath": str(parent), "sheetPath": "sub.kicad_sch"}
+        )
+        assert g["sheets"][0]["properties"]["IS.Param.freq"] == "440"
+
+    def test_unknown_sheet_fails(self, tmp_path):
+        parent = self._parent_with_sheet(tmp_path)
+        r = _cmds().set_sheet_property(
+            {
+                "schematicPath": str(parent),
+                "sheetName": "Nope",
+                "key": "K",
+                "value": "V",
+            }
+        )
+        assert r["success"] is False
+        assert "no (sheet" in r["message"]
+
+    def test_get_all_sheets(self, tmp_path):
+        parent = self._parent_with_sheet(tmp_path, name="Power")
+        r = _cmds().add_hierarchical_sheet(
+            {
+                "schematicPath": str(parent),
+                "subsheetPath": str(tmp_path / "io.kicad_sch"),
+                "sheetName": "IO",
+            }
+        )
+        assert r["success"] is True
+        g = _cmds().get_sheet_properties({"schematicPath": str(parent)})
+        assert g["success"] is True
+        assert g["count"] == 2
+        assert {s["name"] for s in g["sheets"]} == {"Power", "IO"}
+        assert all(s["uuid"] for s in g["sheets"])
+        assert all(s["position"]["x"] is not None for s in g["sheets"])
+
+    def test_value_escaping(self, tmp_path):
+        parent = self._parent_with_sheet(tmp_path)
+        c = _cmds()
+        tricky = 'quote " backslash \\ done'
+        r = c.set_sheet_property(
+            {
+                "schematicPath": str(parent),
+                "sheetName": "Power",
+                "key": "IS.Note",
+                "value": tricky,
+            }
+        )
+        assert r["success"] is True
+        g = c.get_sheet_properties({"schematicPath": str(parent), "sheetName": "Power"})
+        assert g["sheets"][0]["properties"]["IS.Note"] == tricky
+        # still parseable as an s-expression
+        import sexpdata
+
+        sexpdata.loads(parent.read_text())
+
+    def test_kicad_cli_still_parses(self, tmp_path):
+        """Render/parse check: kicad-cli must accept the modified parent."""
+        import shutil as _shutil
+        import subprocess
+
+        import pytest as _pytest
+
+        if _shutil.which("kicad-cli") is None:
+            _pytest.skip("kicad-cli not available")
+
+        template = (
+            Path(__file__).parent.parent / "python" / "templates" / "blank.kicad_sch"
+        )
+        parent = tmp_path / "top.kicad_sch"
+        parent.write_text(template.read_text(encoding="utf-8"), encoding="utf-8")
+        sub = tmp_path / "sub.kicad_sch"
+        sub.write_text(template.read_text(encoding="utf-8"), encoding="utf-8")
+
+        c = _cmds()
+        assert c.add_hierarchical_sheet(
+            {
+                "schematicPath": str(parent),
+                "subsheetPath": str(sub),
+                "sheetName": "Cell",
+            }
+        )["success"]
+        assert c.set_sheet_property(
+            {
+                "schematicPath": str(parent),
+                "sheetName": "Cell",
+                "key": "IS.Cell",
+                "value": "vca_2164",
+            }
+        )["success"]
+
+        out_dir = tmp_path / "svg"
+        out_dir.mkdir()
+        result = subprocess.run(
+            ["kicad-cli", "sch", "export", "svg", str(parent), "-o", str(out_dir)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        assert list(out_dir.glob("*.svg"))

--- a/tests/test_schematic_hierarchy.py
+++ b/tests/test_schematic_hierarchy.py
@@ -253,14 +253,9 @@ class TestSheetProperties:
         c = _cmds()
         assert c.set_sheet_property({})["success"] is False
         assert c.set_sheet_property({"schematicPath": "/x"})["success"] is False
+        assert c.set_sheet_property({"schematicPath": "/x", "sheetName": "A"})["success"] is False
         assert (
-            c.set_sheet_property({"schematicPath": "/x", "sheetName": "A"})["success"]
-            is False
-        )
-        assert (
-            c.set_sheet_property(
-                {"schematicPath": "/x", "sheetName": "A", "key": "K"}
-            )["success"]
+            c.set_sheet_property({"schematicPath": "/x", "sheetName": "A", "key": "K"})["success"]
             is False
         )
         assert c.get_sheet_properties({})["success"] is False
@@ -334,9 +329,7 @@ class TestSheetProperties:
             }
         )
         assert r["success"] is True
-        g = c.get_sheet_properties(
-            {"schematicPath": str(parent), "sheetPath": "sub.kicad_sch"}
-        )
+        g = c.get_sheet_properties({"schematicPath": str(parent), "sheetPath": "sub.kicad_sch"})
         assert g["sheets"][0]["properties"]["IS.Param.freq"] == "440"
 
     def test_unknown_sheet_fails(self, tmp_path):
@@ -399,9 +392,7 @@ class TestSheetProperties:
         if _shutil.which("kicad-cli") is None:
             _pytest.skip("kicad-cli not available")
 
-        template = (
-            Path(__file__).parent.parent / "python" / "templates" / "blank.kicad_sch"
-        )
+        template = Path(__file__).parent.parent / "python" / "templates" / "blank.kicad_sch"
         parent = tmp_path / "top.kicad_sch"
         parent.write_text(template.read_text(encoding="utf-8"), encoding="utf-8")
         sub = tmp_path / "sub.kicad_sch"


### PR DESCRIPTION
Part of the à la carte split of #314 (per maintainer request for smaller, independently-mergeable PRs).

**Adds three hierarchical-design tools** (all new files — no changes to existing command logic):
- `remove_hierarchical_sheet` — reverse of add_hierarchical_sheet; removes the (sheet …) block + its (sheet_instances) path entry (does not delete the sub-sheet file).
- `set_sheet_property` — edit a hierarchical sheet's name/file/other properties in place.
- `hierarchical_place` — PCB placement that mirrors the schematic sheet hierarchy (vendored HierPlace, MIT, credited in-file).

New files: `python/commands/schematic_hierarchy.py`, `python/commands/_hierplace.py` (vendored), `python/commands/hierarchical_place.py`, `src/tools/schematic-hierarchy.ts`, plus dispatch/registry/schema registration and tests.

Green on the enforced gate: `pre-commit run --all-files` (black/isort/prettier/flake8/mypy/eslint) passes; `npm run build` + `npm test` (64) pass; `pytest` for the hierarchy tools passes (22 passed, 2 skipped). README tool-count line synced to the registry.