### PR TITLE
Schematic authoring & lint tooling: diagnosed load errors, flat-symbol repair, correct SVG page, batch/label fixes, offgrid+cosmetic lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ connections = ConnectionManager.get_net_connections(sch, "VCC", sch_path)
 - Net connectivity: 100% accurate (VCC: 2 connections, GND: 4 connections)
 - Netlist generation: Working with accurate pin-level connections
 
-See [Schematic Tools Reference](docs/SCHEMATIC_TOOLS_REFERENCE.md) for the complete schematic tool documentation.
+See [Schematic Tools Reference](docs/SCHEMATIC_TOOLS_REFERENCE.md) for the complete schematic tool documentation, and the [Headless Authoring Guide](docs/HEADLESS_AUTHORING.md) for field-tested practice driving these tools without the KiCad GUI.
 
 ### IPC Backend (Experimental)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 **Key Capabilities:**
 
-- 143 tools across 13 categories with JSON Schema validation
+- 144 tools across 13 categories with JSON Schema validation
 - Smart tool discovery with router pattern (reduces AI context by 70%)
 - 8 dynamic resources exposing project state
 - Complete schematic workflow with 27 tools and dynamic symbol loading (~10,000 symbols)

--- a/docs/HEADLESS_AUTHORING.md
+++ b/docs/HEADLESS_AUTHORING.md
@@ -1,0 +1,223 @@
+# Headless Schematic Authoring Guide
+
+Field-tested practice for driving the KiCAD MCP Server without the KiCad
+GUI: the per-sheet build recipe, diagnostics, ERC triage, and verification
+discipline. Distilled from building a complete multi-sheet automotive
+carrier design entirely through the server (observed on KiCad 9/10, Linux).
+
+See [SCHEMATIC_TOOLS_REFERENCE.md](SCHEMATIC_TOOLS_REFERENCE.md) for
+per-tool parameters and [ARCHITECTURE.md](ARCHITECTURE.md) for how the
+server is put together.
+
+---
+
+## 1. Two parsers, one truth
+
+Two different parsers are in play, and they disagree — this is the source
+of most headless pitfalls:
+
+| Parser         | Used by                                                                                        | Character                                  |
+| -------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| **kicad-cli**  | `run_erc`, all `export_*`, netlist generation                                                  | Ground truth (what KiCad does)             |
+| **kicad-skip** | editing/inspection tools (`list_schematic_components`, `batch_connect`, pin location, labels…) | Stricter; rejects some files KiCad accepts |
+
+**Diagnostic rule: when a skip-based tool disagrees with ERC or a render,
+believe kicad-cli.** A schematic can be perfectly valid KiCad and still be
+skip-hostile (see §7a). Schematic load failures surface as a structured
+`schematic_load_failed` error naming the offending symbols rather than
+empty results — treat that error as authoritative, not as noise.
+
+---
+
+## 2. Per-sheet build recipe
+
+A proven flow for authoring one sheet end-to-end:
+
+1. `create_schematic(name, path)` — starts from a blank template.
+2. `batch_add_and_connect(schematicPath, components: [...])` — place
+   symbols and connect their pins by net name in one call.
+   - Use `labelType: "global_label"` when the design connects across
+     sheets by name (one valid convention for generated designs — power
+     rails and cross-sheet signals join by label name, no wires).
+   - Put component origins on a **2.54 mm grid** (pin offsets are
+     1.27/2.54 multiples, so pins land on the connection grid).
+   - Space parts ~12.7 mm apart so labels don't overlap (a global label
+     extends ~7.6 mm from the pin).
+3. `batch_add_no_connects(schematicPath, pins: [...])` — flag genuinely
+   unused pins so they don't show up as ERC errors.
+4. `run_erc(schematicPath)` — expect **0 errors**; triage warnings per §4.
+5. `export_schematic_svg(schematicPath, outputPath)` — render the sheet,
+   convert to PNG with any converter, and **eyeball it**.
+
+---
+
+## 3. Verification discipline
+
+The skip-based tools have blind spots; a sheet is only _done_ when all
+three hold:
+
+1. `run_erc` reports **0 errors**, with warnings triaged (§4), AND
+2. the exported SVG/PDF has been **rendered and eyeballed** for misplaced
+   or overlapping labels and wrong topology, AND
+3. `generate_netlist` / `export_netlist` confirms the expected net→pin
+   map for anything you are not sure about.
+
+**Never trust "connected N pin(s)" alone.** Cross-check with kicad-cli
+ERC and a render. Historically the batch tools could report success while
+the sheet was unparseable; load failures now error loudly, but the
+render+ERC+netlist habit remains the safety net.
+
+---
+
+## 4. Reading ERC output
+
+- **Coordinates are mm/100** in the report: `@ (0.78, 1)` means
+  (78 mm, 100 mm). Decode them to map an error back to a component's
+  `(at x y)`. Negative coordinates usually mean off-page junk.
+- **Benign warnings** (don't chase these):
+  - `Symbol 'X' doesn't match copy in library` — embedded lib_symbol vs
+    installed library version drift. Cosmetic.
+  - `The current configuration does not include the symbol library 'Y'` —
+    a project-local vendor library not in the global table. Cosmetic.
+- **Per-sheet ERC is the wrong metric for consumer sheets** in a
+  global-label design: every fabric-sourced signal feeding an input pin
+  shows `pin_not_driven`, and every cross-sheet net shows "label connected
+  to only one pin" — per sheet. Validate the whole design with
+  full-hierarchy ERC from the root sheet
+  (`kicad-cli sch erc root.kicad_sch`, or `run_erc` on the root). Triage:
+  real problems = `pin_to_pin` conflicts, typo'd dangling nets, unplaced
+  power units; benign = `pin_not_driven` on off-board inputs and
+  single-pin labels for genuinely two-sheet nets.
+
+---
+
+## 5. Power nets and PWR_FLAG
+
+ERC wants exactly **one driver per power net, design-wide**:
+
+- Rails driven by a regulator's `power_output` pin need **no** flag.
+- Rails fed only by passive/connector pins need exactly **one**
+  `power:PWR_FLAG` — owned by the rail's _originating_ sheet.
+- Multiple flags on one net, or a flag on a net already driven by a
+  `power_output` pin, produce `Power output and Power output are
+connected` errors at full-hierarchy ERC.
+- Watch vendor symbols: their output pins are often typed `passive`, so
+  those rails **do** need a flag.
+
+Per-sheet ERC will warn about "undriven" globals whose flag lives on
+another sheet — that resolves at full-hierarchy ERC (§4).
+
+---
+
+## 6. The 1.27 mm connection grid
+
+KiCad's schematic connection grid is fixed at **50 mil = 1.27 mm**, and
+junction placement uses exact matching. One off-grid wire endpoint or
+symbol origin can poison junction placement **for the entire sheet**, even
+on items that are on-grid (field-verified: a single capacitor origin
+0.03 mm off 157.48 mm bricked a whole page). A 25-mil editing grid makes
+it worse — 25-mil points fall _between_ the connection points.
+
+- Off-grid coincident pin+label still _connects_ (warnings, not
+  disconnects) — but place symbol origins on 2.54 mm anyway.
+- **Remediation:** run `lint_offgrid` to report every off-grid wire
+  endpoint, symbol origin, and label/junction anchor, and `fix: true` to
+  snap sub-0.5 mm offenders in place with formatting-preserving edits.
+  `snap_to_grid` is the bulk alternative (whole-file rewrite).
+- Property field positions (Reference/Value text) are often off-grid —
+  they are **cosmetic** and irrelevant to junctions; don't churn them.
+  Never snap coordinates inside `(lib_symbols)` — those are local pin
+  definitions and moving them deforms the symbol. (`lint_offgrid`
+  excludes both automatically.)
+
+---
+
+## 7. Symbol gotchas
+
+### a. Flat SnapEDA/SamacSys vendor symbols
+
+Vendor `.kicad_sym` captures often put pins and graphics directly under
+the top-level `(symbol "NAME" ...)` with no `_1_1` sub-unit. kicad-cli
+tolerates this; **kicad-skip crashes on it**, taking down every skip-based
+tool for any sheet that uses the symbol. Sheets also embed a snapshot of
+the symbol in their own `(lib_symbols)`, so a sheet built before the
+library was fixed stays broken until its embedded copy is repaired too.
+
+Load failures surface as a structured error naming the offenders:
+`{"error": "schematic_load_failed", "flatSymbols": ["LIB:PART"]}`. Run
+**`repair_flat_symbols`** on the `.kicad_sym` library _and_ on any
+`.kicad_sch` that embeds a snapshot — it wraps the pins/graphics in a
+proper `(symbol "NAME_1_1" ...)` sub-unit via text insertion (dry-run by
+default, render-neutral, idempotent).
+
+### b. Multi-unit symbols with a separate power unit
+
+Some symbols (e.g. `74xx:74LS139`) put VCC/GND in a separate power unit.
+Placing only unit A yields `missing_power_pin` ERC errors and dangling
+power labels. Place the power unit explicitly, or prefer single-unit
+variants.
+
+### c. Exposed-pad pins
+
+DFN/QFN parts often type the thermal PAD pin as `power_input`; it errors
+(`pin_not_connected` + `power_pin_not_driven`) unless explicitly tied —
+usually to GND.
+
+### d. Deleting a wired component leaves its labels
+
+`batch_add_and_connect` places a symbol plus a separate co-located label
+on each pin. Deleting the symbol alone orphans those labels
+(`label_dangling` ERC errors). Pass
+`deleteAttachedLabels: true` to `delete_schematic_component` when
+permanently removing a wired part — it removes the pin-coincident labels
+unless they still serve a wire or another component's pin.
+
+---
+
+## 8. Diagnostic toolbox
+
+- **Parse-check with ground truth:** `kicad-cli sch export svg|pdf` on the
+  sheet — if it renders, the file is valid KiCad regardless of what a
+  skip-based tool says.
+- **Valid-but-skip-hostile vs truly broken:**
+  `python -c "import sexpdata; sexpdata.loads(open('f').read())"` and
+  `python -c "from skip import Schematic; Schematic('f')"` isolate the two
+  cases (the first passing while the second fails = §7a).
+- **Why won't a pin wire?** Compare `get_schematic_pin_locations(ref)`
+  against `list_schematic_labels` — labels must be coincident with pin
+  endpoints. If a vendor symbol's pins come back as a synthetic stack at
+  the origin, the symbol failed to load — repair it (§7a).
+- **What's really connected?** `generate_netlist` / `export_netlist` is
+  the authoritative net→pin answer.
+- **Render and look:** export SVG, convert to PNG with any converter, and
+  inspect it. Always eyeball before declaring a sheet done.
+- **Raw inspection:** grep the `.kicad_sch` for top-level
+  `(symbol (lib_id "...") (at x y a))` instances when a tool hides
+  something (off-page items, negative coordinates).
+
+---
+
+## 9. Cosmetic cleanup (safe passes only)
+
+Generated sheets are electrically correct but hard to hand-edit. Three
+passes are netlist-safe because they never move a symbol, pin, wire,
+junction, or label anchor:
+
+1. **`lint_schematic_cosmetic` pass `hide_pin_names`** — hide the symbol's
+   internal pin-name text, which duplicates the net label already sitting
+   on each pin.
+2. **`lint_schematic_cosmetic` pass `orient_labels`** — set each label's
+   text angle/justify from the outward side of the pin it sits on, so text
+   reads away from the body (rotation/mirror aware). Don't blanket-flatten
+   labels: vertical is _correct_ for top/bottom pins.
+3. **`autoplace_schematic_fields`** — move Reference/Value fields off the
+   body and clear of net labels.
+
+**Discipline:** prove zero connectivity drift with a golden-netlist diff —
+`kicad-cli sch export netlist --format kicadxml` on the root sheet before
+and after, comparing net → {REF.PIN} sets.
+
+Converting label-pairs into real wires is **placement judgment, not a safe
+mass operation** — component repositioning and per-pin label management
+are involved; do it collaboratively per sheet, verifying each with the
+golden-netlist diff.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -44,14 +44,15 @@ KiCAD MCP Server -- AI-assisted PCB design via Model Context Protocol
 
 ## Workflows
 
-| Document                                      | Description                               |
-| --------------------------------------------- | ----------------------------------------- |
-| [Realtime Workflow](REALTIME_WORKFLOW.md)     | Working with IPC backend for live updates |
-| [Visual Feedback](VISUAL_FEEDBACK.md)         | UI visual feedback guide                  |
-| [UI Auto Launch](UI_AUTO_LAUNCH.md)           | Automatic KiCAD UI launch feature         |
-| [Router Guide](mcp-router-guide.md)           | Tool router pattern usage                 |
-| [Router Architecture](ROUTER_ARCHITECTURE.md) | Router pattern design                     |
-| [Router Quick Start](ROUTER_QUICK_START.md)   | Quick start for the router pattern        |
+| Document                                      | Description                                                                                 |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [Realtime Workflow](REALTIME_WORKFLOW.md)     | Working with IPC backend for live updates                                                   |
+| [Headless Authoring](HEADLESS_AUTHORING.md)   | Driving the server without the KiCad GUI: build recipe, ERC triage, verification discipline |
+| [Visual Feedback](VISUAL_FEEDBACK.md)         | UI visual feedback guide                                                                    |
+| [UI Auto Launch](UI_AUTO_LAUNCH.md)           | Automatic KiCAD UI launch feature                                                           |
+| [Router Guide](mcp-router-guide.md)           | Tool router pattern usage                                                                   |
+| [Router Architecture](ROUTER_ARCHITECTURE.md) | Router pattern design                                                                       |
+| [Router Quick Start](ROUTER_QUICK_START.md)   | Quick start for the router pattern                                                          |
 
 ---
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -87,6 +87,36 @@ AttributeError: 'BOARD' object has no attribute 'LT_USER'
 
 ---
 
+### 6. Flat Vendor Symbols Break kicad-skip-Based Tools (now diagnosed)
+
+**Status:** MITIGATED — loud structured errors
+
+SnapEDA/SamacSys `.kicad_sym` captures put pins/graphics directly under the
+top-level `(symbol "NAME" ...)` with no `_1_1` sub-unit. KiCad and kicad-cli
+tolerate this, but kicad-skip's parser crashes on it, taking down every
+skip-based tool for the whole sheet (including sheets that merely embed a
+snapshot of such a symbol in their own `lib_symbols`).
+
+Schematic load failures now raise `SchematicLoadError` and all schematic
+tools return a structured error naming the offending symbols:
+
+```json
+{
+  "success": false,
+  "error": "schematic_load_failed",
+  "flatSymbols": ["LIB:PART"],
+  "message": "Schematic load failed for ...: embedded flat lib symbols [...]"
+}
+```
+
+**Workaround:** run the `repair_flat_symbols` tool (if available) or wrap
+each flat symbol's pins/graphics in a `(symbol "NAME_1_1" ...)` sub-unit.
+Note that tools which previously returned partial/empty results on
+unparseable schematics (e.g. `find_orphaned_wires`, hierarchical net
+traversal, `sync_schematic_to_board`) now return errors instead.
+
+---
+
 ## Recently Fixed (v2.2.0 - v2.2.3)
 
 ### B.Cu Footprint Routing (Fixed v2.2.3)

--- a/docs/SCHEMATIC_TOOLS_REFERENCE.md
+++ b/docs/SCHEMATIC_TOOLS_REFERENCE.md
@@ -505,6 +505,18 @@ Snap schematic element coordinates to the nearest grid point. KiCAD uses exact i
 | already_on_grid | Number of elements already on the grid                    |
 | grid_size       | Grid spacing used (mm)                                    |
 
+### lint_schematic_cosmetic
+
+Netlist-safe cosmetic cleanup of a schematic, applied as raw-text edits that never move a symbol, pin, wire, junction, or label anchor — only display attributes change. Two passes: `hide_pin_names` gives every top-level embedded lib_symbol definition a `(pin_names ... (hide yes))` directive (in label-driven schematics the internal pin names duplicate the net label on the same pin); `orient_labels` sets each net/global/hierarchical label's text angle and justify from the sheet-space outward side of the pin it sits on (rotation/mirror aware via PinLocator), so text reads away from the symbol body — labels not sitting on a pin are counted and left untouched. Complements `autoplace_schematic_fields`, which handles Reference/Value field placement.
+
+| Parameter     | Type            | Required | Description                                                          |
+| ------------- | --------------- | -------- | -------------------------------------------------------------------- |
+| schematicPath | string          | Yes      | Path to the .kicad_sch file                                          |
+| passes        | array\<string\> | No       | Passes to run in order: `"hide_pin_names"`, `"orient_labels"` (default both) |
+| dryRun        | boolean         | No       | Report change counts without writing (default false)                |
+
+**Response fields:** `changed`, `counts` per pass, `skippedLabels` (labels not on a pin), `message`.
+
 ### lint_offgrid
 
 Report every off-grid connection-relevant coordinate in a schematic — wire/bus endpoints, symbol origins, label/junction/no_connect anchors — and optionally snap them (`fix: true`). KiCad's connection grid is fixed at 50 mil (1.27 mm) and junction placement uses exact matching, so one off-grid endpoint can poison junction placement for a whole sheet. Fixes are byte-exact text splices that preserve file formatting (unlike `snap_to_grid`'s whole-file rewrite). `(lib_symbols)` content (local pin definitions) and property field positions (cosmetic) are never flagged or touched. Offenders more than 0.5 mm off-grid are reported as `needsHuman` and never auto-snapped — sub-half-grid offsets round coincident points to the same grid node, preserving connectivity, while larger ones need a human decision.

--- a/docs/SCHEMATIC_TOOLS_REFERENCE.md
+++ b/docs/SCHEMATIC_TOOLS_REFERENCE.md
@@ -494,7 +494,7 @@ Snap schematic element coordinates to the nearest grid point. KiCAD uses exact i
 | Parameter     | Type            | Required | Description                                                                                                                                                                                                          |
 | ------------- | --------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | schematicPath | string          | Yes      | Path to the .kicad_sch schematic file                                                                                                                                                                                |
-| gridSize      | number          | No       | Grid spacing in mm (default: 2.54 — standard KiCAD schematic grid; use 1.27 for high-density)                                                                                                                        |
+| gridSize      | number          | No       | Grid spacing in mm (default: 1.27 = 50 mil, the KiCad connection grid; do NOT use 2.54 — it moves pins off their 50 mil positions)                                                                                                                        |
 | elements      | array\<string\> | No       | Types to snap: `"wires"`, `"junctions"`, `"labels"`, `"components"`. Default: `["wires", "junctions", "labels"]`. `"components"` is opt-in — moving a component without re-routing its wires creates new mismatches. |
 
 **Response fields:**
@@ -504,6 +504,20 @@ Snap schematic element coordinates to the nearest grid point. KiCAD uses exact i
 | snapped         | Number of elements that had at least one coordinate moved |
 | already_on_grid | Number of elements already on the grid                    |
 | grid_size       | Grid spacing used (mm)                                    |
+
+### lint_offgrid
+
+Report every off-grid connection-relevant coordinate in a schematic — wire/bus endpoints, symbol origins, label/junction/no_connect anchors — and optionally snap them (`fix: true`). KiCad's connection grid is fixed at 50 mil (1.27 mm) and junction placement uses exact matching, so one off-grid endpoint can poison junction placement for a whole sheet. Fixes are byte-exact text splices that preserve file formatting (unlike `snap_to_grid`'s whole-file rewrite). `(lib_symbols)` content (local pin definitions) and property field positions (cosmetic) are never flagged or touched. Offenders more than 0.5 mm off-grid are reported as `needsHuman` and never auto-snapped — sub-half-grid offsets round coincident points to the same grid node, preserving connectivity, while larger ones need a human decision.
+
+| Parameter     | Type    | Required | Description                                                       |
+| ------------- | ------- | -------- | ----------------------------------------------------------------- |
+| schematicPath | string  | Yes      | Path to the .kicad_sch schematic file                             |
+| fix           | boolean | No       | Snap offenders in place (default false: report only)              |
+| gridSize      | number  | No       | Grid spacing in mm (default: 1.27 = 50 mil, the connection grid) |
+
+**Response fields:** `offenders` (type, x/y, snappedX/Y, offsetMm, needsHuman, line), `counts` per type, `fixed`, `needsHuman`.
+
+**When to use which:** `lint_offgrid` is the safe default (report first, surgical fix, guardrails); `snap_to_grid` is the legacy bulk tool that rewrites the whole file.
 
 ### run_erc
 

--- a/docs/SCHEMATIC_TOOLS_REFERENCE.md
+++ b/docs/SCHEMATIC_TOOLS_REFERENCE.md
@@ -5,6 +5,8 @@ Contributors: @Mehanik (PRs #60, #66), @Kletternaut (PR #57)
 
 This document provides a complete reference for the 29 schematic tools in the KiCAD MCP Server. These tools enable a complete schematic design workflow, from creating projects and adding components to wiring, validation, BOM/sourcing metadata, and synchronization with PCB boards. The dynamic symbol loading feature provides access to approximately 10,000 standard KiCad symbols.
 
+**Shared error shape — `schematic_load_failed`:** every kicad-skip-based schematic tool returns a structured error when the schematic cannot be parsed (instead of empty/partial results): `{"success": false, "error": "schematic_load_failed", "flatSymbols": ["LIB:PART", ...], "message": "...", "errorDetails": "..."}`. `flatSymbols` names embedded vendor symbols with no sub-units (the SnapEDA/SamacSys pattern that crashes the parser); see KNOWN_ISSUES.md for the repair procedure.
+
 ## Component Operations (10 tools)
 
 ### add_schematic_component

--- a/docs/SCHEMATIC_TOOLS_REFERENCE.md
+++ b/docs/SCHEMATIC_TOOLS_REFERENCE.md
@@ -30,8 +30,8 @@ Remove a placed symbol from a KiCAD schematic (.kicad_sch). This removes the sym
 
 | Parameter            | Type    | Required | Description                                                                                                    |
 | -------------------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------- |
-| schematicPath        | string  | Yes      | Path to the .kicad_sch file                                                                                     |
-| reference            | string  | Yes      | Reference designator of the component to remove (e.g. R1, U3)                                                   |
+| schematicPath        | string  | Yes      | Path to the .kicad_sch file                                                                                    |
+| reference            | string  | Yes      | Reference designator of the component to remove (e.g. R1, U3)                                                  |
 | deleteAttachedLabels | boolean | No       | Also delete net labels sitting on the deleted component's pin positions (default false; see usage notes below) |
 
 **Usage Notes:** `deleteAttachedLabels` removes the labels that `batch_add_and_connect` placed on the component's pins, which otherwise remain as `label_dangling` ERC errors. A label is kept whenever it is still attached to something else: coincident with a remaining component's pin, coincident with a wire endpoint, or lying on a wire segment (0.5 mm tolerance). Deleted labels are reported in the response (`deleted_labels`, `deleted_label_count`). Labels joined to a pin only through a short wire are not chased — that is wire-graph cleanup, out of scope. Recommended when permanently removing a wired part; leave off (default) for delete-then-re-add-in-place workflows.
@@ -494,7 +494,7 @@ Snap schematic element coordinates to the nearest grid point. KiCAD uses exact i
 | Parameter     | Type            | Required | Description                                                                                                                                                                                                          |
 | ------------- | --------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | schematicPath | string          | Yes      | Path to the .kicad_sch schematic file                                                                                                                                                                                |
-| gridSize      | number          | No       | Grid spacing in mm (default: 1.27 = 50 mil, the KiCad connection grid; do NOT use 2.54 — it moves pins off their 50 mil positions)                                                                                                                        |
+| gridSize      | number          | No       | Grid spacing in mm (default: 1.27 = 50 mil, the KiCad connection grid; do NOT use 2.54 — it moves pins off their 50 mil positions)                                                                                   |
 | elements      | array\<string\> | No       | Types to snap: `"wires"`, `"junctions"`, `"labels"`, `"components"`. Default: `["wires", "junctions", "labels"]`. `"components"` is opt-in — moving a component without re-routing its wires creates new mismatches. |
 
 **Response fields:**
@@ -509,11 +509,11 @@ Snap schematic element coordinates to the nearest grid point. KiCAD uses exact i
 
 Netlist-safe cosmetic cleanup of a schematic, applied as raw-text edits that never move a symbol, pin, wire, junction, or label anchor — only display attributes change. Two passes: `hide_pin_names` gives every top-level embedded lib_symbol definition a `(pin_names ... (hide yes))` directive (in label-driven schematics the internal pin names duplicate the net label on the same pin); `orient_labels` sets each net/global/hierarchical label's text angle and justify from the sheet-space outward side of the pin it sits on (rotation/mirror aware via PinLocator), so text reads away from the symbol body — labels not sitting on a pin are counted and left untouched. Complements `autoplace_schematic_fields`, which handles Reference/Value field placement.
 
-| Parameter     | Type            | Required | Description                                                          |
-| ------------- | --------------- | -------- | -------------------------------------------------------------------- |
-| schematicPath | string          | Yes      | Path to the .kicad_sch file                                          |
+| Parameter     | Type            | Required | Description                                                                  |
+| ------------- | --------------- | -------- | ---------------------------------------------------------------------------- |
+| schematicPath | string          | Yes      | Path to the .kicad_sch file                                                  |
 | passes        | array\<string\> | No       | Passes to run in order: `"hide_pin_names"`, `"orient_labels"` (default both) |
-| dryRun        | boolean         | No       | Report change counts without writing (default false)                |
+| dryRun        | boolean         | No       | Report change counts without writing (default false)                         |
 
 **Response fields:** `changed`, `counts` per pass, `skippedLabels` (labels not on a pin), `message`.
 
@@ -521,10 +521,10 @@ Netlist-safe cosmetic cleanup of a schematic, applied as raw-text edits that nev
 
 Report every off-grid connection-relevant coordinate in a schematic — wire/bus endpoints, symbol origins, label/junction/no_connect anchors — and optionally snap them (`fix: true`). KiCad's connection grid is fixed at 50 mil (1.27 mm) and junction placement uses exact matching, so one off-grid endpoint can poison junction placement for a whole sheet. Fixes are byte-exact text splices that preserve file formatting (unlike `snap_to_grid`'s whole-file rewrite). `(lib_symbols)` content (local pin definitions) and property field positions (cosmetic) are never flagged or touched. Offenders more than 0.5 mm off-grid are reported as `needsHuman` and never auto-snapped — sub-half-grid offsets round coincident points to the same grid node, preserving connectivity, while larger ones need a human decision.
 
-| Parameter     | Type    | Required | Description                                                       |
-| ------------- | ------- | -------- | ----------------------------------------------------------------- |
-| schematicPath | string  | Yes      | Path to the .kicad_sch schematic file                             |
-| fix           | boolean | No       | Snap offenders in place (default false: report only)              |
+| Parameter     | Type    | Required | Description                                                      |
+| ------------- | ------- | -------- | ---------------------------------------------------------------- |
+| schematicPath | string  | Yes      | Path to the .kicad_sch schematic file                            |
+| fix           | boolean | No       | Snap offenders in place (default false: report only)             |
 | gridSize      | number  | No       | Grid spacing in mm (default: 1.27 = 50 mil, the connection grid) |
 
 **Response fields:** `offenders` (type, x/y, snappedX/Y, offsetMm, needsHuman, line), `counts` per type, `fixed`, `needsHuman`.

--- a/docs/SCHEMATIC_TOOLS_REFERENCE.md
+++ b/docs/SCHEMATIC_TOOLS_REFERENCE.md
@@ -28,10 +28,13 @@ Add a component to the schematic. Symbol format is 'Library:SymbolName' (e.g., '
 
 Remove a placed symbol from a KiCAD schematic (.kicad_sch). This removes the symbol instance (the placed component) from the schematic. It does NOT remove the symbol definition from lib_symbols. Note: This tool operates on schematic files (.kicad_sch). To remove a footprint from a PCB, use delete_component instead.
 
-| Parameter     | Type   | Required | Description                                                   |
-| ------------- | ------ | -------- | ------------------------------------------------------------- |
-| schematicPath | string | Yes      | Path to the .kicad_sch file                                   |
-| reference     | string | Yes      | Reference designator of the component to remove (e.g. R1, U3) |
+| Parameter            | Type    | Required | Description                                                                                                    |
+| -------------------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| schematicPath        | string  | Yes      | Path to the .kicad_sch file                                                                                     |
+| reference            | string  | Yes      | Reference designator of the component to remove (e.g. R1, U3)                                                   |
+| deleteAttachedLabels | boolean | No       | Also delete net labels sitting on the deleted component's pin positions (default false; see usage notes below) |
+
+**Usage Notes:** `deleteAttachedLabels` removes the labels that `batch_add_and_connect` placed on the component's pins, which otherwise remain as `label_dangling` ERC errors. A label is kept whenever it is still attached to something else: coincident with a remaining component's pin, coincident with a wire endpoint, or lying on a wire segment (0.5 mm tolerance). Deleted labels are reported in the response (`deleted_labels`, `deleted_label_count`). Labels joined to a pin only through a short wire are not chased — that is wire-graph cleanup, out of scope. Recommended when permanently removing a wired part; leave off (default) for delete-then-re-add-in-place workflows.
 
 ### edit_schematic_component
 

--- a/python/commands/pin_locator.py
+++ b/python/commands/pin_locator.py
@@ -16,6 +16,8 @@ import sexpdata
 from sexpdata import Symbol
 from skip import Schematic
 
+from commands.schematic import SchematicLoadError, SchematicManager
+
 logger = logging.getLogger("kicad_interface")
 
 
@@ -198,6 +200,8 @@ class PinLocator:
             logger.warning(f"Symbol {lib_id} not found in lib_symbols")
             return {}
 
+        except SchematicLoadError:
+            raise
         except Exception as e:
             logger.error(f"Error getting symbol pins: {e}")
             import traceback
@@ -239,11 +243,13 @@ class PinLocator:
         try:
             sch_key = str(schematic_path)
             if sch_key not in self._schematic_cache:
-                self._schematic_cache[sch_key] = Schematic(sch_key)
+                self._schematic_cache[sch_key] = SchematicManager.load_schematic(sch_key)
             sch = self._schematic_cache[sch_key]
             for symbol in sch.symbol:
                 if symbol.property.Reference.value.rstrip("_") == symbol_reference:
                     return symbol.lib_id.value if hasattr(symbol, "lib_id") else None
+        except SchematicLoadError:
+            raise
         except Exception:
             pass
         return None
@@ -432,6 +438,8 @@ class PinLocator:
             )
             return math.degrees(math.atan2(-(ey - by), ex - bx)) % 360.0
 
+        except SchematicLoadError:
+            raise
         except Exception:
             return None
 
@@ -454,7 +462,7 @@ class PinLocator:
             # Use cache to avoid reloading the file for every pin lookup
             sch_key = str(schematic_path)
             if sch_key not in self._schematic_cache:
-                self._schematic_cache[sch_key] = Schematic(sch_key)
+                self._schematic_cache[sch_key] = SchematicManager.load_schematic(sch_key)
             sch = self._schematic_cache[sch_key]
 
             # Find the symbol instance.
@@ -548,6 +556,8 @@ class PinLocator:
             logger.info(f"Pin {symbol_reference}/{pin_number} located at ({abs_x}, {abs_y})")
             return [abs_x, abs_y]
 
+        except SchematicLoadError:
+            raise
         except Exception as e:
             logger.error(f"Error getting pin location: {e}")
             import traceback
@@ -572,7 +582,7 @@ class PinLocator:
             # Load schematic (use cache)
             sch_key = str(schematic_path)
             if sch_key not in self._schematic_cache:
-                self._schematic_cache[sch_key] = Schematic(sch_key)
+                self._schematic_cache[sch_key] = SchematicManager.load_schematic(sch_key)
             sch = self._schematic_cache[sch_key]
 
             # Find symbol
@@ -607,6 +617,8 @@ class PinLocator:
             logger.info(f"Located {len(result)} pins on {symbol_reference}")
             return result
 
+        except SchematicLoadError:
+            raise
         except Exception as e:
             logger.error(f"Error getting all symbol pins: {e}")
             return {}

--- a/python/commands/pin_locator.py
+++ b/python/commands/pin_locator.py
@@ -13,10 +13,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import sexpdata
+from commands.schematic import SchematicLoadError, SchematicManager
 from sexpdata import Symbol
 from skip import Schematic
-
-from commands.schematic import SchematicLoadError, SchematicManager
 
 logger = logging.getLogger("kicad_interface")
 

--- a/python/commands/schematic.py
+++ b/python/commands/schematic.py
@@ -1,13 +1,110 @@
 import logging
 import os
 import shutil
+import traceback
 import uuid
-from typing import Any, Optional
+from typing import Any, List, Optional
 
+import sexpdata
 from skip import Schematic
 from utils.sexpr_format import prettify
 
 logger = logging.getLogger("kicad_interface")
+
+
+class SchematicLoadError(Exception):
+    """A schematic could not be loaded by the kicad-skip parser.
+
+    Carries a structured diagnosis so every schematic tool can fail loudly
+    and actionably instead of returning plausible-looking empty results.
+    ``kind`` is ``"not_found"`` or ``"parse_error"``; ``flat_symbols`` names
+    embedded lib symbols with no sub-units (the SnapEDA/SamacSys pattern
+    that crashes kicad-skip's LibSymbol parser).
+    """
+
+    def __init__(
+        self,
+        path: str,
+        kind: str = "parse_error",
+        flat_symbols: Optional[List[str]] = None,
+        details: Optional[str] = None,
+    ):
+        self.path = path
+        self.kind = kind
+        self.flat_symbols = flat_symbols or []
+        self.details = details
+        super().__init__(self._message())
+
+    def _message(self) -> str:
+        if self.kind == "not_found":
+            return f"Schematic file not found: {self.path}"
+        if self.flat_symbols:
+            names = ", ".join(self.flat_symbols)
+            return (
+                f"Schematic load failed for {self.path}: embedded flat lib "
+                f"symbols [{names}] have no sub-units and break the "
+                f"kicad-skip parser; run the repair_flat_symbols tool (if "
+                f'available) or wrap each flat symbol\'s pins/graphics in a '
+                f'(symbol "NAME_1_1" ...) sub-unit'
+            )
+        cause = (self.details or "").strip().splitlines()
+        return f"Schematic load failed for {self.path}: {cause[-1] if cause else 'unknown parse error'}"
+
+    def to_response(self) -> dict:
+        """Standard structured failure dict for handlers."""
+        response = {
+            "success": False,
+            "error": "schematic_load_failed",
+            "message": str(self),
+            "flatSymbols": list(self.flat_symbols),
+        }
+        if self.details:
+            response["errorDetails"] = self.details
+        return response
+
+
+def find_flat_lib_symbols(file_path: str) -> List[str]:
+    """Names of embedded lib symbols that have no ``(symbol "NAME_x_y")``
+    sub-unit children — the flat SnapEDA/SamacSys capture pattern that makes
+    kicad-skip's LibSymbol raise (``pv.symbol`` -> AttributeError).
+
+    Best-effort: returns [] when the file cannot be read/parsed (a diagnosis
+    failure must never mask the original load error).
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = sexpdata.loads(f.read())
+        sym = sexpdata.Symbol("symbol")
+        lib_symbols = sexpdata.Symbol("lib_symbols")
+        extends = sexpdata.Symbol("extends")
+
+        flat: List[str] = []
+        for item in data:
+            if not (isinstance(item, list) and item and item[0] == lib_symbols):
+                continue
+            for sym_def in item[1:]:
+                if not (
+                    isinstance(sym_def, list)
+                    and len(sym_def) > 1
+                    and sym_def[0] == sym
+                ):
+                    continue
+                name = str(sym_def[1])
+                has_subunit = any(
+                    isinstance(child, list) and child and child[0] == sym
+                    for child in sym_def[2:]
+                )
+                is_derived = any(
+                    isinstance(child, list) and child and child[0] == extends
+                    for child in sym_def[2:]
+                )
+                if not has_subunit and not is_derived:
+                    flat.append(name)
+            break
+        return flat
+    except Exception as e:
+        logger.warning(f"flat-symbol diagnosis failed for {file_path}: {e}")
+        return []
 
 
 class SchematicManager:
@@ -94,18 +191,28 @@ class SchematicManager:
             raise
 
     @staticmethod
-    def load_schematic(file_path: str) -> Optional[Any]:
-        """Load an existing schematic"""
+    def load_schematic(file_path: str) -> Any:
+        """Load an existing schematic.
+
+        Raises SchematicLoadError (never returns None) when the file is
+        missing or kicad-skip cannot parse it, with flat vendor symbols
+        diagnosed by name so callers can surface an actionable error.
+        """
         if not os.path.exists(file_path):
             logger.error(f"Schematic file not found at {file_path}")
-            return None
+            raise SchematicLoadError(file_path, kind="not_found")
         try:
             sch = Schematic(file_path)
             logger.info(f"Loaded schematic from: {file_path}")
             return sch
         except Exception as e:
             logger.error(f"Error loading schematic from {file_path}: {e}")
-            return None
+            raise SchematicLoadError(
+                file_path,
+                kind="parse_error",
+                flat_symbols=find_flat_lib_symbols(file_path),
+                details=traceback.format_exc(),
+            ) from e
 
     @staticmethod
     def save_schematic(schematic: Any, file_path: str) -> bool:

--- a/python/commands/schematic.py
+++ b/python/commands/schematic.py
@@ -44,7 +44,7 @@ class SchematicLoadError(Exception):
                 f"Schematic load failed for {self.path}: embedded flat lib "
                 f"symbols [{names}] have no sub-units and break the "
                 f"kicad-skip parser; run the repair_flat_symbols tool (if "
-                f'available) or wrap each flat symbol\'s pins/graphics in a '
+                f"available) or wrap each flat symbol's pins/graphics in a "
                 f'(symbol "NAME_1_1" ...) sub-unit'
             )
         cause = (self.details or "").strip().splitlines()
@@ -83,16 +83,11 @@ def find_flat_lib_symbols(file_path: str) -> List[str]:
             if not (isinstance(item, list) and item and item[0] == lib_symbols):
                 continue
             for sym_def in item[1:]:
-                if not (
-                    isinstance(sym_def, list)
-                    and len(sym_def) > 1
-                    and sym_def[0] == sym
-                ):
+                if not (isinstance(sym_def, list) and len(sym_def) > 1 and sym_def[0] == sym):
                     continue
                 name = str(sym_def[1])
                 has_subunit = any(
-                    isinstance(child, list) and child and child[0] == sym
-                    for child in sym_def[2:]
+                    isinstance(child, list) and child and child[0] == sym for child in sym_def[2:]
                 )
                 is_derived = any(
                     isinstance(child, list) and child and child[0] == extends

--- a/python/commands/schematic_analysis.py
+++ b/python/commands/schematic_analysis.py
@@ -920,8 +920,10 @@ def find_orphaned_wires(schematic_path: Path) -> Dict[str, Any]:
     # --- anchors: component pins ---
     pin_iu: Set[Tuple[int, int]] = set()
     try:
+        from commands.schematic import SchematicLoadError, SchematicManager
+
         locator = PinLocator()
-        sch = Schematic(str(schematic_path))
+        sch = SchematicManager.load_schematic(str(schematic_path))
         for symbol in sch.symbol:
             try:
                 if not hasattr(symbol, "property") or not hasattr(symbol.property, "Reference"):
@@ -934,6 +936,10 @@ def find_orphaned_wires(schematic_path: Path) -> Dict[str, Any]:
                     pin_iu.add(_to_iu(float(coords[0]), float(coords[1])))
             except Exception as e:
                 logger.warning(f"Error reading pins for symbol: {e}")
+    except SchematicLoadError:
+        # An unparseable schematic must error, not misreport every wire as
+        # orphaned because no pin anchors could be extracted.
+        raise
     except Exception as e:
         logger.warning(f"Could not load schematic via skip for pin extraction: {e}")
         sch = None

--- a/python/commands/schematic_batch.py
+++ b/python/commands/schematic_batch.py
@@ -813,9 +813,7 @@ class SchematicBatchCommands:
                     {
                         "schematicPath": schematic_path,
                         "connections": nets_per_ref,
-                        "labelType": params.get("labelType")
-                        or params.get("label_type")
-                        or "label",
+                        "labelType": params.get("labelType") or params.get("label_type") or "label",
                     }
                 )
 

--- a/python/commands/schematic_batch.py
+++ b/python/commands/schematic_batch.py
@@ -512,12 +512,27 @@ class SchematicBatchCommands:
             return {"success": False, "message": str(e)}
 
     def batch_connect(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        """Place net labels on multiple pins in a single call, with facing-label wiring."""
+        """Place net labels on multiple pins in a single call, with facing-label wiring.
+
+        labelType (default "label") selects the label kind:
+          - "label":        sheet-local net label (connects only within this sheet)
+          - "global_label": connects across all sheets in the design by name
+        Facing-label auto-wiring only applies to local labels; global labels join
+        their net by name, so one is placed per pin with no inter-label wiring.
+        """
         logger.info("Batch connect: placing net labels on multiple pins")
         try:
             schematic_path = params.get("schematicPath")
             connections = params.get("connections")
             replace = bool(params.get("replace", False))
+            label_type = params.get("labelType") or params.get("label_type") or "label"
+            if label_type not in ("label", "global_label"):
+                return {
+                    "success": False,
+                    "message": (
+                        f"invalid labelType '{label_type}'; expected 'label' or 'global_label'"
+                    ),
+                }
 
             if not schematic_path:
                 return {"success": False, "message": "schematicPath is required"}
@@ -584,7 +599,13 @@ class SchematicBatchCommands:
                         cardinal = round(raw_angle / 90) * 90 % 360
                         orientation = {0: 180, 90: 270, 180: 0, 270: 90}.get(cardinal, 0)
 
-                        existing_pos = _find_facing_label(sch_path, net_name, position, orientation)
+                        # Facing-label auto-wiring is only meaningful for local labels;
+                        # global labels join their net by name (one placed per pin).
+                        existing_pos = (
+                            _find_facing_label(sch_path, net_name, position, orientation)
+                            if label_type == "label"
+                            else None
+                        )
                         if existing_pos:
                             if WireManager.add_wire(sch_path, list(position), existing_pos):
                                 placed.append(
@@ -618,7 +639,7 @@ class SchematicBatchCommands:
                             sch_path,
                             net_name,
                             position,
-                            label_type="label",
+                            label_type=label_type,
                             orientation=orientation,
                         ):
                             placed.append(
@@ -789,7 +810,13 @@ class SchematicBatchCommands:
             }
             if nets_per_ref:
                 connect_result = self.batch_connect(
-                    {"schematicPath": schematic_path, "connections": nets_per_ref}
+                    {
+                        "schematicPath": schematic_path,
+                        "connections": nets_per_ref,
+                        "labelType": params.get("labelType")
+                        or params.get("label_type")
+                        or "label",
+                    }
                 )
 
             add_errors = add_result.get("errors", [])

--- a/python/commands/schematic_batch.py
+++ b/python/commands/schematic_batch.py
@@ -531,17 +531,13 @@ class SchematicBatchCommands:
             sch_path = Path(schematic_path)
 
             try:
-                from skip import Schematic
+                from commands.schematic import SchematicLoadError, SchematicManager
 
-                Schematic(str(sch_path))
-            except Exception as parse_err:
-                return {
-                    "success": False,
-                    "message": (
-                        f"ERROR: Failed to load schematic at {schematic_path}: {parse_err}. "
-                        "All pin operations aborted. Run run_erc to check the schematic."
-                    ),
-                }
+                SchematicManager.load_schematic(str(sch_path))
+            except SchematicLoadError as parse_err:
+                response = parse_err.to_response()
+                response["message"] += " All pin operations aborted."
+                return response
 
             placed: List[Dict[str, Any]] = []
             failed: List[Dict[str, Any]] = []

--- a/python/commands/schematic_field_layout.py
+++ b/python/commands/schematic_field_layout.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from commands.pin_locator import PinLocator
-from commands.schematic import SchematicManager
+from commands.schematic import SchematicLoadError, SchematicManager
 from commands.schematic_text_utils import (
     _extract_property_position,
     _extract_property_visible,
@@ -352,9 +352,10 @@ class SchematicFieldLayoutCommands:
                     "y_max": fy + half_h,
                 }
 
-            schematic = SchematicManager.load_schematic(schematic_path)
-            if not schematic:
-                return {"success": False, "message": "Failed to load schematic"}
+            try:
+                schematic = SchematicManager.load_schematic(schematic_path)
+            except SchematicLoadError as e:
+                return e.to_response()
             raw_content = sch_path.read_text(encoding="utf-8")
             locator = PinLocator()
 

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -3462,3 +3462,57 @@ class SchematicHandlersMixin:
 
             logger.error(traceback.format_exc())
             return {"success": False, "message": str(e)}
+
+    def _handle_lint_offgrid(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Report (and optionally fix) off-grid connection geometry"""
+        logger.info("Linting schematic for off-grid geometry")
+        try:
+            from commands.schematic_lint_grid import lint_offgrid
+
+            schematic_path = params.get("schematicPath")
+            if not schematic_path:
+                return {"success": False, "message": "schematicPath is required"}
+            if not os.path.isfile(schematic_path):
+                return {
+                    "success": False,
+                    "message": f"Schematic not found: {schematic_path}",
+                }
+
+            fix = bool(params.get("fix", False))
+            grid_size = float(params.get("gridSize", 1.27))
+            if grid_size <= 0:
+                return {"success": False, "message": "gridSize must be > 0"}
+
+            result = lint_offgrid(schematic_path, grid_mm=grid_size, fix=fix)
+            offender_count = len(result["offenders"])
+            if offender_count == 0:
+                message = f"No off-grid geometry (grid {grid_size} mm)"
+            elif fix:
+                message = (
+                    f"Snapped {result['fixed']} of {offender_count} off-grid "
+                    f"item(s) to the {grid_size} mm grid"
+                    + (
+                        f"; {result['needsHuman']} offender(s) >0.5mm off-grid "
+                        f"left untouched (needsHuman)"
+                        if result["needsHuman"]
+                        else ""
+                    )
+                )
+            else:
+                message = (
+                    f"Found {offender_count} off-grid item(s) on the "
+                    f"{grid_size} mm grid ({result['needsHuman']} needing "
+                    f"human review); run with fix=true to snap them"
+                )
+            return {
+                "success": True,
+                "gridSize": grid_size,
+                **result,
+                "message": message,
+            }
+        except Exception as e:
+            logger.error(f"Error linting off-grid geometry: {e}")
+            import traceback
+
+            logger.error(traceback.format_exc())
+            return {"success": False, "message": str(e)}

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 import pcbnew
 import sexpdata
 from commands.library_schematic import LibraryManager as SchematicLibraryManager
-from commands.schematic import SchematicManager
+from commands.schematic import SchematicLoadError, SchematicManager
 from commands.wire_manager import WireManager
 from utils.interactive_schematic import reload_kicad_schematic
 from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
@@ -188,14 +188,13 @@ class SchematicHandlersMixin:
             if not filename:
                 return {"success": False, "message": "Filename is required"}
 
-            schematic = SchematicManager.load_schematic(filename)
-            success = schematic is not None
+            try:
+                schematic = SchematicManager.load_schematic(filename)
+            except SchematicLoadError as e:
+                return e.to_response()
 
-            if success:
-                metadata = SchematicManager.get_schematic_metadata(schematic)
-                return {"success": success, "metadata": metadata}
-            else:
-                return {"success": False, "message": "Failed to load schematic"}
+            metadata = SchematicManager.get_schematic_metadata(schematic)
+            return {"success": True, "metadata": metadata}
         except Exception as e:
             logger.error(f"Error loading schematic: {str(e)}")
             return {"success": False, "message": str(e)}
@@ -899,10 +898,9 @@ class SchematicHandlersMixin:
                 locator = PinLocator()
                 sch_path = Path(schematic_path)
 
-                # Load schematic to iterate all symbols
-                from skip import Schematic as SkipSchematic
-
-                sch = SkipSchematic(str(sch_path))
+                # Load schematic via the guarded loader so a parse failure
+                # surfaces a diagnosed SchematicLoadError instead of a crash.
+                sch = SchematicManager.load_schematic(str(sch_path))
 
                 # Collect all pin locations: list of (ref, pin_num, [x, y])
                 all_pins = []
@@ -980,6 +978,8 @@ class SchematicHandlersMixin:
                 return {"success": True, "message": message}
             else:
                 return {"success": False, "message": "Failed to add wire"}
+        except SchematicLoadError as e:
+            return e.to_response()
         except Exception as e:
             logger.error(f"Error adding wire to schematic: {str(e)}")
             import traceback
@@ -1360,9 +1360,10 @@ class SchematicHandlersMixin:
                     "message": f"Schematic not found: {schematic_path}",
                 }
 
-            schematic = SchematicManager.load_schematic(schematic_path)
-            if not schematic:
-                return {"success": False, "message": "Failed to load schematic"}
+            try:
+                schematic = SchematicManager.load_schematic(schematic_path)
+            except SchematicLoadError as e:
+                return e.to_response()
 
             # Optional filters
             filter_params = params.get("filter", {})
@@ -1453,9 +1454,10 @@ class SchematicHandlersMixin:
             if not schematic_path:
                 return {"success": False, "message": "schematicPath is required"}
 
-            schematic = SchematicManager.load_schematic(schematic_path)
-            if not schematic:
-                return {"success": False, "message": "Failed to load schematic"}
+            try:
+                schematic = SchematicManager.load_schematic(schematic_path)
+            except SchematicLoadError as e:
+                return e.to_response()
 
             # Collect net names from the top-level sheet using sexpdata.
             # Falls back to kicad-skip's label collections when the file
@@ -1537,9 +1539,10 @@ class SchematicHandlersMixin:
             if not schematic_path:
                 return {"success": False, "message": "schematicPath is required"}
 
-            schematic = SchematicManager.load_schematic(schematic_path)
-            if not schematic:
-                return {"success": False, "message": "Failed to load schematic"}
+            try:
+                schematic = SchematicManager.load_schematic(schematic_path)
+            except SchematicLoadError as e:
+                return e.to_response()
 
             wires = []
             if hasattr(schematic, "wire"):
@@ -1587,9 +1590,10 @@ class SchematicHandlersMixin:
             if label_type is not None and label_type not in _valid_label_types:
                 return {"success": False, "message": "labelType must be one of: net, global, power"}
 
-            schematic = SchematicManager.load_schematic(schematic_path)
-            if not schematic:
-                return {"success": False, "message": "Failed to load schematic"}
+            try:
+                schematic = SchematicManager.load_schematic(schematic_path)
+            except SchematicLoadError as e:
+                return e.to_response()
 
             labels = []
 
@@ -1844,9 +1848,10 @@ class SchematicHandlersMixin:
             if not schematic_path:
                 return {"success": False, "message": "schematicPath is required"}
 
-            schematic = SchematicManager.load_schematic(schematic_path)
-            if not schematic:
-                return {"success": False, "message": "Failed to load schematic"}
+            try:
+                schematic = SchematicManager.load_schematic(schematic_path)
+            except SchematicLoadError as e:
+                return e.to_response()
 
             # Collect existing references by prefix
             existing_refs = {}  # prefix -> set of numbers
@@ -2192,9 +2197,10 @@ class SchematicHandlersMixin:
                 except (TypeError, ValueError):
                     return {"success": False, "message": "Parameters x and y must be numeric"}
 
-            schematic = SchematicManager.load_schematic(schematic_path)
-            if not schematic:
-                return {"success": False, "message": "Failed to load schematic"}
+            try:
+                schematic = SchematicManager.load_schematic(schematic_path)
+            except SchematicLoadError as e:
+                return e.to_response()
 
             if not hasattr(schematic, "wire"):
                 return {"success": False, "message": "Schematic has no wires"}
@@ -2577,11 +2583,10 @@ class SchematicHandlersMixin:
         logger.info(f"_build_hierarchical_pad_net_map: scanning {len(sch_files)} schematic files")
 
         for sch_path in sch_files:
-            try:
-                sch = Schematic(str(sch_path))
-            except Exception as e:
-                logger.warning(f"Could not load {sch_path}: {e}")
-                continue
+            # A broken sheet must fail the sync loudly: silently skipping it
+            # would produce an incomplete pad->net map and wrong-looking
+            # success. SchematicLoadError carries the flat-symbol diagnosis.
+            sch = SchematicManager.load_schematic(str(sch_path))
 
             # ── 1. Collect explicit label positions → net name ──────────────
             point_net: dict = {}  # snap(x,y) -> net_name
@@ -2795,6 +2800,8 @@ class SchematicHandlersMixin:
                 "footprints_skipped": skipped_footprints,
             }
 
+        except SchematicLoadError as e:
+            return e.to_response()
         except Exception as e:
             logger.error(f"Error in sync_schematic_to_board: {e}")
             import traceback
@@ -3161,6 +3168,8 @@ class SchematicHandlersMixin:
                 **result,
                 "message": f"Found {result['count']} orphaned wire(s)",
             }
+        except SchematicLoadError as e:
+            return e.to_response()
         except Exception as e:
             logger.error(f"Error finding orphaned wires: {e}")
             import traceback
@@ -3178,9 +3187,10 @@ class SchematicHandlersMixin:
             if not schematic_path:
                 return {"success": False, "message": "schematicPath is required"}
 
-            schematic = SchematicManager.load_schematic(schematic_path)
-            if not schematic:
-                return {"success": False, "message": "Failed to load schematic"}
+            try:
+                schematic = SchematicManager.load_schematic(schematic_path)
+            except SchematicLoadError as e:
+                return e.to_response()
 
             labels = list_floating_labels(schematic, schematic_path)
             return {

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -382,9 +382,7 @@ class SchematicHandlersMixin:
             label_cleanup_warning: Optional[str] = None
             if delete_attached_labels:
                 try:
-                    target_pin_positions = self._pin_positions_for_reference(
-                        content, reference
-                    )
+                    target_pin_positions = self._pin_positions_for_reference(content, reference)
                     if not target_pin_positions:
                         logger.warning(
                             "deleteAttachedLabels: no pin positions resolvable "
@@ -394,9 +392,7 @@ class SchematicHandlersMixin:
                         )
                 except Exception as e:
                     label_cleanup_warning = f"could not compute pin positions: {e}"
-                    logger.warning(
-                        "deleteAttachedLabels: %s", label_cleanup_warning
-                    )
+                    logger.warning("deleteAttachedLabels: %s", label_cleanup_warning)
 
             # Delete from back to front to preserve character offsets
             for b_start, b_end in sorted(blocks_to_delete, reverse=True):
@@ -426,11 +422,7 @@ class SchematicHandlersMixin:
                     result["deleted_label_count"] = 0
                     result["labelCleanupWarning"] = label_cleanup_warning
                 else:
-                    result.update(
-                        self._delete_dangling_labels_at(
-                            sch_file, target_pin_positions
-                        )
-                    )
+                    result.update(self._delete_dangling_labels_at(sch_file, target_pin_positions))
 
             return result
 
@@ -442,9 +434,7 @@ class SchematicHandlersMixin:
             return {"success": False, "message": str(e)}
 
     @staticmethod
-    def _pin_positions_for_reference(
-        content: str, reference: str
-    ) -> List[Tuple[float, float]]:
+    def _pin_positions_for_reference(content: str, reference: str) -> List[Tuple[float, float]]:
         """World (x, y) positions of every pin of every placed instance whose
         Reference property equals ``reference``.
 
@@ -514,8 +504,7 @@ class SchematicHandlersMixin:
 
             def _near(x: float, y: float, points: List[Tuple[float, float]]) -> bool:
                 return any(
-                    abs(x - px) <= tolerance and abs(y - py) <= tolerance
-                    for px, py in points
+                    abs(x - px) <= tolerance and abs(y - py) <= tolerance for px, py in points
                 )
 
             label_types = {
@@ -531,11 +520,7 @@ class SchematicHandlersMixin:
                 if not (isinstance(item, list) and item and item[0] in label_types):
                     continue
                 at_entry = next(
-                    (
-                        p
-                        for p in item[1:]
-                        if isinstance(p, list) and len(p) >= 3 and p[0] == at_sym
-                    ),
+                    (p for p in item[1:] if isinstance(p, list) and len(p) >= 3 and p[0] == at_sym),
                     None,
                 )
                 if at_entry is None:
@@ -1508,8 +1493,7 @@ class SchematicHandlersMixin:
                 if svg_path is None:
                     svg_path = sorted(svg_files)[0]
                     logger.warning(
-                        "Could not identify root SVG page for %s; "
-                        "falling back to %s",
+                        "Could not identify root SVG page for %s; " "falling back to %s",
                         schematic_path,
                         svg_path,
                     )
@@ -2321,9 +2305,7 @@ class SchematicHandlersMixin:
                 if params.get("blackAndWhite"):
                     cmd.append("--black-and-white")
 
-                result = subprocess.run(
-                    cmd, capture_output=True, text=True, timeout=60
-                )
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
 
                 if result.returncode != 0:
                     return {
@@ -2332,8 +2314,7 @@ class SchematicHandlersMixin:
                     }
 
                 pages = sorted(
-                    os.path.basename(f)
-                    for f in glob.glob(os.path.join(tmpdir, "*.svg"))
+                    os.path.basename(f) for f in glob.glob(os.path.join(tmpdir, "*.svg"))
                 )
                 if not pages:
                     return {
@@ -3289,8 +3270,7 @@ class SchematicHandlersMixin:
                 if svg_output is None:
                     svg_output = os.path.join(tmp_dir, sorted(svg_files)[0])
                     logger.warning(
-                        "Could not identify root SVG page for %s; "
-                        "falling back to %s",
+                        "Could not identify root SVG page for %s; " "falling back to %s",
                         schematic_path,
                         svg_output,
                     )

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -8,8 +8,10 @@ No behavior change — pure relocation.
 """
 
 import base64
+import glob
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -51,6 +53,24 @@ def _find_placed_symbol_position(content: str, reference: str) -> Optional[Tuple
         block_end = headers[i + 1].start() if i + 1 < len(headers) else len(content)
         if ref_needle in content[header.start() : block_end]:
             return float(header.group(1)), float(header.group(2))
+    return None
+
+
+def _pick_root_svg(svg_dir: str, schematic_path: str) -> Optional[str]:
+    """Return the root-page SVG produced by ``kicad-cli sch export svg``.
+
+    kicad-cli names the root page ``<schematic-stem>.svg`` and hierarchical
+    sub-sheet pages ``<stem>-<SheetName>.svg``. Returns the absolute path of
+    the stem-matched root SVG when present, the sole SVG when exactly one was
+    produced, or None when the root page cannot be identified.
+    """
+    stem = Path(schematic_path).stem
+    candidate = os.path.join(svg_dir, stem + ".svg")
+    if os.path.isfile(candidate):
+        return candidate
+    svg_files = sorted(glob.glob(os.path.join(svg_dir, "*.svg")))
+    if len(svg_files) == 1:
+        return svg_files[0]
     return None
 
 
@@ -1298,14 +1318,23 @@ class SchematicHandlersMixin:
                         "message": f"kicad-cli SVG export failed: {result.stderr}",
                     }
 
-                # kicad-cli may name the file after the schematic, find it
-                svg_files = list(Path(tmpdir).glob("*.svg"))
+                # kicad-cli names one file per page after the schematic/sheet
+                # names — pick the root page deterministically.
+                svg_files = glob.glob(os.path.join(tmpdir, "*.svg"))
                 if not svg_files:
                     return {
                         "success": False,
                         "message": "No SVG file produced by kicad-cli",
                     }
-                svg_path = str(svg_files[0])
+                svg_path = _pick_root_svg(tmpdir, schematic_path)
+                if svg_path is None:
+                    svg_path = sorted(svg_files)[0]
+                    logger.warning(
+                        "Could not identify root SVG page for %s; "
+                        "falling back to %s",
+                        schematic_path,
+                        svg_path,
+                    )
 
                 if fmt == "svg":
                     with open(svg_path, "r", encoding="utf-8") as f:
@@ -2091,53 +2120,63 @@ class SchematicHandlersMixin:
                     "message": f"Schematic not found: {schematic_path}",
                 }
 
-            # kicad-cli's --output flag for SVG export expects a directory, not a file path.
-            # The output file is auto-named based on the schematic name.
-            output_dir_p = Path(output_path).parent
-            if str(output_dir_p) == "":
-                output_dir_p = Path(".")
-            output_dir_p.mkdir(parents=True, exist_ok=True)
-            output_dir = str(output_dir_p)
-
             kicad_cli = resolve_kicad_cli()
             if not kicad_cli:
                 return {"success": False, "message": kicad_cli_not_found_message()}
-            cmd = [
-                kicad_cli,
-                "sch",
-                "export",
-                "svg",
-                schematic_path,
-                "-o",
-                output_dir,
-            ]
 
-            if params.get("blackAndWhite"):
-                cmd.append("--black-and-white")
+            # kicad-cli's --output flag for SVG export expects a directory, and
+            # auto-names one SVG per page after the schematic/sheet names.
+            # Export into a private temp directory so stale SVGs from earlier
+            # exports (or extra hierarchical pages) can never be picked up,
+            # then move only the root page to the requested outputPath.
+            with tempfile.TemporaryDirectory() as tmpdir:
+                cmd = [
+                    kicad_cli,
+                    "sch",
+                    "export",
+                    "svg",
+                    schematic_path,
+                    "-o",
+                    tmpdir,
+                ]
 
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+                if params.get("blackAndWhite"):
+                    cmd.append("--black-and-white")
 
-            if result.returncode != 0:
-                return {
-                    "success": False,
-                    "message": f"kicad-cli failed: {result.stderr}",
-                }
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=60
+                )
 
-            # kicad-cli names the file after the schematic, so find the generated SVG
-            svg_files = list(output_dir_p.glob("*.svg"))
-            if not svg_files:
-                return {
-                    "success": False,
-                    "message": "No SVG file produced by kicad-cli",
-                }
+                if result.returncode != 0:
+                    return {
+                        "success": False,
+                        "message": f"kicad-cli failed: {result.stderr}",
+                    }
 
-            generated_svg = str(svg_files[0])
+                pages = sorted(
+                    os.path.basename(f)
+                    for f in glob.glob(os.path.join(tmpdir, "*.svg"))
+                )
+                if not pages:
+                    return {
+                        "success": False,
+                        "message": "No SVG file produced by kicad-cli",
+                    }
 
-            # Move/rename to the user-specified output path if it differs
-            if Path(generated_svg).resolve() != Path(output_path).resolve():
-                shutil.move(generated_svg, output_path)
+                root_svg = _pick_root_svg(tmpdir, schematic_path)
+                if root_svg is None:
+                    return {
+                        "success": False,
+                        "message": "Could not identify root SVG page",
+                        "files": pages,
+                    }
 
-            return {"success": True, "file": {"path": output_path}}
+                output_dir = os.path.dirname(output_path)
+                if output_dir:
+                    os.makedirs(output_dir, exist_ok=True)
+                shutil.move(root_svg, output_path)
+
+            return {"success": True, "file": {"path": output_path}, "pages": pages}
 
         except FileNotFoundError:
             return {"success": False, "message": kicad_cli_not_found_message()}
@@ -3060,15 +3099,23 @@ class SchematicHandlersMixin:
                         "message": f"SVG export failed: {result.stderr}",
                     }
 
-                # kicad-cli names the file after the schematic
-                tmp_dir_p = Path(tmp_dir)
-                svg_files = [p for p in tmp_dir_p.iterdir() if p.suffix == ".svg"]
+                # kicad-cli names one file per page after the schematic/sheet
+                # names — pick the root page deterministically.
+                svg_files = [f for f in os.listdir(tmp_dir) if f.endswith(".svg")]
                 if not svg_files:
                     return {
                         "success": False,
                         "message": "kicad-cli produced no SVG output",
                     }
-                svg_output = str(svg_files[0])
+                svg_output = _pick_root_svg(tmp_dir, schematic_path)
+                if svg_output is None:
+                    svg_output = os.path.join(tmp_dir, sorted(svg_files)[0])
+                    logger.warning(
+                        "Could not identify root SVG page for %s; "
+                        "falling back to %s",
+                        schematic_path,
+                        svg_output,
+                    )
 
                 import xml.etree.ElementTree as ET
 

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -1489,14 +1489,15 @@ class SchematicHandlersMixin:
                         "success": False,
                         "message": "No SVG file produced by kicad-cli",
                     }
-                svg_path = _pick_root_svg(tmpdir, schematic_path)
-                if svg_path is None:
-                    svg_path = sorted(svg_files)[0]
+                picked = _pick_root_svg(tmpdir, schematic_path)
+                if picked is None:
+                    picked = sorted(svg_files)[0]
                     logger.warning(
                         "Could not identify root SVG page for %s; " "falling back to %s",
                         schematic_path,
-                        svg_path,
+                        picked,
                     )
+                svg_path = picked
 
                 if fmt == "svg":
                     with open(svg_path, "r", encoding="utf-8") as f:
@@ -3298,7 +3299,7 @@ class SchematicHandlersMixin:
                         root.set("height", str(height))
 
                 # Write modified SVG
-                cropped_svg_path = str(tmp_dir_p / "cropped.svg")
+                cropped_svg_path = os.path.join(tmp_dir, "cropped.svg")
                 tree.write(cropped_svg_path, xml_declaration=True, encoding="utf-8")
 
                 if out_format == "svg":

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -307,6 +307,7 @@ class SchematicHandlersMixin:
 
             schematic_path = params.get("schematicPath")
             reference = params.get("reference")
+            delete_attached_labels = bool(params.get("deleteAttachedLabels", False))
 
             if not schematic_path:
                 return {"success": False, "message": "schematicPath is required"}
@@ -375,6 +376,28 @@ class SchematicHandlersMixin:
                     "message": f"Component '{reference}' not found in schematic (note: this tool removes schematic symbols, use delete_component for PCB footprints)",
                 }
 
+            # Compute the doomed symbol's pin world positions BEFORE removal so
+            # the optional label cleanup knows where its labels sat.
+            target_pin_positions: List[Tuple[float, float]] = []
+            label_cleanup_warning: Optional[str] = None
+            if delete_attached_labels:
+                try:
+                    target_pin_positions = self._pin_positions_for_reference(
+                        content, reference
+                    )
+                    if not target_pin_positions:
+                        logger.warning(
+                            "deleteAttachedLabels: no pin positions resolvable "
+                            "for %s (missing lib_symbols entry?); skipping "
+                            "label cleanup",
+                            reference,
+                        )
+                except Exception as e:
+                    label_cleanup_warning = f"could not compute pin positions: {e}"
+                    logger.warning(
+                        "deleteAttachedLabels: %s", label_cleanup_warning
+                    )
+
             # Delete from back to front to preserve character offsets
             for b_start, b_end in sorted(blocks_to_delete, reverse=True):
                 # Include any leading newline/whitespace before the block
@@ -390,12 +413,26 @@ class SchematicHandlersMixin:
 
             deleted_count = len(blocks_to_delete)
             logger.info(f"Deleted {deleted_count} instance(s) of {reference} from {sch_file.name}")
-            return {
+            result = {
                 "success": True,
                 "reference": reference,
                 "deleted_count": deleted_count,
                 "schematic": str(sch_file),
             }
+
+            if delete_attached_labels:
+                if label_cleanup_warning is not None:
+                    result["deleted_labels"] = []
+                    result["deleted_label_count"] = 0
+                    result["labelCleanupWarning"] = label_cleanup_warning
+                else:
+                    result.update(
+                        self._delete_dangling_labels_at(
+                            sch_file, target_pin_positions
+                        )
+                    )
+
+            return result
 
         except Exception as e:
             logger.error(f"Error deleting schematic component: {e}")
@@ -403,6 +440,147 @@ class SchematicHandlersMixin:
 
             logger.error(traceback.format_exc())
             return {"success": False, "message": str(e)}
+
+    @staticmethod
+    def _pin_positions_for_reference(
+        content: str, reference: str
+    ) -> List[Tuple[float, float]]:
+        """World (x, y) positions of every pin of every placed instance whose
+        Reference property equals ``reference``.
+
+        Builds a mini document of [lib_symbols] + [matching placed symbols]
+        and reuses WireManager._collect_pin_positions, which applies the
+        authoritative unit-aware y-negate/mirror/rotate/translate transform.
+        Returns [] when the symbol has no lib_symbols entry.
+        """
+        sym = sexpdata.Symbol("symbol")
+        lib_symbols = sexpdata.Symbol("lib_symbols")
+        prop = sexpdata.Symbol("property")
+
+        data = sexpdata.loads(content)
+        mini_doc: list = []
+        for item in data:
+            if not (isinstance(item, list) and item):
+                continue
+            if item[0] == lib_symbols:
+                mini_doc.append(item)
+                continue
+            if item[0] != sym:
+                continue
+            # Placed instance whose (property "Reference" "<ref>") matches
+            for part in item[1:]:
+                if (
+                    isinstance(part, list)
+                    and len(part) >= 3
+                    and part[0] == prop
+                    and str(part[1]) == "Reference"
+                    and str(part[2]) == reference
+                ):
+                    mini_doc.append(item)
+                    break
+        return WireManager._collect_pin_positions(mini_doc)
+
+    @staticmethod
+    def _delete_dangling_labels_at(
+        sch_file: Path,
+        target_positions: List[Tuple[float, float]],
+        tolerance: float = 0.5,
+    ) -> Dict[str, Any]:
+        """Delete net labels left dangling at a removed symbol's pin positions.
+
+        Re-reads ``sch_file`` (the symbol is already gone) and removes every
+        label/global_label/hierarchical_label whose anchor lies within
+        ``tolerance`` mm of one of ``target_positions`` — unless the label is
+        still attached to something else: coincident with a remaining
+        component pin, coincident with a wire endpoint, or lying strictly on
+        a wire segment. Never raises; cleanup failure is reported via
+        ``labelCleanupWarning``.
+        """
+        try:
+            if not target_positions:
+                return {"deleted_labels": [], "deleted_label_count": 0}
+
+            with open(sch_file, "r", encoding="utf-8") as f:
+                sch_content = f.read()
+            sch_data = sexpdata.loads(sch_content)
+
+            remaining_pins = WireManager._collect_pin_positions(sch_data)
+            wire_endpoints = WireManager._collect_wire_endpoints(sch_data)
+            wire_segments = [
+                parsed
+                for parsed in (WireManager._parse_wire(item) for item in sch_data)
+                if parsed is not None
+            ]
+
+            def _near(x: float, y: float, points: List[Tuple[float, float]]) -> bool:
+                return any(
+                    abs(x - px) <= tolerance and abs(y - py) <= tolerance
+                    for px, py in points
+                )
+
+            label_types = {
+                sexpdata.Symbol("label"),
+                sexpdata.Symbol("global_label"),
+                sexpdata.Symbol("hierarchical_label"),
+            }
+            at_sym = sexpdata.Symbol("at")
+
+            deleted: List[Dict[str, Any]] = []
+            doomed_indices: List[int] = []
+            for i, item in enumerate(sch_data):
+                if not (isinstance(item, list) and item and item[0] in label_types):
+                    continue
+                at_entry = next(
+                    (
+                        p
+                        for p in item[1:]
+                        if isinstance(p, list) and len(p) >= 3 and p[0] == at_sym
+                    ),
+                    None,
+                )
+                if at_entry is None:
+                    continue
+                x, y = float(at_entry[1]), float(at_entry[2])
+                if not _near(x, y, target_positions):
+                    continue
+                # Attachment guards: keep the label if it still serves live
+                # connectivity.
+                if _near(x, y, remaining_pins):
+                    continue
+                if _near(x, y, wire_endpoints):
+                    continue
+                if any(
+                    WireManager._point_strictly_on_wire(x, y, x1, y1, x2, y2)
+                    for (x1, y1), (x2, y2), _w, _t in wire_segments
+                ):
+                    continue
+                doomed_indices.append(i)
+                deleted.append(
+                    {
+                        "text": str(item[1]) if len(item) > 1 else "",
+                        "type": str(item[0]),
+                        "position": {"x": x, "y": y},
+                    }
+                )
+
+            if doomed_indices:
+                for i in reversed(doomed_indices):
+                    del sch_data[i]
+                with open(sch_file, "w", encoding="utf-8") as f:
+                    f.write(kicad_dumps(sch_data))
+                logger.info(
+                    "Deleted %d dangling label(s) at removed pin positions",
+                    len(deleted),
+                )
+
+            return {"deleted_labels": deleted, "deleted_label_count": len(deleted)}
+        except Exception as e:
+            logger.warning(f"Label cleanup after component delete failed: {e}")
+            return {
+                "deleted_labels": [],
+                "deleted_label_count": 0,
+                "labelCleanupWarning": str(e),
+            }
 
     @staticmethod
     def _escape_sexpr_string(value: str) -> str:

--- a/python/commands/schematic_lint.py
+++ b/python/commands/schematic_lint.py
@@ -1,0 +1,286 @@
+"""Netlist-safe cosmetic lint for .kicad_sch files (lint_schematic_cosmetic).
+
+Two passes, both applied as raw-text edits that never move a symbol, pin,
+wire, junction, or label ANCHOR — only display attributes change, so the
+netlist is preserved by construction:
+
+  * hide_pin_names — ensure every top-level embedded lib_symbol definition
+    (name contains ':'; sub-units and placed instances skipped) has a
+    ``(pin_names ... (hide yes))`` directive, inserting
+    ``(pin_names (offset 1.016) (hide yes))`` when the block is absent.
+    In label-driven schematics the symbol's internal pin names duplicate the
+    net label sitting on the same pin.
+
+  * orient_labels — for every label/global_label/hierarchical_label whose
+    anchor coincides with a component pin endpoint, rewrite only the text
+    angle and justify so the text reads AWAY from the symbol body. Pin
+    sheet positions and outward angles come from PinLocator
+    (get_all_symbol_pins / get_pin_angle), which applies the full
+    mirror/rotation-aware transform — rotated and mirrored instances are
+    handled. Labels not sitting on a pin are counted and left untouched.
+
+Field repositioning (Reference/Value) is autoplace_schematic_fields' job,
+not this tool's.
+"""
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+logger = logging.getLogger("kicad_interface")
+
+_PASSES = ("hide_pin_names", "orient_labels")
+
+# pin sheet-space outward angle -> (label text angle, justify), field-validated.
+_ORIENT = {
+    0: (180, "right"),  # pin on left edge  -> text extends left
+    180: (0, "left"),  # pin on right edge -> text extends right
+    90: (270, "right"),  # pin on top edge   -> text reads upward
+    270: (90, "left"),  # pin on bottom edge-> text reads downward
+}
+
+
+def _find_blocks(src: str, opener: str) -> List[Tuple[int, int]]:
+    """Spans (start, end_exclusive) of balanced-paren blocks starting with
+    ``opener``. String-aware: parens inside quoted strings are ignored."""
+    out: List[Tuple[int, int]] = []
+    i = 0
+    while True:
+        j = src.find(opener, i)
+        if j < 0:
+            break
+        depth = 0
+        k = j
+        in_str = esc = False
+        while k < len(src):
+            c = src[k]
+            if in_str:
+                if esc:
+                    esc = False
+                elif c == "\\":
+                    esc = True
+                elif c == '"':
+                    in_str = False
+            elif c == '"':
+                in_str = True
+            elif c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    out.append((j, k + 1))
+                    break
+            k += 1
+        i = k + 1
+    return out
+
+
+def _hide_pin_names(src: str) -> Tuple[str, int]:
+    """Ensure every top-level embedded lib_symbol def hides its pin names.
+
+    Only defs whose name contains ':' (real Lib:Part ids) are touched;
+    sub-units like PART_1_1 and placed instances are skipped. Display
+    attribute only — no geometry, no connectivity impact. Idempotent.
+    """
+    n = 0
+    lib_blocks = _find_blocks(src, "(lib_symbols")
+    if not lib_blocks:
+        return src, 0
+    lib_s, lib_e = lib_blocks[0]
+    section = src[lib_s:lib_e]
+    defs = []
+    for s, e in _find_blocks(section, '(symbol "'):
+        m = re.match(r'\(symbol "([^"]*)"', section[s:e])
+        if m and ":" in m.group(1):
+            defs.append((s, e))
+    # right-to-left so earlier spans stay valid
+    for s, e in reversed(defs):
+        blk = section[s:e]
+        # this def's OWN pin_names = the first (pin_names before any sub-unit
+        sub = blk.find('(symbol "', 1)
+        header = blk if sub < 0 else blk[:sub]
+        pn = header.find("(pin_names")
+        if pn >= 0:
+            for ps, pe in _find_blocks(blk, "(pin_names"):
+                if ps == pn:
+                    if "hide" not in blk[ps:pe]:
+                        blk = (
+                            blk[: pe - 1].rstrip()
+                            + "\n\t\t\t\t(hide yes)\n\t\t\t)"
+                            + blk[pe:]
+                        )
+                        n += 1
+                    break
+        else:
+            nl = blk.find("\n")
+            blk = (
+                blk[: nl + 1]
+                + "\t\t\t(pin_names\n\t\t\t\t(offset 1.016)\n\t\t\t\t(hide yes)\n\t\t\t)\n"
+                + blk[nl + 1 :]
+            )
+            n += 1
+        section = section[:s] + blk + section[e:]
+    return src[:lib_s] + section + src[lib_e:], n
+
+
+def _build_pin_orient_map(sch_path: Path) -> Dict[Tuple[float, float], int]:
+    """(round(x,2), round(y,2)) -> outward angle (0/90/180/270) for every
+    placed component pin, via the mirror/rotation-aware PinLocator."""
+    from commands.pin_locator import PinLocator
+    from commands.schematic import SchematicManager
+
+    # Fresh locator per call: PinLocator caches parsed schematics by path
+    # with no mtime invalidation, so a shared instance could serve stale
+    # geometry after other edits.
+    locator = PinLocator()
+    sch = SchematicManager.load_schematic(str(sch_path))
+
+    pin_map: Dict[Tuple[float, float], int] = {}
+    for symbol in getattr(sch, "symbol", None) or []:
+        try:
+            if not hasattr(symbol, "property") or not hasattr(
+                symbol.property, "Reference"
+            ):
+                continue
+            ref = symbol.property.Reference.value
+            if ref.startswith("_TEMPLATE"):
+                continue
+            pin_locations = locator.get_all_symbol_pins(sch_path, ref)
+            for pin_num, coords in pin_locations.items():
+                angle = locator.get_pin_angle(sch_path, ref, pin_num)
+                if angle is None:
+                    continue
+                rounded = int(round(angle / 90.0) * 90) % 360
+                if min(abs(angle - rounded) % 360, 360 - abs(angle - rounded) % 360) > 1:
+                    continue  # non-cardinal pin; skip
+                pin_map[(round(coords[0], 2), round(coords[1], 2))] = rounded
+        except Exception as e:
+            logger.warning(f"orient_labels: skipping symbol pins: {e}")
+    return pin_map
+
+
+def _orient_labels(
+    src: str, pin_map: Dict[Tuple[float, float], int]
+) -> Tuple[str, int, int]:
+    """Rewrite label text angle + justify from the pin each label sits on.
+
+    The anchor coordinates are never touched. Returns
+    (new_src, oriented_count, skipped_not_on_pin).
+    """
+    n = 0
+    skipped = 0
+    for opener in ('(global_label "', '(hierarchical_label "', '(label "'):
+        for s, e in reversed(_find_blocks(src, opener)):
+            blk = src[s:e]
+            at = re.search(r"(\(at )(-?[\d.]+) (-?[\d.]+) (-?[\d.]+)(\))", blk)
+            if not at:
+                continue
+            key = (round(float(at.group(2)), 2), round(float(at.group(3)), 2))
+            if key not in pin_map:
+                skipped += 1
+                continue
+            angle, justify = _ORIENT[pin_map[key]]
+            new = blk
+            if float(at.group(4)) != angle:
+                new = (
+                    new[: at.start()]
+                    + f"{at.group(1)}{at.group(2)} {at.group(3)} {angle}{at.group(5)}"
+                    + new[at.end() :]
+                )
+            jm = re.search(r"\(justify [^)]*\)", new)
+            if jm:
+                new = new[: jm.start()] + f"(justify {justify})" + new[jm.end() :]
+            else:
+                fm = re.search(r"(\(font\s*\(size [\d.]+ [\d.]+\)\s*\))", new)
+                if fm:
+                    new = new[: fm.end()] + f"\n\t\t\t(justify {justify})" + new[fm.end() :]
+            if new != blk:
+                src = src[:s] + new + src[e:]
+                n += 1
+    return src, n, skipped
+
+
+class SchematicLintCommands:
+    """Handler for the lint_schematic_cosmetic MCP tool."""
+
+    def lint_schematic_cosmetic(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            from commands.schematic import SchematicLoadError
+
+            schematic_path = params.get("schematicPath")
+            if not schematic_path:
+                return {"success": False, "message": "schematicPath is required"}
+            if not os.path.isfile(schematic_path):
+                return {
+                    "success": False,
+                    "message": f"Schematic not found: {schematic_path}",
+                }
+
+            passes = params.get("passes", list(_PASSES))
+            unknown = [p for p in passes if p not in _PASSES]
+            if unknown:
+                return {
+                    "success": False,
+                    "message": (
+                        f"Unknown pass(es): {', '.join(unknown)}. "
+                        f"Valid passes: {', '.join(_PASSES)}"
+                    ),
+                }
+            dry_run = bool(params.get("dryRun", False))
+
+            with open(schematic_path, "r", encoding="utf-8") as f:
+                src = f.read()
+            original = src
+
+            counts = {p: 0 for p in _PASSES}
+            skipped_labels = 0
+            for pass_name in passes:
+                if pass_name == "hide_pin_names":
+                    src, counts["hide_pin_names"] = _hide_pin_names(src)
+                elif pass_name == "orient_labels":
+                    try:
+                        pin_map = _build_pin_orient_map(Path(schematic_path))
+                    except SchematicLoadError as e:
+                        return e.to_response()
+                    src, counts["orient_labels"], skipped_labels = _orient_labels(
+                        src, pin_map
+                    )
+
+            changed = src != original
+            if changed and not dry_run:
+                with open(schematic_path, "w", encoding="utf-8") as f:
+                    f.write(src)
+
+            message_parts = []
+            if "hide_pin_names" in passes:
+                message_parts.append(
+                    f"hide_pin_names: {counts['hide_pin_names']} def(s) hidden"
+                )
+            if "orient_labels" in passes:
+                message_parts.append(
+                    f"orient_labels: {counts['orient_labels']} label(s) reoriented "
+                    f"({skipped_labels} not on a pin, untouched)"
+                )
+            message = "; ".join(message_parts)
+            if dry_run:
+                message = f"[dry run] {message}"
+
+            return {
+                "success": True,
+                "dryRun": dry_run,
+                "changed": changed,
+                "counts": {p: counts[p] for p in passes},
+                "skippedLabels": skipped_labels,
+                "message": message,
+            }
+        except Exception as e:
+            import traceback
+
+            logger.error(f"lint_schematic_cosmetic failed: {e}")
+            return {
+                "success": False,
+                "message": f"lint_schematic_cosmetic failed: {e}",
+                "errorDetails": traceback.format_exc(),
+            }

--- a/python/commands/schematic_lint.py
+++ b/python/commands/schematic_lint.py
@@ -106,11 +106,7 @@ def _hide_pin_names(src: str) -> Tuple[str, int]:
             for ps, pe in _find_blocks(blk, "(pin_names"):
                 if ps == pn:
                     if "hide" not in blk[ps:pe]:
-                        blk = (
-                            blk[: pe - 1].rstrip()
-                            + "\n\t\t\t\t(hide yes)\n\t\t\t)"
-                            + blk[pe:]
-                        )
+                        blk = blk[: pe - 1].rstrip() + "\n\t\t\t\t(hide yes)\n\t\t\t)" + blk[pe:]
                         n += 1
                     break
         else:
@@ -140,9 +136,7 @@ def _build_pin_orient_map(sch_path: Path) -> Dict[Tuple[float, float], int]:
     pin_map: Dict[Tuple[float, float], int] = {}
     for symbol in getattr(sch, "symbol", None) or []:
         try:
-            if not hasattr(symbol, "property") or not hasattr(
-                symbol.property, "Reference"
-            ):
+            if not hasattr(symbol, "property") or not hasattr(symbol.property, "Reference"):
                 continue
             ref = symbol.property.Reference.value
             if ref.startswith("_TEMPLATE"):
@@ -161,9 +155,7 @@ def _build_pin_orient_map(sch_path: Path) -> Dict[Tuple[float, float], int]:
     return pin_map
 
 
-def _orient_labels(
-    src: str, pin_map: Dict[Tuple[float, float], int]
-) -> Tuple[str, int, int]:
+def _orient_labels(src: str, pin_map: Dict[Tuple[float, float], int]) -> Tuple[str, int, int]:
     """Rewrite label text angle + justify from the pin each label sits on.
 
     The anchor coordinates are never touched. Returns
@@ -244,9 +236,7 @@ class SchematicLintCommands:
                         pin_map = _build_pin_orient_map(Path(schematic_path))
                     except SchematicLoadError as e:
                         return e.to_response()
-                    src, counts["orient_labels"], skipped_labels = _orient_labels(
-                        src, pin_map
-                    )
+                    src, counts["orient_labels"], skipped_labels = _orient_labels(src, pin_map)
 
             changed = src != original
             if changed and not dry_run:
@@ -255,9 +245,7 @@ class SchematicLintCommands:
 
             message_parts = []
             if "hide_pin_names" in passes:
-                message_parts.append(
-                    f"hide_pin_names: {counts['hide_pin_names']} def(s) hidden"
-                )
+                message_parts.append(f"hide_pin_names: {counts['hide_pin_names']} def(s) hidden")
             if "orient_labels" in passes:
                 message_parts.append(
                     f"orient_labels: {counts['orient_labels']} label(s) reoriented "

--- a/python/commands/schematic_lint_grid.py
+++ b/python/commands/schematic_lint_grid.py
@@ -1,0 +1,228 @@
+"""Off-grid geometry lint for .kicad_sch files (lint_offgrid tool).
+
+KiCad's schematic connection grid is fixed at 50 mil (1.27 mm) and junction
+placement uses exact coordinate matching: a single off-grid wire endpoint or
+symbol origin can poison junction placement for an entire sheet.
+
+This module reports every off-grid connection-relevant coordinate — wire/bus
+endpoints, symbol origins, label/junction/no_connect/bus_entry anchors — and
+optionally snaps offenders to the nearest grid point via byte-exact text
+surgery that preserves the file's formatting (unlike snap_to_grid's
+whole-file sexpdata rewrite). Anything inside the (lib_symbols) block (local
+pin definitions — snapping deforms symbols) or under a (property ...)
+(cosmetic field text positions) is deliberately excluded, which the
+stack-based scanner gives for free.
+
+Offenders more than ``needs_human_mm`` (default 0.5 mm) off-grid are
+reported as needsHuman and never auto-snapped: sub-half-grid offsets round
+coincident points to the SAME grid node, preserving connectivity, while
+larger offsets need a human decision.
+"""
+
+import bisect
+import logging
+import os
+import tempfile
+from typing import Any, Dict, List, Optional, Tuple
+
+import sexpdata
+
+logger = logging.getLogger("kicad_interface")
+
+# stack suffixes (under the kicad_sch root) -> offender type
+_WIRE_CONTEXTS = {
+    ("wire", "pts", "xy"): "wire_endpoint",
+    ("bus", "pts", "xy"): "wire_endpoint",
+}
+_ANCHOR_CONTEXTS = {
+    ("symbol", "at"): "symbol_origin",
+    ("label", "at"): "label",
+    ("global_label", "at"): "label",
+    ("hierarchical_label", "at"): "label",
+    ("junction", "at"): "junction",
+    ("no_connect", "at"): "no_connect",
+    ("bus_entry", "at"): "wire_endpoint",
+}
+
+
+def _scan_coordinate_nodes(text: str) -> List[Dict[str, Any]]:
+    """Single-pass, string-aware scan yielding every (at ...)/(xy ...) node.
+
+    Each node record: {"stack": tuple of tags from the root, "tokens":
+    [(token_text, start, end), ...] for the node's direct atom children}.
+    """
+    nodes: List[Dict[str, Any]] = []
+    stack: List[str] = []
+    open_captures: List[Dict[str, Any]] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':
+            i += 1
+            while i < n:
+                if text[i] == "\\":
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    break
+                i += 1
+            i += 1
+            continue
+        if c == "(":
+            j = i + 1
+            while j < n and text[j] in " \t\r\n":
+                j += 1
+            k = j
+            while k < n and (text[k].isalnum() or text[k] == "_"):
+                k += 1
+            tag = text[j:k]
+            stack.append(tag)
+            if tag in ("at", "xy"):
+                capture = {"stack": tuple(stack), "tokens": [], "depth": len(stack)}
+                open_captures.append(capture)
+                nodes.append(capture)
+            i = k
+            continue
+        if c == ")":
+            if open_captures and len(stack) == open_captures[-1]["depth"]:
+                open_captures.pop()
+            if stack:
+                stack.pop()
+            i += 1
+            continue
+        if c in " \t\r\n":
+            i += 1
+            continue
+        j = i
+        while j < n and text[j] not in ' \t\r\n()"':
+            j += 1
+        if open_captures and len(stack) == open_captures[-1]["depth"]:
+            open_captures[-1]["tokens"].append((text[i:j], i, j))
+        i = j
+    return nodes
+
+
+def _classify(stack: Tuple[str, ...]) -> Optional[str]:
+    """Return the offender type for a coordinate node, or None to skip."""
+    if len(stack) < 2 or stack[0] != "kicad_sch":
+        return None
+    if "lib_symbols" in stack or "property" in stack:
+        return None  # symbol-local pin defs / cosmetic field positions
+    if len(stack) >= 4 and stack[-3:] in _WIRE_CONTEXTS and len(stack) == 4:
+        return _WIRE_CONTEXTS[stack[-3:]]
+    if len(stack) == 3 and stack[-2:] in _ANCHOR_CONTEXTS:
+        return _ANCHOR_CONTEXTS[stack[-2:]]
+    return None
+
+
+def _snap_value(v: float, grid: float) -> float:
+    return round(round(v / grid) * grid, 6)
+
+
+def _format_number(v: float) -> str:
+    """Format a coordinate the way KiCad does (no trailing zeros)."""
+    s = f"{v:.4f}".rstrip("0").rstrip(".")
+    return s if s not in ("", "-0") else "0"
+
+
+def lint_offgrid(
+    path: str,
+    grid_mm: float = 1.27,
+    tolerance_mm: float = 1e-4,
+    needs_human_mm: float = 0.5,
+    fix: bool = False,
+) -> Dict[str, Any]:
+    """Report (and with fix=True, snap) off-grid connection geometry.
+
+    Returns {"offenders": [...], "counts": {...}, "fixed": n,
+    "needsHuman": n}. Raises on unreadable/unparseable input.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    newline_offsets = [idx for idx, ch in enumerate(text) if ch == "\n"]
+
+    def _line_of(offset: int) -> int:
+        return bisect.bisect_right(newline_offsets, offset) + 1
+
+    offenders: List[Dict[str, Any]] = []
+    counts: Dict[str, int] = {}
+    for node in _scan_coordinate_nodes(text):
+        offender_type = _classify(node["stack"])
+        if offender_type is None:
+            continue
+        tokens = node["tokens"][:2]  # x, y (ignore trailing angle)
+        if len(tokens) < 2:
+            continue
+        try:
+            x = float(tokens[0][0])
+            y = float(tokens[1][0])
+        except ValueError:
+            continue
+        sx = _snap_value(x, grid_mm)
+        sy = _snap_value(y, grid_mm)
+        offset_mm = max(abs(sx - x), abs(sy - y))
+        if offset_mm <= tolerance_mm:
+            continue
+        offenders.append(
+            {
+                "type": offender_type,
+                "x": x,
+                "y": y,
+                "snappedX": sx,
+                "snappedY": sy,
+                "offsetMm": round(offset_mm, 6),
+                "needsHuman": offset_mm > needs_human_mm,
+                "line": _line_of(tokens[0][1]),
+                "_spans": [
+                    (tokens[0][1], tokens[0][2], sx),
+                    (tokens[1][1], tokens[1][2], sy),
+                ],
+            }
+        )
+        counts[offender_type] = counts.get(offender_type, 0) + 1
+
+    fixed = 0
+    if fix and offenders:
+        splices: List[Tuple[int, int, float]] = []
+        for offender in offenders:
+            if offender["needsHuman"]:
+                continue
+            splices.extend(offender["_spans"])
+            fixed += 1
+        if splices:
+            new_text = text
+            for start, end, value in sorted(splices, reverse=True):
+                # Guard: the span must still parse as the original float.
+                float(new_text[start:end])
+                new_text = new_text[:start] + _format_number(value) + new_text[end:]
+            # Post-fix sanity: the file must still parse before we write it.
+            sexpdata.loads(new_text)
+            directory = os.path.dirname(path) or "."
+            fd, tmp_path = tempfile.mkstemp(
+                dir=directory, prefix=".lintgrid-", suffix=".kicad_sch"
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(new_text)
+                os.replace(tmp_path, path)
+            except Exception:
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+                raise
+            logger.info("lint_offgrid: snapped %d offender(s) in %s", fixed, path)
+        else:
+            fixed = 0
+
+    for offender in offenders:
+        del offender["_spans"]
+
+    return {
+        "offenders": offenders,
+        "counts": counts,
+        "fixed": fixed if fix else 0,
+        "needsHuman": sum(1 for o in offenders if o["needsHuman"]),
+    }

--- a/python/commands/schematic_lint_grid.py
+++ b/python/commands/schematic_lint_grid.py
@@ -200,9 +200,7 @@ def lint_offgrid(
             # Post-fix sanity: the file must still parse before we write it.
             sexpdata.loads(new_text)
             directory = os.path.dirname(path) or "."
-            fd, tmp_path = tempfile.mkstemp(
-                dir=directory, prefix=".lintgrid-", suffix=".kicad_sch"
-            )
+            fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".lintgrid-", suffix=".kicad_sch")
             try:
                 with os.fdopen(fd, "w", encoding="utf-8") as f:
                     f.write(new_text)

--- a/python/commands/symbol_repair.py
+++ b/python/commands/symbol_repair.py
@@ -1,0 +1,265 @@
+"""Repair "flat" vendor symbols so kicad-skip can parse them.
+
+SnapEDA/SamacSys ``.kicad_sym`` captures often put pins and graphics directly
+under the top-level ``(symbol "NAME" ...)`` with no ``(symbol "NAME_1_1")``
+sub-unit. KiCad and kicad-cli tolerate that, but kicad-skip's lib_symbol
+parser does ``pv.symbol`` and crashes when a lib symbol has zero sub-units —
+taking down every skip-based tool for any sheet that uses (or embeds a
+snapshot of) such a symbol.
+
+The repair is pure TEXT surgery: insert ``(symbol "NAME_1_1" ...)`` around
+the drawable/pin children, leaving every other byte intact. Never round-trip
+through sexpdata.dumps — that collapses formatting and has been observed to
+break downstream parsers. Idempotent: symbols that already have a sub-unit
+(or are ``extends``-derived) are skipped.
+"""
+
+import logging
+import os
+import re
+import traceback
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("kicad_interface")
+
+# Child s-exprs that are unit content (must move into the sub-symbol).
+DRAWABLES = (
+    "pin",
+    "rectangle",
+    "polyline",
+    "circle",
+    "arc",
+    "text",
+    "bezier",
+    "text_box",
+)
+
+_HEAD_TOKEN = re.compile(r"\(\s*([A-Za-z_]+)")
+
+
+def _scan_block(text: str, start: int) -> Tuple[Optional[int], List[int]]:
+    """Balanced-paren scan (string-aware) from the ``(`` at ``start``.
+
+    Returns ``(end_index, child_open_positions)`` where ``end_index`` is the
+    index of the block's closing paren (or None if unbalanced) and
+    ``child_open_positions`` are the offsets of each depth-2 ``(`` — the
+    block's direct children. KiCad does not backslash-escape parens inside
+    quoted strings, so an in-string state machine is required.
+    """
+    depth = 0
+    i = start
+    in_str = esc = False
+    child_opens: List[int] = []
+    end: Optional[int] = None
+    while i < len(text):
+        c = text[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif c == "\\":
+                esc = True
+            elif c == '"':
+                in_str = False
+        elif c == '"':
+            in_str = True
+        elif c == "(":
+            depth += 1
+            if depth == 2:  # a direct child of the scanned block
+                child_opens.append(i)
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                end = i  # the block's closing paren
+                break
+        i += 1
+    return end, child_opens
+
+
+def _classify(text: str, child_opens: List[int]) -> Tuple[bool, bool, Optional[int]]:
+    """Classify a symbol block by its direct children.
+
+    Returns ``(is_wrapped, is_derived, first_drawable_offset)``:
+    wrapped = has a ``(symbol ...)`` sub-unit already; derived = has an
+    ``(extends ...)`` child (legitimately drawable-free); first_drawable is
+    the offset of the first pin/graphic child, or None.
+    """
+    is_wrapped = False
+    is_derived = False
+    first_drawable: Optional[int] = None
+    for cs in child_opens:
+        tok = _HEAD_TOKEN.match(text[cs : cs + 40])
+        if not tok:
+            continue
+        head = tok.group(1)
+        if head == "symbol":
+            is_wrapped = True
+        elif head == "extends":
+            is_derived = True
+        elif head in DRAWABLES and first_drawable is None:
+            first_drawable = cs
+    return is_wrapped, is_derived, first_drawable
+
+
+def _wrap(text: str, name: str, first_drawable: int, end: int) -> str:
+    """Insert a ``(symbol "<base>_1_1" ...)`` sub-unit around the drawable
+    children [first_drawable, end) of the symbol named ``name``.
+
+    Embedded schematic snapshots name symbols ``LIB:NAME`` but sub-units must
+    not carry the library prefix, hence the ``split(":")``.
+    """
+    unit_name = name.split(":")[-1] + "_1_1"
+    return (
+        text[:first_drawable]
+        + f'(symbol "{unit_name}"\n      '
+        + text[first_drawable:end]
+        + ")\n  "
+        + text[end:]
+    )
+
+
+def _iter_symbols(text: str, container_start: int) -> List[Tuple[str, int, int, List[int]]]:
+    """Yield ``(name, start, end, child_opens)`` for each direct
+    ``(symbol "NAME" ...)`` child of the container block at ``container_start``."""
+    container_end, child_opens = _scan_block(text, container_start)
+    if container_end is None:
+        raise ValueError("unbalanced s-expression")
+    symbols = []
+    for cs in child_opens:
+        m = re.match(r'\(\s*symbol\s+"([^"]+)"', text[cs : cs + 200])
+        if not m:
+            continue
+        end, sym_children = _scan_block(text, cs)
+        if end is None:
+            raise ValueError("unbalanced s-expression in symbol block")
+        symbols.append((m.group(1), cs, end, sym_children))
+    return symbols
+
+
+def repair_text(text: str, container_start: int) -> Tuple[str, List[str], List[str]]:
+    """Repair all flat symbols inside the container block at ``container_start``.
+
+    Returns ``(new_text, flat_symbols_found, repaired)``. Wraps are applied
+    back-to-front so earlier offsets stay valid.
+    """
+    flat: List[Tuple[str, int, int]] = []  # (name, first_drawable, end)
+    names_found: List[str] = []
+    for name, _start, end, child_opens in _iter_symbols(text, container_start):
+        is_wrapped, is_derived, first_drawable = _classify(text, child_opens)
+        if is_wrapped or is_derived:
+            continue
+        if first_drawable is None:
+            # Properties-only symbol with no drawables: there is no unit
+            # content to move, so don't fabricate an empty sub-unit
+            # (matches the field-validated reference behavior).
+            continue
+        names_found.append(name)
+        flat.append((name, first_drawable, end))
+
+    new_text = text
+    for name, first_drawable, end in sorted(flat, key=lambda t: t[1], reverse=True):
+        new_text = _wrap(new_text, name, first_drawable, end)
+    return new_text, names_found, list(names_found)
+
+
+class SymbolRepairCommands:
+    """Handler for the repair_flat_symbols MCP tool."""
+
+    def repair_flat_symbols(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Detect (and with dryRun=false, repair) flat vendor symbols in a
+        ``.kicad_sym`` library or the embedded ``(lib_symbols)`` block of a
+        ``.kicad_sch`` schematic."""
+        try:
+            path = params.get("path")
+            dry_run = bool(params.get("dryRun", True))
+
+            if not path:
+                return {"success": False, "message": "path is required"}
+            if not os.path.isfile(path):
+                return {"success": False, "message": f"File not found: {path}"}
+
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read()
+
+            if path.endswith(".kicad_sym"):
+                container_start = text.find("(kicad_symbol_lib")
+                if container_start < 0:
+                    return {
+                        "success": False,
+                        "message": "No (kicad_symbol_lib ...) block found — not a symbol library?",
+                    }
+            elif path.endswith(".kicad_sch"):
+                container_start = text.find("(lib_symbols")
+                if container_start < 0:
+                    return {
+                        "success": True,
+                        "path": path,
+                        "dryRun": dry_run,
+                        "flat_symbols_found": [],
+                        "repaired": [],
+                        "skipped_reason": "no lib_symbols block in schematic",
+                        "message": "No embedded lib_symbols block; nothing to repair",
+                    }
+            else:
+                return {
+                    "success": False,
+                    "message": "path must be a .kicad_sym or .kicad_sch file",
+                }
+
+            try:
+                new_text, flat_found, repaired = repair_text(text, container_start)
+            except ValueError as e:
+                return {
+                    "success": False,
+                    "message": f"Could not parse {path}: {e}",
+                }
+
+            if not flat_found:
+                return {
+                    "success": True,
+                    "path": path,
+                    "dryRun": dry_run,
+                    "flat_symbols_found": [],
+                    "repaired": [],
+                    "skipped_reason": "no flat symbols found; all symbols already have sub-units",
+                    "message": "No flat symbols found; nothing to repair",
+                }
+
+            if dry_run:
+                return {
+                    "success": True,
+                    "path": path,
+                    "dryRun": True,
+                    "flat_symbols_found": flat_found,
+                    "repaired": [],
+                    "skipped_reason": "dryRun=true — no changes written",
+                    "message": (
+                        f"Found {len(flat_found)} flat symbol(s): "
+                        f"{', '.join(flat_found)}. Re-run with dryRun=false to repair."
+                    ),
+                }
+
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(new_text)
+            logger.info(
+                "repair_flat_symbols: wrapped %d flat symbol(s) in %s",
+                len(repaired),
+                path,
+            )
+            return {
+                "success": True,
+                "path": path,
+                "dryRun": False,
+                "flat_symbols_found": flat_found,
+                "repaired": repaired,
+                "message": (
+                    f"Wrapped {len(repaired)} flat symbol(s) in a _1_1 sub-unit: "
+                    f"{', '.join(repaired)}"
+                ),
+            }
+        except Exception as e:
+            logger.error(f"repair_flat_symbols failed: {e}")
+            return {
+                "success": False,
+                "message": f"repair_flat_symbols failed: {e}",
+                "errorDetails": traceback.format_exc(),
+            }

--- a/python/commands/wire_connectivity.py
+++ b/python/commands/wire_connectivity.py
@@ -953,8 +953,14 @@ def get_connections_for_net(schematic: Any, schematic_path: str, net_name: str) 
     sub_sheets = _discover_sub_sheets(schematic_path)
     for sub_path in sub_sheets:
         try:
-            sub_sch = SkipSchematic(sub_path)
+            from commands.schematic import SchematicLoadError, SchematicManager
+
+            sub_sch = SchematicManager.load_schematic(sub_path)
             _collect(_process_single_sheet(sub_sch, sub_path, net_name))
+        except SchematicLoadError:
+            # A broken sub-sheet must fail the hierarchical traversal loudly
+            # instead of silently omitting that sheet's pins from the net.
+            raise
         except Exception as e:
             logger.warning(f"Error processing sub-sheet {sub_path}: {e}")
 

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -346,6 +346,7 @@ try:
     from commands.schematic_batch import SchematicBatchCommands
     from commands.schematic_declutter import SchematicDeclutterCommands
     from commands.schematic_field_layout import SchematicFieldLayoutCommands
+    from commands.schematic_lint import SchematicLintCommands
     from commands.schematic_hierarchy import SchematicHierarchyCommands
     from commands.symbol_creator import SymbolCreator
     from commands.symbol_pins import SymbolPinCommands
@@ -428,6 +429,7 @@ class KiCADInterface(SchematicHandlersMixin):
         self.hierarchy_commands = SchematicHierarchyCommands(self)
         # Schematic field placement / layout-check commands
         self.field_layout_commands = SchematicFieldLayoutCommands()
+        self.schematic_lint_commands = SchematicLintCommands()
         # Schematic label declutter (re-orient overlapping labels)
         self.declutter_commands = SchematicDeclutterCommands()
         # Batch schematic authoring commands (need an interface back-reference for the
@@ -553,6 +555,7 @@ class KiCADInterface(SchematicHandlersMixin):
             "set_schematic_property_position": self.field_layout_commands.set_schematic_property_position,
             "batch_set_schematic_property_positions": self.field_layout_commands.batch_set_schematic_property_positions,
             "autoplace_schematic_fields": self.field_layout_commands.autoplace_schematic_fields,
+            "lint_schematic_cosmetic": self.schematic_lint_commands.lint_schematic_cosmetic,
             "suggest_schematic_declutter": self.declutter_commands.suggest_schematic_declutter,
             # Batch schematic authoring commands
             "batch_add_components": self.batch_commands.batch_add_components,

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -636,6 +636,7 @@ class KiCADInterface(SchematicHandlersMixin):
             "find_orphaned_wires": self._handle_find_orphaned_wires,
             "list_floating_labels": self._handle_list_floating_labels,
             "snap_to_grid": self._handle_snap_to_grid,
+            "lint_offgrid": self._handle_lint_offgrid,
             "add_schematic_hierarchical_label": self._handle_add_schematic_hierarchical_label,
             "add_schematic_text": self._handle_add_schematic_text,
             "list_schematic_texts": self._handle_list_schematic_texts,

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -351,6 +351,7 @@ try:
     from commands.symbol_pins import SymbolPinCommands
     from commands.symbol_schematic import SymbolSchematicCommands
     from commands.update_symbol_from_library import update_symbol_from_library
+    from commands.symbol_repair import SymbolRepairCommands
 
     logger.info("Successfully imported all command handlers")
 except ImportError as e:
@@ -422,6 +423,7 @@ class KiCADInterface(SchematicHandlersMixin):
 
         # Symbol pin discovery commands (read-only pin lookup from symbol libraries)
         self.symbol_pin_commands = SymbolPinCommands()
+        self.symbol_repair_commands = SymbolRepairCommands()
         # Schematic hierarchy commands (insert sheets, scaffold sub-sheets)
         self.hierarchy_commands = SchematicHierarchyCommands(self)
         # Schematic field placement / layout-check commands
@@ -543,6 +545,7 @@ class KiCADInterface(SchematicHandlersMixin):
             # Symbol pin discovery commands (read pins straight from symbol libraries)
             "list_symbol_pins": self.symbol_pin_commands.list_symbol_pins,
             "batch_list_symbol_pins": self.symbol_pin_commands.batch_list_symbol_pins,
+            "repair_flat_symbols": self.symbol_repair_commands.repair_flat_symbols,
             # Schematic hierarchy commands (sheet insertion + subsheet scaffolding)
             "add_hierarchical_sheet": self.hierarchy_commands.add_hierarchical_sheet,
             "create_hierarchical_subsheet": self.hierarchy_commands.create_hierarchical_subsheet,

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -342,7 +342,7 @@ try:
     from commands.library_symbol import SymbolLibraryCommands, SymbolLibraryManager
     from commands.project import ProjectCommands
     from commands.routing import RoutingCommands
-    from commands.schematic import SchematicManager
+    from commands.schematic import SchematicLoadError, SchematicManager
     from commands.schematic_batch import SchematicBatchCommands
     from commands.schematic_declutter import SchematicDeclutterCommands
     from commands.schematic_field_layout import SchematicFieldLayoutCommands
@@ -1129,6 +1129,12 @@ class KiCADInterface(SchematicHandlersMixin):
                     "errorDetails": "The specified command is not supported",
                 }
 
+        except SchematicLoadError as e:
+            # Backstop: any load site missed by the per-handler conversion
+            # still yields the structured, diagnosed error rather than the
+            # generic "Error handling command" below.
+            logger.error(f"Schematic load failed handling {command}: {e}")
+            return e.to_response()
         except Exception as e:
             # Get the full traceback
             traceback_str = traceback.format_exc()
@@ -2733,9 +2739,10 @@ class KiCADInterface(SchematicHandlersMixin):
             if not all([schematic_path, net_name]):
                 return {"success": False, "message": "Missing required parameters"}
 
-            schematic = SchematicManager.load_schematic(schematic_path)
-            if not schematic:
-                return {"success": False, "message": "Failed to load schematic"}
+            try:
+                schematic = SchematicManager.load_schematic(schematic_path)
+            except SchematicLoadError as e:
+                return e.to_response()
 
             connections = get_connections_for_net(schematic, schematic_path, net_name)
             return {"success": True, "connections": connections}
@@ -2763,9 +2770,10 @@ class KiCADInterface(SchematicHandlersMixin):
             except (TypeError, ValueError):
                 return {"success": False, "message": "Parameters x and y must be numeric"}
 
-            schematic = SchematicManager.load_schematic(schematic_path)
-            if not schematic:
-                return {"success": False, "message": "Failed to load schematic"}
+            try:
+                schematic = SchematicManager.load_schematic(schematic_path)
+            except SchematicLoadError as e:
+                return e.to_response()
 
             result = get_net_at_point(schematic, schematic_path, x, y)
             return {"success": True, **result}

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -346,13 +346,13 @@ try:
     from commands.schematic_batch import SchematicBatchCommands
     from commands.schematic_declutter import SchematicDeclutterCommands
     from commands.schematic_field_layout import SchematicFieldLayoutCommands
-    from commands.schematic_lint import SchematicLintCommands
     from commands.schematic_hierarchy import SchematicHierarchyCommands
+    from commands.schematic_lint import SchematicLintCommands
     from commands.symbol_creator import SymbolCreator
     from commands.symbol_pins import SymbolPinCommands
+    from commands.symbol_repair import SymbolRepairCommands
     from commands.symbol_schematic import SymbolSchematicCommands
     from commands.update_symbol_from_library import update_symbol_from_library
-    from commands.symbol_repair import SymbolRepairCommands
 
     logger.info("Successfully imported all command handlers")
 except ImportError as e:

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -2741,8 +2741,7 @@ SCHEMATIC_TOOLS = [
                 "gridSize": {
                     "type": "number",
                     "description": (
-                        "Grid spacing in mm (default: 1.27 = 50 mil, the KiCad "
-                        "connection grid)"
+                        "Grid spacing in mm (default: 1.27 = 50 mil, the KiCad " "connection grid)"
                     ),
                     "default": 1.27,
                 },

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -2713,6 +2713,44 @@ SCHEMATIC_TOOLS = [
         },
     },
     {
+        "name": "lint_offgrid",
+        "title": "Lint Off-Grid Schematic Geometry",
+        "description": (
+            "Report every off-grid connection-relevant coordinate in a schematic — "
+            "wire/bus endpoints, symbol origins, label/junction/no_connect anchors — "
+            "and optionally snap them to the nearest grid point (fix=true). "
+            "KiCad's connection grid is fixed at 50 mil (1.27 mm) and junction "
+            "placement uses exact matching, so a single off-grid endpoint can poison "
+            "junction placement for a whole sheet. Fixes are byte-exact text splices "
+            "that preserve file formatting; (lib_symbols) content and property field "
+            "positions are never touched. Offenders more than 0.5 mm off-grid are "
+            "reported as needsHuman and never auto-snapped."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "schematicPath": {
+                    "type": "string",
+                    "description": "Path to the .kicad_sch schematic file",
+                },
+                "fix": {
+                    "type": "boolean",
+                    "description": "Snap offenders in place (default false: report only)",
+                    "default": False,
+                },
+                "gridSize": {
+                    "type": "number",
+                    "description": (
+                        "Grid spacing in mm (default: 1.27 = 50 mil, the KiCad "
+                        "connection grid)"
+                    ),
+                    "default": 1.27,
+                },
+            },
+            "required": ["schematicPath"],
+        },
+    },
+    {
         "name": "suggest_schematic_declutter",
         "title": "Suggest Schematic Declutter",
         "description": (

--- a/src/tools/library-symbol.ts
+++ b/src/tools/library-symbol.ts
@@ -42,6 +42,56 @@ export function registerSymbolLibraryTools(server: McpServer, callKicadScript: F
     },
   );
 
+  // Repair flat vendor symbols (no _1_1 sub-unit) that break kicad-skip
+  server.tool(
+    "repair_flat_symbols",
+    `Repair "flat" vendor symbols so schematic tools can parse the file.
+
+SnapEDA/SamacSys .kicad_sym captures often put pins and graphics directly
+under the top-level (symbol "NAME" ...) with no _1_1 sub-unit. KiCad and
+kicad-cli tolerate this, but the kicad-skip parser used by the schematic
+edit/inspect tools (list_schematic_components, batch_connect, ...) crashes
+on it — for any sheet that uses, or embeds a snapshot of, such a symbol.
+
+This tool wraps the drawable/pin children in a proper (symbol "NAME_1_1")
+sub-unit via pure text insertion (formatting preserved, render-neutral).
+Works on standalone .kicad_sym libraries and on the embedded (lib_symbols)
+block of a .kicad_sch. Idempotent; already-wrapped and extends-derived
+symbols are skipped. Dry-run by default — files are edited in place, so
+keep them under version control before repairing.`,
+    {
+      path: z.string().describe(".kicad_sym library or .kicad_sch schematic to repair"),
+      dryRun: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe("Report flat symbols without writing (default true)"),
+    },
+    async (args: { path: string; dryRun?: boolean }) => {
+      const result = await callKicadScript("repair_flat_symbols", args);
+      if (!result.success) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to repair: ${result.message || "Unknown error"}`,
+            },
+          ],
+        };
+      }
+      const lines = [result.message];
+      if (result.flat_symbols_found?.length) {
+        lines.push(`Flat symbols: ${result.flat_symbols_found.join(", ")}`);
+      }
+      if (result.repaired?.length) {
+        lines.push(`Repaired: ${result.repaired.join(", ")}`);
+      } else if (result.dryRun) {
+        lines.push("Dry run — pass dryRun: false to write the repair.");
+      }
+      return { content: [{ type: "text", text: lines.join("\n") }] };
+    },
+  );
+
   // Search for symbols across all libraries
   server.tool(
     "search_symbols",

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -163,6 +163,7 @@ export const toolCategories: ToolCategory[] = [
       "set_schematic_property_position",
       "batch_set_schematic_property_positions",
       "autoplace_schematic_fields",
+      "lint_schematic_cosmetic",
     ],
   },
   {

--- a/src/tools/schematic-batch.ts
+++ b/src/tools/schematic-batch.ts
@@ -205,12 +205,19 @@ export function registerSchematicBatchTools(server: McpServer, callKicadScript: 
   // Net labels on many pins
   server.tool(
     "batch_connect",
-    "Place net labels on multiple pins in one call to wire nets quickly. 'connections' is a map {reference: {pin: netName}} where pin is a number or name. If a facing label for the same net is nearby, a wire is drawn instead of a duplicate label. Set replace=true to clear any existing label at a pin first. Warns about power nets missing a PWR_FLAG.",
+    "Place net labels on multiple pins in one call to wire nets quickly. 'connections' is a map {reference: {pin: netName}} where pin is a number or name. labelType selects 'label' (sheet-local, the default) or 'global_label' (connects across all sheets by name — use this for power rails and any net that spans sheets). For local labels, if a facing label for the same net is nearby a wire is drawn instead of a duplicate label; global labels are placed one-per-pin since they join their net by name. Set replace=true to clear any existing label at a pin first. Warns about power nets missing a PWR_FLAG.",
     {
       schematicPath: z.string().describe("Path to the .kicad_sch file"),
       connections: z
         .record(z.string(), z.record(z.string(), z.string()))
         .describe("Map of reference -> {pin: netName}"),
+      labelType: z
+        .enum(["label", "global_label"])
+        .optional()
+        .default("label")
+        .describe(
+          "Label kind: 'label' = sheet-local (default); 'global_label' = connects across all sheets by name",
+        ),
       replace: z
         .boolean()
         .optional()
@@ -231,7 +238,7 @@ export function registerSchematicBatchTools(server: McpServer, callKicadScript: 
   // Place + wire in one call
   server.tool(
     "batch_add_and_connect",
-    "Place multiple components AND wire their nets in a single call — the fewest-round-trip way to build a subcircuit. Each component is like batch_add_components plus an optional 'nets' map {pin: netName}. Components are placed first, then nets are connected via batch_connect.",
+    "Place multiple components AND wire their nets in a single call — the fewest-round-trip way to build a subcircuit. Each component is like batch_add_components plus an optional 'nets' map {pin: netName}. Components are placed first, then nets are connected via batch_connect. labelType selects 'label' (sheet-local, default) or 'global_label' (cross-sheet by name) for all the nets wired in this call.",
     {
       schematicPath: z.string().describe("Path to the .kicad_sch file"),
       components: z
@@ -250,6 +257,13 @@ export function registerSchematicBatchTools(server: McpServer, callKicadScript: 
           }),
         )
         .describe("Components to place and connect"),
+      labelType: z
+        .enum(["label", "global_label"])
+        .optional()
+        .default("label")
+        .describe(
+          "Label kind used to wire the nets: 'label' = sheet-local (default); 'global_label' = cross-sheet by name",
+        ),
       origin_x: z.number().optional(),
       origin_y: z.number().optional(),
     },

--- a/src/tools/schematic-layout.ts
+++ b/src/tools/schematic-layout.ts
@@ -102,6 +102,41 @@ export function registerSchematicLayoutTools(server: McpServer, callKicadScript:
     },
   );
 
+  // Netlist-safe cosmetic lint: hide pin names, orient labels pin-side-aware
+  server.tool(
+    "lint_schematic_cosmetic",
+    "Netlist-safe cosmetic cleanup of a .kicad_sch, applied as raw-text edits that never " +
+      "move a symbol, pin, wire, junction, or label anchor. Pass hide_pin_names gives every " +
+      "top-level embedded lib_symbol a (pin_names ... (hide yes)) directive — in label-driven " +
+      "schematics the internal pin names duplicate the net label on the same pin. Pass " +
+      "orient_labels sets each net/global/hierarchical label's text angle and justify from " +
+      "the sheet-space outward side of the pin it sits on (rotation/mirror aware), so text " +
+      "reads away from the symbol body; labels not on a pin are left untouched. " +
+      "Complements autoplace_schematic_fields (which handles Reference/Value fields).",
+    {
+      schematicPath: z.string().describe("Path to the .kicad_sch file"),
+      passes: z
+        .array(z.enum(["hide_pin_names", "orient_labels"]))
+        .optional()
+        .describe("Passes to run, in order (default: both)"),
+      dryRun: z
+        .boolean()
+        .optional()
+        .describe("Report change counts without writing (default false)"),
+    },
+    async (args: any) => {
+      const result = await callKicadScript("lint_schematic_cosmetic", args);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.success ? result.message : `Failed: ${result.message || "Unknown error"}`,
+          },
+        ],
+      };
+    },
+  );
+
   server.tool(
     "suggest_schematic_declutter",
     "Re-orient overlapping net/global labels so their text lands in free space and becomes readable. Each label's (at x,y) anchor is its electrical connection point, so it is held FIXED — only the orientation (0/90/180/270) and justification change, throwing the text away from component bodies and other labels. Connectivity is never altered. DRY RUN by default: returns proposals [{name, at, from_angle, to_angle}] plus an overlap score (before/after) WITHOUT modifying the schematic. Set apply=true to rewrite the label orientations. (Phase 1: labels only; symbol spreading + wire reroute is a separate future capability.)",

--- a/src/tools/schematic.ts
+++ b/src/tools/schematic.ts
@@ -154,11 +154,7 @@ To remove a footprint from a PCB, use delete_component instead.`,
             "unless still attached to a wire or another component's pin (default false)",
         ),
     },
-    async (args: {
-      schematicPath: string;
-      reference: string;
-      deleteAttachedLabels?: boolean;
-    }) => {
+    async (args: { schematicPath: string; reference: string; deleteAttachedLabels?: boolean }) => {
       const result = await callKicadScript("delete_schematic_component", args);
       if (result.success) {
         const labelNote =
@@ -1899,10 +1895,7 @@ edit_schematic_component and set its value to an empty string.`,
       "Offenders more than 0.5 mm off-grid are reported as NEEDS HUMAN and never auto-snapped.",
     {
       schematicPath: z.string().describe("Path to the .kicad_sch schematic file"),
-      fix: z
-        .boolean()
-        .optional()
-        .describe("Snap offenders in place (default false: report only)"),
+      fix: z.boolean().optional().describe("Snap offenders in place (default false: report only)"),
       gridSize: z
         .number()
         .optional()

--- a/src/tools/schematic.ts
+++ b/src/tools/schematic.ts
@@ -1862,7 +1862,11 @@ edit_schematic_component and set its value to an empty string.`,
       gridSize: z
         .number()
         .optional()
-        .describe("Grid spacing in mm (default: 2.54 — standard KiCAD schematic grid)"),
+        .describe(
+          "Grid spacing in mm (default: 1.27 mm = 50 mil, the KiCad connection grid; " +
+            "do NOT use 2.54 — snapping to a 100 mil grid moves pins off their 50 mil " +
+            "positions and breaks connectivity)",
+        ),
       elements: z
         .array(z.enum(["wires", "junctions", "labels", "components"]))
         .optional()
@@ -1875,6 +1879,55 @@ edit_schematic_component and set its value to an empty string.`,
       const result = await callKicadScript("snap_to_grid", args);
       if (result.success) {
         return { content: [{ type: "text", text: result.message }] };
+      }
+      return {
+        content: [{ type: "text", text: `Failed: ${result.message || "Unknown error"}` }],
+      };
+    },
+  );
+
+  // Off-grid geometry lint (report + safe surgical snap)
+  server.tool(
+    "lint_offgrid",
+    "Report every off-grid connection-relevant coordinate in a schematic — wire/bus " +
+      "endpoints, symbol origins, label/junction/no_connect anchors — and optionally snap " +
+      "them to the nearest grid point (fix: true). KiCad's connection grid is fixed at " +
+      "50 mil (1.27 mm) and junction placement uses exact matching, so a single off-grid " +
+      "endpoint can poison junction placement for a whole sheet. Unlike snap_to_grid " +
+      "(whole-file rewrite), fixes here are byte-exact text splices that preserve file " +
+      "formatting; (lib_symbols) content and property field positions are never touched. " +
+      "Offenders more than 0.5 mm off-grid are reported as NEEDS HUMAN and never auto-snapped.",
+    {
+      schematicPath: z.string().describe("Path to the .kicad_sch schematic file"),
+      fix: z
+        .boolean()
+        .optional()
+        .describe("Snap offenders in place (default false: report only)"),
+      gridSize: z
+        .number()
+        .optional()
+        .describe("Grid spacing in mm (default: 1.27 mm = 50 mil, the KiCad connection grid)"),
+    },
+    async (args: { schematicPath: string; fix?: boolean; gridSize?: number }) => {
+      const result = await callKicadScript("lint_offgrid", args);
+      if (result.success) {
+        const lines: string[] = [result.message];
+        const offenders = result.offenders ?? [];
+        const auto = offenders.filter((o: any) => !o.needsHuman);
+        const human = offenders.filter((o: any) => o.needsHuman);
+        auto.slice(0, 50).forEach((o: any) => {
+          lines.push(
+            `  (${o.x}, ${o.y}) -> (${o.snappedX}, ${o.snappedY}) offset ${o.offsetMm}mm [${o.type}] line ${o.line}`,
+          );
+        });
+        if (auto.length > 50) lines.push(`  ... and ${auto.length - 50} more`);
+        if (human.length > 0) {
+          lines.push("NEEDS HUMAN (>0.5mm off-grid, never auto-snapped):");
+          human.forEach((o: any) => {
+            lines.push(`  (${o.x}, ${o.y}) offset ${o.offsetMm}mm [${o.type}] line ${o.line}`);
+          });
+        }
+        return { content: [{ type: "text", text: lines.join("\n") }] };
       }
       return {
         content: [{ type: "text", text: `Failed: ${result.message || "Unknown error"}` }],

--- a/src/tools/schematic.ts
+++ b/src/tools/schematic.ts
@@ -132,6 +132,13 @@ export function registerSchematicTools(server: McpServer, callKicadScript: Funct
 This removes the symbol instance (the placed component) from the schematic.
 It does NOT remove the symbol definition from lib_symbols.
 
+With deleteAttachedLabels, net labels sitting exactly on the deleted
+component's pin positions are removed too — unless a label is still attached
+to a wire or another component's pin. Recommended when permanently removing
+a wired part, since orphaned labels otherwise produce label_dangling ERC
+errors. Default false for backward compatibility (delete-then-re-add
+workflows rely on labels surviving).
+
 Note: This tool operates on schematic files (.kicad_sch).
 To remove a footprint from a PCB, use delete_component instead.`,
     {
@@ -139,15 +146,30 @@ To remove a footprint from a PCB, use delete_component instead.`,
       reference: z
         .string()
         .describe("Reference designator of the component to remove (e.g. R1, U3)"),
+      deleteAttachedLabels: z
+        .boolean()
+        .optional()
+        .describe(
+          "Also delete net labels sitting on the deleted component's pin positions, " +
+            "unless still attached to a wire or another component's pin (default false)",
+        ),
     },
-    async (args: { schematicPath: string; reference: string }) => {
+    async (args: {
+      schematicPath: string;
+      reference: string;
+      deleteAttachedLabels?: boolean;
+    }) => {
       const result = await callKicadScript("delete_schematic_component", args);
       if (result.success) {
+        const labelNote =
+          Array.isArray(result.deleted_labels) && result.deleted_labels.length > 0
+            ? ` (also removed ${result.deleted_labels.length} attached label(s))`
+            : "";
         return {
           content: [
             {
               type: "text",
-              text: `Successfully removed ${args.reference} from schematic`,
+              text: `Successfully removed ${args.reference} from schematic${labelNote}`,
             },
           ],
         };

--- a/tests/test_delete_schematic_component.py
+++ b/tests/test_delete_schematic_component.py
@@ -206,3 +206,177 @@ class TestDeleteSchematicComponentIntegration:
         sch = _make_test_schematic(tmp_path)
         result = self._get_handler()({"schematicPath": str(sch)})
         assert result["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# deleteAttachedLabels — orphan label cleanup
+# ---------------------------------------------------------------------------
+
+
+def _label_block(text: str, x: float, y: float, kind: str = "label") -> str:
+    return (
+        f'  ({kind} "{text}" (at {x} {y} 0)\n'
+        "    (effects (font (size 1.27 1.27)) (justify left bottom))\n"
+        '    (uuid "12121212-3434-5656-7878-909090909090")\n'
+        "  )\n"
+    )
+
+
+def _wire_block(x1: float, y1: float, x2: float, y2: float) -> str:
+    return (
+        f"  (wire (pts (xy {x1} {y1}) (xy {x2} {y2}))\n"
+        "    (stroke (width 0) (type default))\n"
+        '    (uuid "abababab-cdcd-efef-0101-232323232323")\n'
+        "  )\n"
+    )
+
+
+# A second resistor whose top pin coincides with R1's bottom pin region is
+# not needed; instead place it so ONE pin coincides with a label under test.
+def _placed_resistor(ref: str, x: float, y: float) -> str:
+    return PLACED_RESISTOR_INLINE.replace('"R1"', f'"{ref}"').replace(
+        "(at 50 50 0)", f"(at {x} {y} 0)"
+    )
+
+
+@pytest.mark.unit
+class TestDeleteAttachedLabels:
+    """R1 (Device:R at 50,50) has pins at (50, 46.19) and (50, 53.81) —
+    derived from WireManager._collect_pin_positions in _pin_positions()."""
+
+    PIN_TOP = (50.0, 46.19)
+    PIN_BOT = (50.0, 53.81)
+
+    def _get_handler(self) -> Any:
+        from kicad_interface import KiCADInterface
+
+        iface = KiCADInterface.__new__(KiCADInterface)
+        return iface._handle_delete_schematic_component
+
+    def _pin_positions(self, sch: Path) -> list:
+        import sexpdata
+
+        from commands.wire_manager import WireManager
+
+        return WireManager._collect_pin_positions(
+            sexpdata.loads(sch.read_text(encoding="utf-8"))
+        )
+
+    def test_fixture_pins_self_check(self, tmp_path: Any) -> None:
+        sch = _make_test_schematic(tmp_path, PLACED_RESISTOR_INLINE)
+        pins = sorted(self._pin_positions(sch), key=lambda p: p[1])
+        assert pins == [self.PIN_TOP, self.PIN_BOT]
+
+    def test_labels_on_both_pins_deleted(self, tmp_path: Any) -> None:
+        extra = (
+            PLACED_RESISTOR_INLINE
+            + _label_block("NET_A", *self.PIN_TOP)
+            + _label_block("NET_B", *self.PIN_BOT)
+        )
+        sch = _make_test_schematic(tmp_path, extra)
+        result = self._get_handler()(
+            {
+                "schematicPath": str(sch),
+                "reference": "R1",
+                "deleteAttachedLabels": True,
+            }
+        )
+        assert result["success"] is True
+        assert result["deleted_label_count"] == 2
+        assert {d["text"] for d in result["deleted_labels"]} == {"NET_A", "NET_B"}
+        content = sch.read_text(encoding="utf-8")
+        assert "NET_A" not in content
+        assert "NET_B" not in content
+        assert '"R1"' not in content
+
+    def test_default_off_keeps_labels(self, tmp_path: Any) -> None:
+        extra = PLACED_RESISTOR_INLINE + _label_block("NET_A", *self.PIN_TOP)
+        sch = _make_test_schematic(tmp_path, extra)
+        for flag_params in ({}, {"deleteAttachedLabels": False}):
+            sch_i = _make_test_schematic(tmp_path, extra)
+            result = self._get_handler()(
+                {"schematicPath": str(sch_i), "reference": "R1", **flag_params}
+            )
+            assert result["success"] is True
+            assert "deleted_labels" not in result or not result["deleted_labels"]
+            content = sch_i.read_text(encoding="utf-8")
+            assert 'label "NET_A"' in content
+
+    def test_label_shared_with_wire_survives(self, tmp_path: Any) -> None:
+        # NET_A sits on the top pin AND is a wire endpoint -> keep.
+        # NET_B sits strictly mid-wire -> keep. NET_C is only on the pin -> delete.
+        extra = (
+            PLACED_RESISTOR_INLINE
+            + _label_block("NET_A", *self.PIN_TOP)
+            + _wire_block(self.PIN_TOP[0], self.PIN_TOP[1], 70, self.PIN_TOP[1])
+            + _wire_block(
+                self.PIN_BOT[0] - 10, self.PIN_BOT[1], self.PIN_BOT[0] + 10, self.PIN_BOT[1]
+            )
+            + _label_block("NET_B", *self.PIN_BOT)
+        )
+        sch = _make_test_schematic(tmp_path, extra)
+        result = self._get_handler()(
+            {
+                "schematicPath": str(sch),
+                "reference": "R1",
+                "deleteAttachedLabels": True,
+            }
+        )
+        assert result["success"] is True
+        content = sch.read_text(encoding="utf-8")
+        assert 'label "NET_A"' in content  # wire endpoint at pin
+        assert 'label "NET_B"' in content  # strictly mid-wire
+        assert result["deleted_label_count"] == 0
+
+    def test_label_shared_with_other_component_pin_survives(self, tmp_path: Any) -> None:
+        # R9 placed so its top pin lands exactly on R1's bottom pin position:
+        # R9 at (50, 53.81 + 3.81) has top pin at (50, 53.81).
+        extra = (
+            PLACED_RESISTOR_INLINE
+            + _placed_resistor("R9", 50, 57.62)
+            + _label_block("SHARED", *self.PIN_BOT)
+            + _label_block("ONLY_R1", *self.PIN_TOP)
+        )
+        sch = _make_test_schematic(tmp_path, extra)
+        result = self._get_handler()(
+            {
+                "schematicPath": str(sch),
+                "reference": "R1",
+                "deleteAttachedLabels": True,
+            }
+        )
+        assert result["success"] is True
+        content = sch.read_text(encoding="utf-8")
+        assert 'label "SHARED"' in content
+        assert "ONLY_R1" not in content
+        assert result["deleted_label_count"] == 1
+        assert result["deleted_labels"][0]["text"] == "ONLY_R1"
+
+    def test_global_label_deleted_and_typed(self, tmp_path: Any) -> None:
+        extra = PLACED_RESISTOR_INLINE + _label_block(
+            "GNET", *self.PIN_TOP, kind="global_label"
+        )
+        sch = _make_test_schematic(tmp_path, extra)
+        result = self._get_handler()(
+            {
+                "schematicPath": str(sch),
+                "reference": "R1",
+                "deleteAttachedLabels": True,
+            }
+        )
+        assert result["success"] is True
+        assert result["deleted_label_count"] == 1
+        assert result["deleted_labels"][0]["type"] == "global_label"
+        assert "GNET" not in sch.read_text(encoding="utf-8")
+
+    def test_unknown_reference_with_flag_unchanged(self, tmp_path: Any) -> None:
+        sch = _make_test_schematic(tmp_path, PLACED_RESISTOR_INLINE)
+        result = self._get_handler()(
+            {
+                "schematicPath": str(sch),
+                "reference": "U99",
+                "deleteAttachedLabels": True,
+            }
+        )
+        assert result["success"] is False
+        assert "not found" in result["message"]

--- a/tests/test_delete_schematic_component.py
+++ b/tests/test_delete_schematic_component.py
@@ -255,12 +255,9 @@ class TestDeleteAttachedLabels:
 
     def _pin_positions(self, sch: Path) -> list:
         import sexpdata
-
         from commands.wire_manager import WireManager
 
-        return WireManager._collect_pin_positions(
-            sexpdata.loads(sch.read_text(encoding="utf-8"))
-        )
+        return WireManager._collect_pin_positions(sexpdata.loads(sch.read_text(encoding="utf-8")))
 
     def test_fixture_pins_self_check(self, tmp_path: Any) -> None:
         sch = _make_test_schematic(tmp_path, PLACED_RESISTOR_INLINE)
@@ -353,9 +350,7 @@ class TestDeleteAttachedLabels:
         assert result["deleted_labels"][0]["text"] == "ONLY_R1"
 
     def test_global_label_deleted_and_typed(self, tmp_path: Any) -> None:
-        extra = PLACED_RESISTOR_INLINE + _label_block(
-            "GNET", *self.PIN_TOP, kind="global_label"
-        )
+        extra = PLACED_RESISTOR_INLINE + _label_block("GNET", *self.PIN_TOP, kind="global_label")
         sch = _make_test_schematic(tmp_path, extra)
         result = self._get_handler()(
             {

--- a/tests/test_export_schematic_svg.py
+++ b/tests/test_export_schematic_svg.py
@@ -1,0 +1,231 @@
+"""
+Tests for deterministic SVG page selection in export_schematic_svg and
+the schematic view tools.
+
+Regression coverage for the "export sheet X renders sheet Y" defect:
+export_schematic_svg used to export directly into the user's output
+directory and then glob-pick the first *.svg found there, so stale SVGs
+from earlier exports of other sheets (or extra hierarchical pages) were
+returned as the requested export. The handlers now export into a private
+temp directory and select the root page by schematic filename stem.
+"""
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.schematic_handlers import _pick_root_svg  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_iface() -> Any:
+    with patch("kicad_interface.USE_IPC_BACKEND", False):
+        from kicad_interface import KiCADInterface
+
+        iface = KiCADInterface.__new__(KiCADInterface)
+    return iface
+
+
+@pytest.fixture()
+def iface():
+    return _make_iface()
+
+
+class FakeKicadCli:
+    """subprocess.run side_effect emulating `kicad-cli sch export svg`.
+
+    Writes `<schematic-stem>.svg` (content = per-sheet marker) into the
+    output directory parsed from the command, plus any configured extra
+    pages (hierarchical sub-sheets).
+    """
+
+    def __init__(self, extra_pages=None, page_names=None):
+        # extra_pages: list of suffixes appended as "<stem>-<suffix>.svg"
+        self.extra_pages = extra_pages or []
+        # page_names: if set, write exactly these file names instead of
+        # the stem-derived ones (used for the failure-path test)
+        self.page_names = page_names
+
+    def __call__(self, cmd, **kwargs):
+        # Parse output dir (after -o or --output) and the schematic path
+        out_dir = None
+        sch_path = None
+        for i, tok in enumerate(cmd):
+            if tok in ("-o", "--output"):
+                out_dir = cmd[i + 1]
+            elif tok.endswith(".kicad_sch"):
+                sch_path = tok
+        assert out_dir is not None and sch_path is not None, cmd
+        stem = Path(sch_path).stem
+        marker = f"MARKER:{stem}"
+        if self.page_names is not None:
+            for name in self.page_names:
+                Path(out_dir, name).write_text(f"{marker}:{name}")
+        else:
+            Path(out_dir, f"{stem}.svg").write_text(marker)
+            for suffix in self.extra_pages:
+                Path(out_dir, f"{stem}-{suffix}.svg").write_text(
+                    f"{marker}:{suffix}"
+                )
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Result()
+
+
+def _make_sch(tmp_path, name):
+    p = tmp_path / name
+    p.write_text("(kicad_sch)")
+    return str(p)
+
+
+def _export(iface, sch, out, fake_cli):
+    with patch(
+        "commands.schematic_handlers.resolve_kicad_cli",
+        return_value="/fake/kicad-cli",
+    ), patch("subprocess.run", side_effect=fake_cli):
+        return iface._handle_export_schematic_svg(
+            {"schematicPath": sch, "outputPath": out}
+        )
+
+
+# ---------------------------------------------------------------------------
+# _pick_root_svg unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPickRootSvg:
+    def test_stem_match(self, tmp_path):
+        (tmp_path / "root.svg").write_text("root")
+        (tmp_path / "root-Sub1.svg").write_text("sub")
+        picked = _pick_root_svg(str(tmp_path), "/x/y/root.kicad_sch")
+        assert picked == str(tmp_path / "root.svg")
+
+    def test_single_file_fallback(self, tmp_path):
+        (tmp_path / "renamed.svg").write_text("only")
+        picked = _pick_root_svg(str(tmp_path), "/x/y/other.kicad_sch")
+        assert picked == str(tmp_path / "renamed.svg")
+
+    def test_ambiguous_returns_none(self, tmp_path):
+        (tmp_path / "a.svg").write_text("a")
+        (tmp_path / "b.svg").write_text("b")
+        assert _pick_root_svg(str(tmp_path), "/x/y/c.kicad_sch") is None
+
+
+# ---------------------------------------------------------------------------
+# export_schematic_svg
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExportSchematicSvg:
+    def test_export_a_then_b_same_directory(self, iface, tmp_path):
+        """The headline regression: exporting B after A into the same
+        directory must return B's content, with decoy stale SVGs sorting
+        both before and after the expected name."""
+        sch_a = _make_sch(tmp_path, "sheet_a.kicad_sch")
+        sch_b = _make_sch(tmp_path, "sheet_b.kicad_sch")
+        out = tmp_path / "out"
+        out.mkdir()
+        # Decoys around any plausible pick order
+        (out / "aaa_stale.svg").write_text("STALE-FIRST")
+        (out / "zzz_stale.svg").write_text("STALE-LAST")
+
+        r1 = _export(iface, sch_a, str(out / "a.svg"), FakeKicadCli())
+        assert r1["success"], r1
+        r2 = _export(iface, sch_b, str(out / "b.svg"), FakeKicadCli())
+        assert r2["success"], r2
+
+        assert (out / "b.svg").read_text() == "MARKER:sheet_b"
+        assert (out / "a.svg").read_text() == "MARKER:sheet_a"
+
+    def test_same_output_path_reuse(self, iface, tmp_path):
+        sch_a = _make_sch(tmp_path, "sheet_a.kicad_sch")
+        sch_b = _make_sch(tmp_path, "sheet_b.kicad_sch")
+        out = tmp_path / "out"
+        out.mkdir()
+        view = str(out / "view.svg")
+
+        assert _export(iface, sch_a, view, FakeKicadCli())["success"]
+        assert _export(iface, sch_b, view, FakeKicadCli())["success"]
+
+        assert Path(view).read_text() == "MARKER:sheet_b"
+        # No orphan SVGs beyond the requested output
+        assert sorted(os.listdir(out)) == ["view.svg"]
+
+    def test_multipage_selects_root(self, iface, tmp_path):
+        sch = _make_sch(tmp_path, "root.kicad_sch")
+        out = tmp_path / "out"
+        out.mkdir()
+        r = _export(
+            iface, sch, str(out / "root_view.svg"), FakeKicadCli(["Sub1"])
+        )
+        assert r["success"], r
+        assert (out / "root_view.svg").read_text() == "MARKER:root"
+        # Sub-sheet page is not leaked into the user directory
+        assert sorted(os.listdir(out)) == ["root_view.svg"]
+        # Pages are reported for transparency
+        assert r.get("pages") == ["root-Sub1.svg", "root.svg"]
+
+    def test_unidentifiable_root_fails_with_listing(self, iface, tmp_path):
+        sch = _make_sch(tmp_path, "root.kicad_sch")
+        out = tmp_path / "out"
+        out.mkdir()
+        fake = FakeKicadCli(page_names=["odd1.svg", "odd2.svg"])
+        r = _export(iface, sch, str(out / "root.svg"), fake)
+        assert r["success"] is False
+        assert "root SVG" in r["message"]
+        assert r["files"] == ["odd1.svg", "odd2.svg"]
+        assert not (out / "root.svg").exists()
+
+    def test_missing_params(self, iface):
+        r = iface._handle_export_schematic_svg({"schematicPath": "x"})
+        assert r["success"] is False
+        assert "required" in r["message"]
+        r = iface._handle_export_schematic_svg({"outputPath": "x"})
+        assert r["success"] is False
+
+    def test_missing_schematic(self, iface, tmp_path):
+        r = iface._handle_export_schematic_svg(
+            {
+                "schematicPath": str(tmp_path / "nope.kicad_sch"),
+                "outputPath": str(tmp_path / "o.svg"),
+            }
+        )
+        assert r["success"] is False
+        assert "not found" in r["message"]
+
+
+# ---------------------------------------------------------------------------
+# get_schematic_view
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetSchematicView:
+    def test_multipage_returns_root_content(self, iface, tmp_path):
+        sch = _make_sch(tmp_path, "root.kicad_sch")
+        with patch(
+            "commands.schematic_handlers.resolve_kicad_cli",
+            return_value="/fake/kicad-cli",
+        ), patch("subprocess.run", side_effect=FakeKicadCli(["Sub1"])):
+            r = iface._handle_get_schematic_view(
+                {"schematicPath": sch, "format": "svg"}
+            )
+        assert r["success"], r
+        assert r["format"] == "svg"
+        assert r["imageData"] == "MARKER:root"

--- a/tests/test_export_schematic_svg.py
+++ b/tests/test_export_schematic_svg.py
@@ -22,7 +22,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
 
 from commands.schematic_handlers import _pick_root_svg  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -74,9 +73,7 @@ class FakeKicadCli:
         else:
             Path(out_dir, f"{stem}.svg").write_text(marker)
             for suffix in self.extra_pages:
-                Path(out_dir, f"{stem}-{suffix}.svg").write_text(
-                    f"{marker}:{suffix}"
-                )
+                Path(out_dir, f"{stem}-{suffix}.svg").write_text(f"{marker}:{suffix}")
 
         class _Result:
             returncode = 0
@@ -93,13 +90,14 @@ def _make_sch(tmp_path, name):
 
 
 def _export(iface, sch, out, fake_cli):
-    with patch(
-        "commands.schematic_handlers.resolve_kicad_cli",
-        return_value="/fake/kicad-cli",
-    ), patch("subprocess.run", side_effect=fake_cli):
-        return iface._handle_export_schematic_svg(
-            {"schematicPath": sch, "outputPath": out}
-        )
+    with (
+        patch(
+            "commands.schematic_handlers.resolve_kicad_cli",
+            return_value="/fake/kicad-cli",
+        ),
+        patch("subprocess.run", side_effect=fake_cli),
+    ):
+        return iface._handle_export_schematic_svg({"schematicPath": sch, "outputPath": out})
 
 
 # ---------------------------------------------------------------------------
@@ -171,9 +169,7 @@ class TestExportSchematicSvg:
         sch = _make_sch(tmp_path, "root.kicad_sch")
         out = tmp_path / "out"
         out.mkdir()
-        r = _export(
-            iface, sch, str(out / "root_view.svg"), FakeKicadCli(["Sub1"])
-        )
+        r = _export(iface, sch, str(out / "root_view.svg"), FakeKicadCli(["Sub1"]))
         assert r["success"], r
         assert (out / "root_view.svg").read_text() == "MARKER:root"
         # Sub-sheet page is not leaked into the user directory
@@ -219,13 +215,14 @@ class TestExportSchematicSvg:
 class TestGetSchematicView:
     def test_multipage_returns_root_content(self, iface, tmp_path):
         sch = _make_sch(tmp_path, "root.kicad_sch")
-        with patch(
-            "commands.schematic_handlers.resolve_kicad_cli",
-            return_value="/fake/kicad-cli",
-        ), patch("subprocess.run", side_effect=FakeKicadCli(["Sub1"])):
-            r = iface._handle_get_schematic_view(
-                {"schematicPath": sch, "format": "svg"}
-            )
+        with (
+            patch(
+                "commands.schematic_handlers.resolve_kicad_cli",
+                return_value="/fake/kicad-cli",
+            ),
+            patch("subprocess.run", side_effect=FakeKicadCli(["Sub1"])),
+        ):
+            r = iface._handle_get_schematic_view({"schematicPath": sch, "format": "svg"})
         assert r["success"], r
         assert r["format"] == "svg"
         assert r["imageData"] == "MARKER:root"

--- a/tests/test_hierarchical_pad_net_map.py
+++ b/tests/test_hierarchical_pad_net_map.py
@@ -154,8 +154,9 @@ def iface() -> Any:
 
 
 # ---------------------------------------------------------------------------
-# Helper: call _build_hierarchical_pad_net_map with both skip.Schematic
-# entry-points patched (walker import + PinLocator module-level import).
+# Helper: call _build_hierarchical_pad_net_map with every skip.Schematic
+# entry-point patched (walker import, PinLocator module-level import, and
+# the guarded SchematicManager loader in commands.schematic).
 # ---------------------------------------------------------------------------
 
 
@@ -163,6 +164,7 @@ def _call(iface: Any, sch_file: Path, mock_sch: MagicMock):
     with (
         patch("skip.Schematic", return_value=mock_sch),
         patch("commands.pin_locator.Schematic", return_value=mock_sch),
+        patch("commands.schematic.Schematic", return_value=mock_sch),
     ):
         return iface._build_hierarchical_pad_net_map(str(sch_file))
 
@@ -373,6 +375,7 @@ class TestMultipleSubsheets:
         with (
             patch("skip.Schematic", side_effect=_factory),
             patch("commands.pin_locator.Schematic", side_effect=_factory),
+            patch("commands.schematic.Schematic", side_effect=_factory),
         ):
             pad_net_map, net_names = iface._build_hierarchical_pad_net_map(str(top))
 
@@ -405,6 +408,7 @@ class TestMultipleSubsheets:
         with (
             patch("skip.Schematic", side_effect=_factory),
             patch("commands.pin_locator.Schematic", side_effect=_factory),
+            patch("commands.schematic.Schematic", side_effect=_factory),
         ):
             pad_net_map, _ = iface._build_hierarchical_pad_net_map(str(top))
 

--- a/tests/test_lint_offgrid.py
+++ b/tests/test_lint_offgrid.py
@@ -1,0 +1,261 @@
+"""
+Tests for the lint_offgrid tool (python/commands/schematic_lint_grid.py).
+
+Field-observed failure mode: a symbol origin 0.03 mm off 157.48 mm
+(= 124 x 1.27) poisoned junction placement for a whole sheet. lint_offgrid
+reports such offenders and, with fix=true, snaps them via byte-exact text
+surgery — never touching (lib_symbols) content, property field positions,
+or offenders more than 0.5 mm off-grid (needsHuman).
+"""
+
+import difflib
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+import sexpdata  # noqa: E402
+
+from commands.schematic_lint_grid import lint_offgrid  # noqa: E402
+
+TEMPLATE_SCH = Path(__file__).parent.parent / "python" / "templates" / "empty.kicad_sch"
+
+
+def _make_temp_schematic(tmp_path: Path, extra_block: str = "") -> Path:
+    dest = tmp_path / "test.kicad_sch"
+    content = TEMPLATE_SCH.read_text(encoding="utf-8")
+    if extra_block:
+        content = content.rstrip()
+        if content.endswith(")"):
+            content = content[:-1] + "\n" + extra_block + ")\n"
+    dest.write_text(content, encoding="utf-8")
+    return dest
+
+
+# The field-observed case: origin at 157.51 instead of 157.48 (124 x 1.27).
+OFFGRID_SYMBOL = """\
+  (symbol (lib_id "Device:R") (at 157.51 50.8 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no)
+    (uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+    (property "Reference" "R1" (at 158.78 47.46 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Value" "10k" (at 158.78 52.54 0)
+      (effects (font (size 1.27 1.27)))
+    )
+  )
+"""
+
+OFFGRID_WIRE = """\
+  (wire (pts (xy 157.51 50.8) (xy 165.1 50.8))
+    (stroke (width 0) (type default))
+    (uuid "abababab-cdcd-efef-0101-232323232323")
+  )
+"""
+
+LABEL_VARIANTS = """\
+  (label "NET1" (at 157.51 25.4 0)
+    (effects (font (size 1.27 1.27)))
+  )
+  (global_label "NET2" (at 157.51 27.94 0)
+    (effects (font (size 1.27 1.27)))
+  )
+  (hierarchical_label "NET3" (at 157.51 30.48 0)
+    (effects (font (size 1.27 1.27)))
+  )
+  (junction (at 157.51 33.02)
+    (diameter 0) (color 0 0 0 0)
+  )
+  (no_connect (at 157.51 35.56)
+    (uuid "12312312-4564-7897-8908-098098098098")
+  )
+"""
+
+# lib_symbols block carrying an off-grid local pin (must never be flagged)
+LIB_WITH_OFFGRID_PIN = """\
+  (symbol (lib_id "Test:FAKE") (at 25.4 25.4 0) (unit 1)
+    (uuid "deadbeef-0000-0000-0000-000000000000")
+    (property "Reference" "U9" (at 25.41 22.2 0)
+      (effects (font (size 1.27 1.27)))
+    )
+  )
+"""
+
+
+@pytest.mark.unit
+class TestLint:
+    def test_clean_sheet_no_offenders(self, tmp_path):
+        sch = _make_temp_schematic(tmp_path)
+        r = lint_offgrid(str(sch))
+        assert r["offenders"] == []
+        assert r["fixed"] == 0
+
+    def test_detects_symbol_origin_and_wire_endpoint(self, tmp_path):
+        sch = _make_temp_schematic(tmp_path, OFFGRID_SYMBOL + OFFGRID_WIRE)
+        before = sch.read_text(encoding="utf-8")
+        r = lint_offgrid(str(sch))
+        types = sorted(o["type"] for o in r["offenders"])
+        assert types == ["symbol_origin", "wire_endpoint"]
+        for o in r["offenders"]:
+            assert o["x"] == 157.51
+            assert o["snappedX"] == 157.48
+            assert abs(o["offsetMm"] - 0.03) < 1e-6
+            assert o["needsHuman"] is False
+            assert o["line"] > 0
+        # report-only: file bytes unchanged
+        assert sch.read_text(encoding="utf-8") == before
+
+    def test_fix_snaps_and_preserves_formatting(self, tmp_path):
+        sch = _make_temp_schematic(tmp_path, OFFGRID_SYMBOL + OFFGRID_WIRE)
+        before = sch.read_text(encoding="utf-8")
+        r = lint_offgrid(str(sch), fix=True)
+        assert r["fixed"] == 2
+        after = sch.read_text(encoding="utf-8")
+
+        # Both offenders snapped to the SAME grid node -> connectivity kept
+        assert "157.51" not in after
+        assert '(at 157.48 50.8 0)' in after
+        assert "(xy 157.48 50.8)" in after
+
+        # re-lint: clean; file still parses
+        assert lint_offgrid(str(sch))["offenders"] == []
+        sexpdata.loads(after)
+
+        # formatting preserved: diff touches only the two offender lines
+        changed = [
+            line
+            for line in difflib.unified_diff(
+                before.splitlines(), after.splitlines(), lineterm="", n=0
+            )
+            if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
+        ]
+        assert len(changed) == 4  # 2 lines removed + 2 added
+
+    def test_lib_symbols_pins_excluded(self, tmp_path):
+        # The template's lib_symbols carries pins at (0, 3.81)-style local
+        # coords; inject a placed symbol so the sheet is non-trivial and make
+        # a lib pin off-grid by rewriting one local pin coordinate.
+        sch = _make_temp_schematic(tmp_path, LIB_WITH_OFFGRID_PIN)
+        content = sch.read_text(encoding="utf-8")
+        assert "(at 0 3.81 270)" in content  # template Device:R pin
+        content = content.replace("(at 0 3.81 270)", "(at 0 3.812 270)", 1)
+        sch.write_text(content, encoding="utf-8")
+
+        r = lint_offgrid(str(sch), fix=True)
+        # The off-grid LOCAL pin def is not flagged and not modified
+        assert all(o["type"] != "wire_endpoint" or True for o in r["offenders"])
+        assert "(at 0 3.812 270)" in sch.read_text(encoding="utf-8")
+        # No offender at the lib pin coordinate
+        assert not any(abs(o["y"] - 3.812) < 1e-9 for o in r["offenders"])
+
+    def test_property_positions_excluded(self, tmp_path):
+        sch = _make_temp_schematic(tmp_path, LIB_WITH_OFFGRID_PIN)
+        r = lint_offgrid(str(sch))
+        # U9's Reference property sits at 25.41 (off-grid) — not flagged;
+        # the symbol origin itself (25.4 = 20 x 1.27) is on-grid.
+        assert r["offenders"] == []
+
+    def test_needs_human_threshold(self, tmp_path):
+        # 1.0 mm off-grid: 11.16 -> nearest 11.43 (9 x 1.27) offset 0.27?
+        # Use an unambiguous case: x = 10.16 + 0.6 = 10.76 -> nearest 10.16
+        # or 11.43; 10.76/1.27 = 8.472 -> 8 -> 10.16, offset 0.6 > 0.5.
+        wire = """\
+  (wire (pts (xy 10.76 20.32) (xy 15.24 20.32))
+    (stroke (width 0) (type default))
+    (uuid "abababab-cdcd-efef-0101-888888888888")
+  )
+"""
+        sch = _make_temp_schematic(tmp_path, wire)
+        before = sch.read_text(encoding="utf-8")
+        r = lint_offgrid(str(sch), fix=True)
+        offender = next(o for o in r["offenders"] if o["x"] == 10.76)
+        assert offender["needsHuman"] is True
+        assert r["needsHuman"] == 1
+        assert r["fixed"] == 0
+        assert sch.read_text(encoding="utf-8") == before  # untouched
+
+    def test_label_variants_detected(self, tmp_path):
+        sch = _make_temp_schematic(tmp_path, LABEL_VARIANTS)
+        r = lint_offgrid(str(sch))
+        assert r["counts"].get("label") == 3
+        assert r["counts"].get("junction") == 1
+        assert r["counts"].get("no_connect") == 1
+
+    def test_string_with_parens_does_not_break_scan(self, tmp_path):
+        block = OFFGRID_SYMBOL.replace('"10k"', '"Cap (100nF) special"')
+        sch = _make_temp_schematic(tmp_path, block)
+        r = lint_offgrid(str(sch), fix=True)
+        assert r["fixed"] == 1
+        after = sch.read_text(encoding="utf-8")
+        assert '"Cap (100nF) special"' in after
+        sexpdata.loads(after)
+
+
+# ---------------------------------------------------------------------------
+# Handler-level tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHandler:
+    def _get_handler(self) -> Any:
+        with patch("kicad_interface.USE_IPC_BACKEND", False):
+            from kicad_interface import KiCADInterface
+
+            iface = KiCADInterface.__new__(KiCADInterface)
+        return iface._handle_lint_offgrid
+
+    def test_missing_path(self):
+        r = self._get_handler()({})
+        assert r["success"] is False
+        assert "schematicPath" in r["message"]
+
+    def test_nonexistent_file(self, tmp_path):
+        r = self._get_handler()({"schematicPath": str(tmp_path / "no.kicad_sch")})
+        assert r["success"] is False
+
+    def test_invalid_grid(self, tmp_path):
+        sch = _make_temp_schematic(tmp_path)
+        r = self._get_handler()({"schematicPath": str(sch), "gridSize": 0})
+        assert r["success"] is False
+
+    def test_report_and_fix(self, tmp_path):
+        sch = _make_temp_schematic(tmp_path, OFFGRID_SYMBOL + OFFGRID_WIRE)
+        handler = self._get_handler()
+        r = handler({"schematicPath": str(sch)})
+        assert r["success"] is True
+        assert len(r["offenders"]) == 2
+        assert r["fixed"] == 0
+        assert "_spans" not in r["offenders"][0]
+
+        r = handler({"schematicPath": str(sch), "fix": True})
+        assert r["success"] is True
+        assert r["fixed"] == 2
+        assert handler({"schematicPath": str(sch)})["offenders"] == []
+
+
+# ---------------------------------------------------------------------------
+# Netlist equivalence (integration)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestConnectivityPreserved:
+    def test_wire_and_label_snap_to_same_node(self, tmp_path):
+        """An off-grid label anchor coincident with an off-grid wire endpoint
+        must land on the same grid node after fix (net membership identical)."""
+        block = (
+            OFFGRID_WIRE
+            + '  (label "NETX" (at 157.51 50.8 0)\n'
+            + "    (effects (font (size 1.27 1.27)))\n"
+            + "  )\n"
+        )
+        sch = _make_temp_schematic(tmp_path, block)
+        r = lint_offgrid(str(sch), fix=True)
+        assert r["fixed"] == 2
+        content = sch.read_text(encoding="utf-8")
+        assert content.count("157.48 50.8") == 2  # wire endpoint + label anchor

--- a/tests/test_lint_offgrid.py
+++ b/tests/test_lint_offgrid.py
@@ -19,7 +19,6 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
 
 import sexpdata  # noqa: E402
-
 from commands.schematic_lint_grid import lint_offgrid  # noqa: E402
 
 TEMPLATE_SCH = Path(__file__).parent.parent / "python" / "templates" / "empty.kicad_sch"
@@ -118,7 +117,7 @@ class TestLint:
 
         # Both offenders snapped to the SAME grid node -> connectivity kept
         assert "157.51" not in after
-        assert '(at 157.48 50.8 0)' in after
+        assert "(at 157.48 50.8 0)" in after
         assert "(xy 157.48 50.8)" in after
 
         # re-lint: clean; file still parses

--- a/tests/test_repair_flat_symbols.py
+++ b/tests/test_repair_flat_symbols.py
@@ -1,0 +1,287 @@
+"""
+Tests for the repair_flat_symbols tool (python/commands/symbol_repair.py).
+
+Flat SnapEDA/SamacSys captures put pins/graphics directly under the
+top-level (symbol "NAME") with no _1_1 sub-unit; kicad-skip crashes on
+them. The tool wraps the drawable children in a proper sub-unit via pure
+balanced-paren text insertion (never a sexpdata round-trip).
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.symbol_repair import SymbolRepairCommands  # noqa: E402
+
+FLAT_SYM = """\
+(kicad_symbol_lib (version 20211014) (generator SamacSys_ECAD_Model)
+  (symbol "NCV7356" (in_bom yes) (on_board yes)
+    (property "Reference" "IC" (id 0) (at 27.94 7.62 0)
+      (effects (font (size 1.27 1.27)) (justify left top))
+    )
+    (property "Value" "NCV7356" (id 1) (at 27.94 5.08 0)
+      (effects (font (size 1.27 1.27)) (justify left top))
+    )
+    (pin passive line (at 0 0 0) (length 5.08)
+      (name "TXD" (effects (font (size 1.27 1.27))))
+      (number "1" (effects (font (size 1.27 1.27))))
+    )
+    (pin passive line (at 0 -2.54 0) (length 5.08)
+      (name "GND" (effects (font (size 1.27 1.27))))
+      (number "2" (effects (font (size 1.27 1.27))))
+    )
+    (rectangle (start 5.08 2.54) (end 22.86 -7.62)
+      (stroke (width 0.254) (type default)) (fill (type background))
+    )
+  )
+)
+"""
+
+WRAPPED_SYM = """\
+(kicad_symbol_lib (version 20211014) (generator kicad_symbol_editor)
+  (symbol "GOOD_PART" (in_bom yes) (on_board yes)
+    (property "Reference" "U" (id 0) (at 0 0 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (symbol "GOOD_PART_1_1"
+      (pin passive line (at 0 0 0) (length 2.54)
+        (name "P1" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )
+)
+"""
+
+MULTI_SYM = """\
+(kicad_symbol_lib (version 20211014) (generator test)
+  (symbol "FLAT_ONE" (in_bom yes) (on_board yes)
+    (property "Reference" "U" (id 0) (at 0 0 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (pin passive line (at 0 0 0) (length 2.54)
+      (name "A" (effects (font (size 1.27 1.27))))
+      (number "1" (effects (font (size 1.27 1.27))))
+    )
+  )
+  (symbol "GOOD_PART" (in_bom yes) (on_board yes)
+    (property "Reference" "U" (id 0) (at 0 0 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (symbol "GOOD_PART_1_1"
+      (pin passive line (at 0 0 0) (length 2.54)
+        (name "P1" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )
+  (symbol "DERIVED_PART" (extends "GOOD_PART")
+    (property "Reference" "U" (id 0) (at 0 0 0)
+      (effects (font (size 1.27 1.27)))
+    )
+  )
+)
+"""
+
+# A schematic embedding a flat symbol snapshot in (lib_symbols) — symbol
+# names carry the LIB: prefix but sub-unit names must not. Property values
+# contain unescaped parens to exercise the string-aware scanner.
+FLAT_SCH = """\
+(kicad_sch (version 20250114) (generator "eeschema") (generator_version "9.0")
+  (uuid 11111111-2222-3333-4444-555555555555)
+  (paper "A4")
+  (lib_symbols
+    (symbol "VendorLib:ADM3057E" (pin_numbers hide) (in_bom yes) (on_board yes)
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Description" "Isolated CAN (5kV rms) transceiver" (at 0 2 0)
+        (effects (font (size 1.27 1.27)))
+      )
+      (pin passive line (at 0 0 0) (length 2.54)
+        (name "VIO(1)" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )
+  (symbol (lib_id "VendorLib:ADM3057E") (at 50 50 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no)
+    (uuid aaaaaaaa-bbbb-cccc-dddd-111111111111)
+    (property "Reference" "U1" (at 50 45 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "ADM3057E" (at 50 55 0) (effects (font (size 1.27 1.27))))
+  )
+  (sheet_instances (path "/" (page "1")))
+)
+"""
+
+
+@pytest.fixture()
+def commands():
+    return SymbolRepairCommands()
+
+
+def _write(tmp_path, name, content):
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return str(p)
+
+
+@pytest.mark.unit
+class TestRepairFlatSymbols:
+    def test_dry_run_default_reports_without_writing(self, commands, tmp_path):
+        path = _write(tmp_path, "flat.kicad_sym", FLAT_SYM)
+        r = commands.repair_flat_symbols({"path": path})
+        assert r["success"] is True
+        assert r["dryRun"] is True
+        assert r["flat_symbols_found"] == ["NCV7356"]
+        assert r["repaired"] == []
+        assert Path(path).read_text(encoding="utf-8") == FLAT_SYM  # untouched
+
+    def test_repair_writes_subunit(self, commands, tmp_path):
+        path = _write(tmp_path, "flat.kicad_sym", FLAT_SYM)
+        r = commands.repair_flat_symbols({"path": path, "dryRun": False})
+        assert r["success"] is True
+        assert r["repaired"] == ["NCV7356"]
+        content = Path(path).read_text(encoding="utf-8")
+        assert '(symbol "NCV7356_1_1"' in content
+        # No-reformat guarantee: original property lines appear verbatim
+        assert '    (property "Reference" "IC" (id 0) (at 27.94 7.62 0)' in content
+
+    def test_idempotent(self, commands, tmp_path):
+        path = _write(tmp_path, "flat.kicad_sym", FLAT_SYM)
+        commands.repair_flat_symbols({"path": path, "dryRun": False})
+        first = Path(path).read_text(encoding="utf-8")
+        r = commands.repair_flat_symbols({"path": path, "dryRun": False})
+        assert r["success"] is True
+        assert r["flat_symbols_found"] == []
+        assert "skipped_reason" in r
+        assert Path(path).read_text(encoding="utf-8") == first
+
+    def test_wrapped_symbol_untouched(self, commands, tmp_path):
+        path = _write(tmp_path, "good.kicad_sym", WRAPPED_SYM)
+        r = commands.repair_flat_symbols({"path": path, "dryRun": False})
+        assert r["success"] is True
+        assert r["flat_symbols_found"] == []
+        assert Path(path).read_text(encoding="utf-8") == WRAPPED_SYM
+
+    def test_multi_symbol_lib_wraps_only_flat(self, commands, tmp_path):
+        path = _write(tmp_path, "multi.kicad_sym", MULTI_SYM)
+        r = commands.repair_flat_symbols({"path": path, "dryRun": False})
+        assert r["success"] is True
+        assert r["flat_symbols_found"] == ["FLAT_ONE"]
+        content = Path(path).read_text(encoding="utf-8")
+        assert '(symbol "FLAT_ONE_1_1"' in content
+        assert content.count('(symbol "GOOD_PART_1_1"') == 1
+        assert '(symbol "DERIVED_PART_1_1"' not in content
+
+    def test_schematic_embedded_snapshot(self, commands, tmp_path):
+        path = _write(tmp_path, "flat.kicad_sch", FLAT_SCH)
+        r = commands.repair_flat_symbols({"path": path, "dryRun": False})
+        assert r["success"] is True
+        assert r["flat_symbols_found"] == ["VendorLib:ADM3057E"]
+        content = Path(path).read_text(encoding="utf-8")
+        # LIB: prefix stripped from the sub-unit name
+        assert '(symbol "ADM3057E_1_1"' in content
+        assert '(symbol "VendorLib:ADM3057E_1_1"' not in content
+        # Placed instance outside lib_symbols untouched
+        assert '(symbol (lib_id "VendorLib:ADM3057E") (at 50 50 0) (unit 1)' in content
+
+    def test_schematic_without_lib_symbols(self, commands, tmp_path):
+        path = _write(tmp_path, "bare.kicad_sch", "(kicad_sch (version 1))")
+        r = commands.repair_flat_symbols({"path": path, "dryRun": False})
+        assert r["success"] is True
+        assert r["flat_symbols_found"] == []
+        assert "no lib_symbols" in r["skipped_reason"]
+
+    def test_bad_extension(self, commands, tmp_path):
+        path = _write(tmp_path, "notes.txt", "hello")
+        r = commands.repair_flat_symbols({"path": path})
+        assert r["success"] is False
+        assert ".kicad_sym or .kicad_sch" in r["message"]
+
+    def test_missing_path(self, commands, tmp_path):
+        r = commands.repair_flat_symbols({})
+        assert r["success"] is False
+        r = commands.repair_flat_symbols({"path": str(tmp_path / "nope.kicad_sym")})
+        assert r["success"] is False
+        assert "not found" in r["message"]
+
+    def test_unbalanced_file_fails_cleanly(self, commands, tmp_path):
+        path = _write(tmp_path, "broken.kicad_sym", "(kicad_symbol_lib (symbol \"X\" (pin ")
+        before = Path(path).read_text(encoding="utf-8")
+        r = commands.repair_flat_symbols({"path": path, "dryRun": False})
+        assert r["success"] is False
+        assert Path(path).read_text(encoding="utf-8") == before
+
+
+# ---------------------------------------------------------------------------
+# Integration: kicad-skip can load the repaired schematic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestKicadSkipLoads:
+    @pytest.fixture(autouse=True)
+    def _require_real_skip(self):
+        skip_mod = pytest.importorskip("skip")
+        if getattr(skip_mod, "__file__", None) is None:
+            pytest.skip("real kicad-skip not installed (conftest stub)")
+        self.skip = skip_mod
+
+    def test_flat_schematic_fails_then_repaired_loads(self, commands, tmp_path):
+        path = _write(tmp_path, "flat.kicad_sch", FLAT_SCH)
+        with pytest.raises(Exception):
+            self.skip.Schematic(path)
+
+        r = commands.repair_flat_symbols({"path": path, "dryRun": False})
+        assert r["success"] is True
+
+        sch = self.skip.Schematic(path)  # must not raise now
+        refs = [s.property.Reference.value for s in sch.symbol]
+        assert "U1" in refs
+
+
+# ---------------------------------------------------------------------------
+# Integration: kicad-cli renders flat and repaired schematics identically
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestRenderNeutral:
+    def test_svg_render_identity(self, commands, tmp_path):
+        if shutil.which("kicad-cli") is None:
+            pytest.skip("kicad-cli not available")
+
+        # Same file name in two directories: kicad-cli embeds the file name
+        # in the rendered title block.
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        flat = _write(tmp_path / "a", "sheet.kicad_sch", FLAT_SCH)
+        repaired = _write(tmp_path / "b", "sheet.kicad_sch", FLAT_SCH)
+        r = commands.repair_flat_symbols({"path": repaired, "dryRun": False})
+        assert r["success"] is True
+
+        def _export(sch, out_dir):
+            out_dir.mkdir()
+            subprocess.run(
+                ["kicad-cli", "sch", "export", "svg", sch, "-o", str(out_dir)],
+                check=True,
+                capture_output=True,
+                timeout=120,
+            )
+            svgs = sorted(out_dir.glob("*.svg"))
+            assert len(svgs) == 1
+            return svgs[0].read_text(encoding="utf-8")
+
+        svg_flat = _export(flat, tmp_path / "out_flat")
+        svg_repaired = _export(repaired, tmp_path / "out_repaired")
+        # Strip the title block (carries the file name/date) before comparing
+        import re as _re
+
+        def _normalize(svg):
+            return _re.sub(r"<title>.*?</title>", "", svg, flags=_re.S)
+
+        assert _normalize(svg_flat) == _normalize(svg_repaired)

--- a/tests/test_repair_flat_symbols.py
+++ b/tests/test_repair_flat_symbols.py
@@ -210,7 +210,7 @@ class TestRepairFlatSymbols:
         assert "not found" in r["message"]
 
     def test_unbalanced_file_fails_cleanly(self, commands, tmp_path):
-        path = _write(tmp_path, "broken.kicad_sym", "(kicad_symbol_lib (symbol \"X\" (pin ")
+        path = _write(tmp_path, "broken.kicad_sym", '(kicad_symbol_lib (symbol "X" (pin ')
         before = Path(path).read_text(encoding="utf-8")
         r = commands.repair_flat_symbols({"path": path, "dryRun": False})
         assert r["success"] is False

--- a/tests/test_schematic_batch.py
+++ b/tests/test_schematic_batch.py
@@ -194,6 +194,7 @@ class TestBatchConnect:
             add_wire=lambda *a: True,
             delete_label=lambda *a, **k: True,
         )
+
         # _find_facing_label must NOT be consulted for global labels; make it raise if called.
         def _boom(*a, **k):
             raise AssertionError("facing-label lookup should be skipped for global labels")

--- a/tests/test_schematic_batch.py
+++ b/tests/test_schematic_batch.py
@@ -177,6 +177,52 @@ class TestBatchConnect:
         assert len(r["placed"]) == 1
         assert labels == [("SDA", 180)]  # pin angle 0 -> label orientation 180
 
+    def test_places_global_label(self, monkeypatch, tmp_path):
+        f = tmp_path / "x.kicad_sch"
+        f.write_text("(kicad_sch)")
+        fake_loc = types.SimpleNamespace(
+            get_pin_location=lambda p, ref, pin: [10.0, 20.0],
+            get_pin_angle=lambda p, ref, pin: 0,
+            get_all_symbol_pins=lambda p, ref: {"1": [10.0, 20.0]},
+        )
+        kinds = []
+        fake_wm = types.SimpleNamespace(
+            add_label=lambda p, net, pos, label_type="label", orientation=0: kinds.append(
+                label_type
+            )
+            or True,
+            add_wire=lambda *a: True,
+            delete_label=lambda *a, **k: True,
+        )
+        # _find_facing_label must NOT be consulted for global labels; make it raise if called.
+        def _boom(*a, **k):
+            raise AssertionError("facing-label lookup should be skipped for global labels")
+
+        monkeypatch.setattr(sb, "PinLocator", lambda: fake_loc)
+        monkeypatch.setattr(sb, "WireManager", fake_wm)
+        monkeypatch.setattr(sb, "_find_facing_label", _boom)
+
+        c = SchematicBatchCommands(types.SimpleNamespace())
+        r = c.batch_connect(
+            {
+                "schematicPath": str(f),
+                "connections": {"U1": {"9": "GND"}},
+                "labelType": "global_label",
+            }
+        )
+        assert r["success"] is True
+        assert kinds == ["global_label"]
+
+    def test_rejects_invalid_label_type(self, tmp_path):
+        f = tmp_path / "x.kicad_sch"
+        f.write_text("(kicad_sch)")
+        c = SchematicBatchCommands(types.SimpleNamespace())
+        r = c.batch_connect(
+            {"schematicPath": str(f), "connections": {"R1": {"1": "X"}}, "labelType": "bogus"}
+        )
+        assert r["success"] is False
+        assert "labelType" in r["message"]
+
 
 class TestBatchAddAndConnect:
     def test_splits_nets_and_orchestrates(self):
@@ -204,6 +250,7 @@ class TestBatchAddAndConnect:
             {
                 "schematicPath": "/x.kicad_sch",
                 "components": [{"symbol": "Device:R", "reference": "R1", "nets": {"1": "VCC"}}],
+                "labelType": "global_label",
             }
         )
         assert r["success"] is True
@@ -213,6 +260,8 @@ class TestBatchAddAndConnect:
         assert "nets" not in add_args["components"][0]
         # nets routed to batch_connect keyed by reference
         assert conn_args["connections"] == {"R1": {"1": "VCC"}}
+        # labelType threaded through to batch_connect
+        assert conn_args["labelType"] == "global_label"
 
 
 class TestReplaceFieldRestore:

--- a/tests/test_schematic_lint.py
+++ b/tests/test_schematic_lint.py
@@ -1,0 +1,312 @@
+"""
+Tests for lint_schematic_cosmetic (python/commands/schematic_lint.py).
+
+Both passes are netlist-safe by construction: they never move a symbol,
+pin, wire, junction, or label anchor — only display attributes change.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.schematic_lint import (  # noqa: E402
+    SchematicLintCommands,
+    _hide_pin_names,
+    _orient_labels,
+)
+
+TEMPLATE_SCH = Path(__file__).parent.parent / "python" / "templates" / "empty.kicad_sch"
+
+# Minimal schematic text with three lib defs:
+#  - VendorA:NO_PIN_NAMES  — no (pin_names) block -> gets a full insert
+#  - VendorA:HAS_PIN_NAMES — (pin_names (offset 1)) without hide -> hide added
+#  - VendorA:ALREADY_HIDDEN — already hidden -> untouched
+LINT_SCH = """\
+(kicad_sch (version 20250114) (generator "eeschema")
+  (uuid 99999999-0000-0000-0000-000000000000)
+  (paper "A4")
+  (lib_symbols
+    (symbol "VendorA:NO_PIN_NAMES" (in_bom yes) (on_board yes)
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "NO_PIN_NAMES_1_1"
+        (pin passive line (at -5.08 0 0) (length 2.54)
+          (name "IN" (effects (font (size 1.27 1.27))))
+          (number "1" (effects (font (size 1.27 1.27))))
+        )
+      )
+    )
+    (symbol "VendorA:HAS_PIN_NAMES" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "HAS_PIN_NAMES_1_1"
+        (pin passive line (at -5.08 0 0) (length 2.54)
+          (name "IN" (effects (font (size 1.27 1.27))))
+          (number "1" (effects (font (size 1.27 1.27))))
+        )
+      )
+    )
+    (symbol "VendorA:ALREADY_HIDDEN" (pin_names (offset 1.016) (hide yes)) (in_bom yes) (on_board yes)
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "ALREADY_HIDDEN_1_1"
+        (pin passive line (at -5.08 0 0) (length 2.54)
+          (name "IN" (effects (font (size 1.27 1.27))))
+          (number "1" (effects (font (size 1.27 1.27))))
+        )
+      )
+    )
+  )
+  (sheet_instances (path "/" (page "1")))
+)
+"""
+
+
+@pytest.mark.unit
+class TestHidePinNames:
+    def test_all_three_cases(self):
+        out, n = _hide_pin_names(LINT_SCH)
+        assert n == 2  # insert + add-hide; already-hidden untouched
+        # Every top-level def now hides pin names
+        for name in ("NO_PIN_NAMES", "HAS_PIN_NAMES", "ALREADY_HIDDEN"):
+            def_start = out.index(f'(symbol "VendorA:{name}"')
+            sub_start = out.index(f'(symbol "{name}_1_1"')
+            header = out[def_start:sub_start]
+            assert "(pin_names" in header
+            assert "hide" in header, name
+
+    def test_idempotent(self):
+        once, n1 = _hide_pin_names(LINT_SCH)
+        twice, n2 = _hide_pin_names(once)
+        assert n1 == 2
+        assert n2 == 0
+        assert twice == once
+
+    def test_subunits_and_instances_untouched(self):
+        out, _ = _hide_pin_names(LINT_SCH)
+        # Sub-unit defs (no ':' in name) got no pin_names insert
+        for name in ("NO_PIN_NAMES_1_1", "HAS_PIN_NAMES_1_1", "ALREADY_HIDDEN_1_1"):
+            sub_start = out.index(f'(symbol "{name}"')
+            sub_line_end = out.index("\n", sub_start)
+            following = out[sub_line_end : sub_line_end + 60]
+            assert "(pin_names" not in following
+
+    def test_no_lib_symbols_noop(self):
+        out, n = _hide_pin_names("(kicad_sch (version 1))")
+        assert n == 0
+        assert out == "(kicad_sch (version 1))"
+
+
+@pytest.mark.unit
+class TestOrientLabels:
+    LABEL = (
+        '\t(label "NETX"\n'
+        "\t\t(at 10 20 0)\n"
+        "\t\t(effects\n"
+        "\t\t\t(font\n\t\t\t\t(size 1.27 1.27)\n\t\t\t)\n"
+        "\t\t\t(justify left bottom)\n"
+        "\t\t)\n"
+        "\t)\n"
+    )
+
+    def _sch(self, label_block):
+        return f"(kicad_sch (version 1)\n{label_block})\n"
+
+    @pytest.mark.parametrize(
+        "pin_angle,expected_angle,expected_justify",
+        [(0, 180, "right"), (180, 0, "left"), (90, 270, "right"), (270, 90, "left")],
+    )
+    def test_each_cardinal(self, pin_angle, expected_angle, expected_justify):
+        src = self._sch(self.LABEL)
+        out, n, skipped = _orient_labels(src, {(10.0, 20.0): pin_angle})
+        assert n == 1
+        assert skipped == 0
+        assert f"(at 10 20 {expected_angle})" in out
+        assert f"(justify {expected_justify})" in out
+        # anchor untouched
+        assert "(at 10 20 " in out
+
+    def test_label_not_on_pin_untouched(self):
+        src = self._sch(self.LABEL)
+        out, n, skipped = _orient_labels(src, {(99.0, 99.0): 0})
+        assert n == 0
+        assert skipped == 1
+        assert out == src
+
+    def test_justify_inserted_when_missing(self):
+        label = self.LABEL.replace("\t\t\t(justify left bottom)\n", "")
+        src = self._sch(label)
+        out, n, _ = _orient_labels(src, {(10.0, 20.0): 180})
+        assert n == 1
+        assert "(justify left)" in out
+
+    def test_global_label_handled(self):
+        label = self.LABEL.replace('(label "NETX"', '(global_label "NETX"')
+        src = self._sch(label)
+        out, n, _ = _orient_labels(src, {(10.0, 20.0): 90})
+        assert n == 1
+        assert "(at 10 20 270)" in out
+
+
+# ---------------------------------------------------------------------------
+# Handler-level
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHandler:
+    def _handler(self):
+        return SchematicLintCommands().lint_schematic_cosmetic
+
+    def test_missing_path(self):
+        r = self._handler()({})
+        assert r["success"] is False
+
+    def test_nonexistent_file(self, tmp_path):
+        r = self._handler()({"schematicPath": str(tmp_path / "no.kicad_sch")})
+        assert r["success"] is False
+
+    def test_bad_pass_name(self, tmp_path):
+        sch = tmp_path / "s.kicad_sch"
+        sch.write_text(LINT_SCH, encoding="utf-8")
+        r = self._handler()({"schematicPath": str(sch), "passes": ["bogus"]})
+        assert r["success"] is False
+        assert "bogus" in r["message"]
+
+    def test_dry_run_counts_but_no_write(self, tmp_path):
+        sch = tmp_path / "s.kicad_sch"
+        sch.write_text(LINT_SCH, encoding="utf-8")
+        r = self._handler()(
+            {"schematicPath": str(sch), "passes": ["hide_pin_names"], "dryRun": True}
+        )
+        assert r["success"] is True
+        assert r["dryRun"] is True
+        assert r["changed"] is True
+        assert r["counts"]["hide_pin_names"] == 2
+        assert sch.read_text(encoding="utf-8") == LINT_SCH
+
+    def test_hide_pass_writes(self, tmp_path):
+        sch = tmp_path / "s.kicad_sch"
+        sch.write_text(LINT_SCH, encoding="utf-8")
+        r = self._handler()({"schematicPath": str(sch), "passes": ["hide_pin_names"]})
+        assert r["success"] is True
+        assert r["changed"] is True
+        content = sch.read_text(encoding="utf-8")
+        assert content.count("(hide yes)") == 3
+
+    def test_zero_counts_on_bare_sheet(self, tmp_path):
+        sch = tmp_path / "s.kicad_sch"
+        sch.write_text(TEMPLATE_SCH.read_text(encoding="utf-8"), encoding="utf-8")
+        r = self._handler()({"schematicPath": str(sch)})
+        assert r["success"] is True
+        assert r["counts"]["orient_labels"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Rotation/mirror integration (real kicad-skip + PinLocator)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestRotationMirrorIntegration:
+    """The case the raw-text reference script could not handle: labels on
+    pins of rotated/mirrored instances must orient by the pin's TRUE
+    sheet-space outward side."""
+
+    @pytest.fixture(autouse=True)
+    def _require_real_skip(self):
+        skip_mod = pytest.importorskip("skip")
+        if getattr(skip_mod, "__file__", None) is None:
+            pytest.skip("real kicad-skip not installed (conftest stub)")
+
+    def _build_sheet(self, tmp_path, rotation=0, mirror=None):
+        """Template + one Device:R at (50,50) with rotation/mirror, plus a
+        label at each pin position (computed by PinLocator itself)."""
+        import sys as _sys
+
+        _sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+        from commands.pin_locator import PinLocator
+
+        mirror_sexp = f" (mirror {mirror})" if mirror else ""
+        placed = (
+            f'  (symbol (lib_id "Device:R") (at 50 50 {rotation}){mirror_sexp} (unit 1)\n'
+            "    (in_bom yes) (on_board yes) (dnp no)\n"
+            '    (uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")\n'
+            '    (property "Reference" "R1" (at 52 47 0)\n'
+            "      (effects (font (size 1.27 1.27)))\n"
+            "    )\n"
+            '    (property "Value" "10k" (at 52 53 0)\n'
+            "      (effects (font (size 1.27 1.27)))\n"
+            "    )\n"
+            "  )\n"
+        )
+        content = TEMPLATE_SCH.read_text(encoding="utf-8").rstrip()
+        assert content.endswith(")")
+        content = content[:-1] + "\n" + placed + ")\n"
+        sch = tmp_path / "rot.kicad_sch"
+        sch.write_text(content, encoding="utf-8")
+
+        locator = PinLocator()
+        pins = locator.get_all_symbol_pins(sch, "R1")
+        assert pins
+        labels = ""
+        for i, (pin_num, coords) in enumerate(sorted(pins.items())):
+            labels += (
+                f'  (label "NET_{pin_num}" (at {round(coords[0], 2)} {round(coords[1], 2)} 0)\n'
+                "    (effects (font (size 1.27 1.27)) (justify left bottom))\n"
+                "  )\n"
+            )
+        content = sch.read_text(encoding="utf-8").rstrip()[:-1] + "\n" + labels + ")\n"
+        sch.write_text(content, encoding="utf-8")
+        return sch, locator, pins
+
+    @pytest.mark.parametrize(
+        "rotation,mirror",
+        [(0, None), (90, None), (180, None), (0, "y"), (90, "x")],
+    )
+    def test_orientation_matches_pin_outward_side(self, tmp_path, rotation, mirror):
+        from commands.pin_locator import PinLocator
+        from commands.schematic_lint import _ORIENT, _build_pin_orient_map
+
+        sch, _, pins = self._build_sheet(tmp_path, rotation=rotation, mirror=mirror)
+        handler = SchematicLintCommands().lint_schematic_cosmetic
+        r = handler({"schematicPath": str(sch), "passes": ["orient_labels"]})
+        assert r["success"], r
+        assert r["counts"]["orient_labels"] >= 1
+        assert r["skippedLabels"] == 0
+
+        # Each label's written angle must equal the _ORIENT entry for the
+        # pin's true outward angle (fresh locator: file changed on disk).
+        locator = PinLocator()
+        pin_map = _build_pin_orient_map(sch)
+        content = sch.read_text(encoding="utf-8")
+        for pin_num, coords in pins.items():
+            key = (round(coords[0], 2), round(coords[1], 2))
+            expected_angle, expected_justify = _ORIENT[pin_map[key]]
+            m = re.search(
+                rf'\(label "NET_{pin_num}" \(at {key[0]} {key[1]} (\d+)\)',
+                content,
+            )
+            assert m, f"label NET_{pin_num} anchor moved!"
+            assert int(m.group(1)) == expected_angle
+            assert f"(justify {expected_justify})" in content
+
+    def test_anchor_multiset_invariant(self, tmp_path):
+        """Netlist-safety proxy: the multiset of label anchors and symbol
+        positions is unchanged after both passes."""
+        sch, _, _ = self._build_sheet(tmp_path, rotation=90)
+
+        def anchors(text):
+            return sorted(
+                (m.group(1), m.group(2))
+                for m in re.finditer(r"\(at (-?[\d.]+) (-?[\d.]+)[ )]", text)
+            )
+
+        before_content = sch.read_text(encoding="utf-8")
+        # angle may change; compare x/y pairs only
+        before = anchors(before_content)
+        r = SchematicLintCommands().lint_schematic_cosmetic({"schematicPath": str(sch)})
+        assert r["success"], r
+        after = anchors(sch.read_text(encoding="utf-8"))
+        assert before == after

--- a/tests/test_schematic_load_errors.py
+++ b/tests/test_schematic_load_errors.py
@@ -1,0 +1,203 @@
+"""
+Tests for loud, diagnosed schematic load failures (SchematicLoadError).
+
+Flat SnapEDA/SamacSys lib symbols (pins directly under the top-level
+(symbol "NAME") with no sub-unit) crash kicad-skip's LibSymbol parser.
+SchematicManager.load_schematic now raises SchematicLoadError with the
+offending symbols named instead of returning None, and every handler
+returns {success: false, error: "schematic_load_failed", flatSymbols: [...]}.
+
+Requires the real kicad-skip package (conftest only stubs `skip` when the
+real module is missing); the module self-skips under the stub.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+skip_mod = pytest.importorskip("skip")
+if getattr(skip_mod, "__file__", None) is None:
+    pytest.skip("real kicad-skip not installed (conftest stub)", allow_module_level=True)
+
+from commands.schematic import (  # noqa: E402
+    SchematicLoadError,
+    SchematicManager,
+    find_flat_lib_symbols,
+)
+
+FLAT_SCH = """\
+(kicad_sch (version 20250114) (generator "eeschema") (generator_version "9.0")
+  (uuid 11111111-2222-3333-4444-555555555555)
+  (paper "A4")
+  (lib_symbols
+    (symbol "FLAT:FLAT_PART" (pin_numbers hide) (in_bom yes) (on_board yes)
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "FLAT_PART" (at 0 2 0) (effects (font (size 1.27 1.27))))
+      (pin passive line (at 0 0 0) (length 2.54)
+        (name "P1" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))
+      )
+      (rectangle (start -2 -2) (end 2 2) (stroke (width 0.254) (type default)) (fill (type background)))
+    )
+  )
+  (symbol (lib_id "FLAT:FLAT_PART") (at 50 50 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no)
+    (uuid aaaaaaaa-bbbb-cccc-dddd-111111111111)
+    (property "Reference" "U1" (at 50 45 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "FLAT_PART" (at 50 55 0) (effects (font (size 1.27 1.27))))
+  )
+  (sheet_instances (path "/" (page "1")))
+)
+"""
+
+TEMPLATE_SCH = Path(__file__).parent.parent / "python" / "templates" / "empty.kicad_sch"
+
+
+@pytest.fixture()
+def flat_sch(tmp_path):
+    p = tmp_path / "flat.kicad_sch"
+    p.write_text(FLAT_SCH, encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def good_sch(tmp_path):
+    p = tmp_path / "good.kicad_sch"
+    p.write_text(TEMPLATE_SCH.read_text(encoding="utf-8"), encoding="utf-8")
+    return p
+
+
+def _make_iface() -> Any:
+    with patch("kicad_interface.USE_IPC_BACKEND", False):
+        from kicad_interface import KiCADInterface
+
+        return KiCADInterface.__new__(KiCADInterface)
+
+
+# ---------------------------------------------------------------------------
+# Diagnosis + loader contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFlatSymbolDiagnosis:
+    def test_find_flat_lib_symbols(self, flat_sch, good_sch):
+        assert find_flat_lib_symbols(str(flat_sch)) == ["FLAT:FLAT_PART"]
+        assert find_flat_lib_symbols(str(good_sch)) == []
+
+    def test_find_flat_on_unreadable_file_returns_empty(self, tmp_path):
+        assert find_flat_lib_symbols(str(tmp_path / "nope.kicad_sch")) == []
+
+    def test_kicad_skip_still_crashes_on_flat(self, flat_sch):
+        """Guards the diagnosis: if a future kicad-skip tolerates flat
+        symbols, this failure signals the special-casing can be removed."""
+        with pytest.raises(Exception):
+            skip_mod.Schematic(str(flat_sch))
+
+
+@pytest.mark.unit
+class TestLoadSchematicRaises:
+    def test_flat_raises_with_diagnosis(self, flat_sch):
+        with pytest.raises(SchematicLoadError) as exc_info:
+            SchematicManager.load_schematic(str(flat_sch))
+        err = exc_info.value
+        assert err.kind == "parse_error"
+        assert err.flat_symbols == ["FLAT:FLAT_PART"]
+        assert "FLAT:FLAT_PART" in str(err)
+        assert "repair_flat_symbols" in str(err)
+
+    def test_missing_file_raises_not_found(self, tmp_path):
+        with pytest.raises(SchematicLoadError) as exc_info:
+            SchematicManager.load_schematic(str(tmp_path / "missing.kicad_sch"))
+        assert exc_info.value.kind == "not_found"
+        assert "not found" in str(exc_info.value)
+
+    def test_good_schematic_loads(self, good_sch):
+        sch = SchematicManager.load_schematic(str(good_sch))
+        assert sch is not None
+
+    def test_to_response_shape(self, flat_sch):
+        with pytest.raises(SchematicLoadError) as exc_info:
+            SchematicManager.load_schematic(str(flat_sch))
+        r = exc_info.value.to_response()
+        assert r["success"] is False
+        assert r["error"] == "schematic_load_failed"
+        assert r["flatSymbols"] == ["FLAT:FLAT_PART"]
+        assert "errorDetails" in r
+
+
+# ---------------------------------------------------------------------------
+# Handlers surface the structured error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHandlersSurfaceError:
+    def test_list_schematic_components(self, flat_sch):
+        iface = _make_iface()
+        r = iface._handle_list_schematic_components({"schematicPath": str(flat_sch)})
+        assert r["success"] is False
+        assert r.get("error") == "schematic_load_failed"
+        assert r.get("flatSymbols") == ["FLAT:FLAT_PART"]
+        assert "repair_flat_symbols" in r["message"]
+        assert r["message"] != "Failed to load schematic"
+
+    def test_list_schematic_wires(self, flat_sch):
+        iface = _make_iface()
+        r = iface._handle_list_schematic_wires({"schematicPath": str(flat_sch)})
+        assert r["success"] is False
+        assert r.get("flatSymbols") == ["FLAT:FLAT_PART"]
+
+    def test_batch_connect_aborts_with_diagnosis(self, flat_sch):
+        import types
+
+        from commands.schematic_batch import SchematicBatchCommands
+
+        cmds = SchematicBatchCommands(types.SimpleNamespace())
+        r = cmds.batch_connect(
+            {
+                "schematicPath": str(flat_sch),
+                "connections": {"U1": {"1": "NET_X"}},
+            }
+        )
+        assert r["success"] is False
+        assert "FLAT:FLAT_PART" in r["message"]
+        assert "All pin operations aborted" in r["message"]
+        assert "connected 0" not in r["message"]
+
+    def test_pin_locator_raises(self, flat_sch):
+        from commands.pin_locator import PinLocator
+
+        locator = PinLocator()
+        with pytest.raises(SchematicLoadError):
+            locator.get_pin_location(flat_sch, "U1", "1")
+
+    def test_find_orphaned_wires_errors(self, flat_sch):
+        iface = _make_iface()
+        r = iface._handle_find_orphaned_wires({"schematicPath": str(flat_sch)})
+        assert r["success"] is False
+        assert r.get("error") == "schematic_load_failed"
+        assert not r.get("message", "").startswith("Found ")
+
+    def test_handle_command_backstop(self, flat_sch):
+        """Any route that lets SchematicLoadError escape must still yield the
+        structured error, never the generic 'Error handling command'."""
+        iface = _make_iface()
+        iface.command_routes = {
+            "boom": lambda params: (_ for _ in ()).throw(
+                SchematicLoadError(str(flat_sch), flat_symbols=["X:Y"])
+            )
+        }
+        # Minimal attrs used by handle_command before dispatch
+        iface.board = None
+        iface.use_ipc = False
+        r = iface.handle_command("boom", {})
+        assert r["success"] is False
+        assert r["error"] == "schematic_load_failed"
+        assert r["flatSymbols"] == ["X:Y"]
+        assert "Error handling command" not in r["message"]

--- a/tests/test_wire_junction_changes.py
+++ b/tests/test_wire_junction_changes.py
@@ -332,7 +332,12 @@ class TestPinSnapping:
         with patch.object(KiCADInterface, "__init__", lambda self, *a, **kw: None):
             iface = KiCADInterface.__new__(KiCADInterface)
 
-        with patch("commands.wire_manager.WireManager.add_wire", return_value=True) as mw:
+        with (
+            patch("commands.wire_manager.WireManager.add_wire", return_value=True) as mw,
+            # add_schematic_wire loads via the guarded SchematicManager
+            # loader, whose Schematic binding lives in commands.schematic.
+            patch("commands.schematic.Schematic", skip_mod.Schematic),
+        ):
             result = iface._handle_add_schematic_wire(
                 {
                     "schematicPath": str(self.sch_path),


### PR DESCRIPTION
Part of the à la carte split of #314 (per maintainer request for smaller, independently-mergeable PRs).

These commits form **one coherent unit** because they share `SchematicLoadError` infrastructure and all touch the same schematic export/handler paths — splitting them further would create PRs that don't build on their own.

**Included:**
- **Diagnosed load errors** — kicad-skip crashes on flat SnapEDA/SamacSys `.kicad_sym` symbols (no `_1_1` sub-unit), taking down every skip-based tool for the whole sheet. Load failures now raise `SchematicLoadError`; tools return a structured error naming the offending symbols instead of empty/partial results.
- **`repair_flat_symbols`** — wraps flat vendor symbols in a `(symbol "NAME_1_1" …)` sub-unit so skip-based tools work again.
- **Correct SVG page selection** — `export_schematic_svg` and schematic views exported *all* pages and picked one arbitrarily; now deterministically selects the root page (`_pick_root_svg`), exporting into a private temp dir so stale/hierarchical pages can't be picked up. (Fixes a latent `tmp_dir_p` NameError in the crop path surfaced by the merge.)
- **`delete_schematic_component`** — optional cleanup of labels attached to the deleted component.
- **`batch_connect`** — support global labels (`labelType`).
- **`lint_offgrid`** — detect and safely snap off-grid schematic geometry.
- **`lint_schematic_cosmetic`** — hide pin names, orient net labels.
- **`docs/HEADLESS_AUTHORING.md`** — guide for GUI-less schematic authoring.

Green on the enforced gate: `pre-commit run --all-files` (black/isort/prettier/flake8/mypy/eslint) passes; `npm run build` + `npm test` (64) pass; schematic pytest sweep passes (578 passed). README tool-count synced to the registry.