### PR TITLE
fix(board): use BOARD.Delete() for deletion, not Remove() (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the KiCAD MCP Server project are documented here.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **Deleting anything from a board no longer breaks the session** (#247).
+  `delete_component` worked exactly once: the next board operation — even a
+  pure read like `get_component_list` — failed with `'SwigPyObject' object
+has no attribute ...`, and recovery needed a full `close_project` /
+  `open_project` cycle.
+
+  The cause was an ownership bug, not a lifetime one. KiCad's SWIG wrapper
+  documents that `BOARD.Remove()` _transfers C++ ownership to the Python
+  wrapper_ (`item.thisown = 1`) — it is for detaching an item you intend to
+  keep or re-add. Six handlers called it to delete and then dropped the
+  reference, so the interpreter ran the C++ destructor on an object KiCad
+  still pointed at. Reproduced against a real KiCad 10.0 install: the damage
+  is **process-wide**, corrupting SWIG's type registry so that even
+  `pcbnew.FootprintLoad` degrades to a raw `SwigPyObject` — and on some
+  builds the process segfaults outright.
+
+  All deletion now goes through `utils.board_items.delete_board_item()`,
+  which uses `BOARD.Delete()` (ownership stays in C++). This fixes
+  `delete_component`, `delete_trace` (all three deletion paths),
+  `clear_board_outline` and `delete_graphic` — the same defect was present
+  in every one. A static test fails the build if bare `board.Remove()` is
+  reintroduced.
+
+  Thanks to @Dewieinns for the instrumented trace that made this findable:
+  the two errors named _different_ methods (`thisown` on the board path,
+  `GetPosition` on the read path), which is what pointed at child proxies
+  rather than the board.
+
+- **Board health checks can now see this class of damage** (#247). The
+  `_is_board_healthy()` probe tested only BOARD-level methods, so a board
+  that dispatched fine while handing back dead child items passed — which is
+  precisely why the existing post-save auto-recovery never fired here. It
+  now samples a child item as well.
+
 ## [2.5.0] - 2026-07-26
 
 A minor bump rather than a patch: **20 new board-lifecycle and geometry tools**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ All notable changes to the KiCAD MCP Server project are documented here.
 ### Bug Fixes
 
 - **Deleting anything from a board no longer breaks the session** (#247).
-  `delete_component` worked exactly once: the next board operation — even a
-  pure read like `get_component_list` — failed with `'SwigPyObject' object
-has no attribute ...`, and recovery needed a full `close_project` /
-  `open_project` cycle.
+  `delete_component` worked exactly once. The next board operation — even a
+  pure read like `get_component_list` — failed with an `AttributeError`
+  naming a raw `SwigPyObject`, and recovery needed a full `close_project`
+  then `open_project` cycle.
 
   The cause was an ownership bug, not a lifetime one. KiCad's SWIG wrapper
   documents that `BOARD.Remove()` _transfers C++ ownership to the Python

--- a/python/commands/board/outline.py
+++ b/python/commands/board/outline.py
@@ -7,6 +7,7 @@ import math
 from typing import Any, Dict, Optional
 
 import pcbnew
+from utils.board_items import delete_board_item
 
 logger = logging.getLogger("kicad_interface")
 
@@ -218,7 +219,7 @@ class BoardOutlineCommands:
             for item in list(self.board.GetDrawings()):
                 try:
                     if item.GetLayer() == edge_layer:
-                        self.board.Remove(item)
+                        delete_board_item(self.board, item)
                         removed += 1
                 except Exception:
                     continue
@@ -283,7 +284,7 @@ class BoardOutlineCommands:
                 return {"success": False, "message": "uuid is required"}
             for item in list(self.board.GetDrawings()):
                 if self._item_uuid(item) == uuid:
-                    self.board.Remove(item)
+                    delete_board_item(self.board, item)
                     return {"success": True, "message": f"Deleted graphic {uuid}", "uuid": uuid}
             return {
                 "success": False,

--- a/python/commands/component.py
+++ b/python/commands/component.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import pcbnew
 from commands.library import LibraryManager
 from commands.placement_optimizer import PlacementOptimizerCommands
+from utils.board_items import delete_board_item
 
 logger = logging.getLogger("kicad_interface")
 
@@ -448,8 +449,10 @@ class ComponentCommands(PlacementOptimizerCommands):
                     "errorDetails": f"Could not find component: {reference}",
                 }
 
-            # Remove from board
-            self.board.Remove(module)
+            # Delete, not Remove: Remove() hands C++ ownership to Python, so
+            # dropping `module` on return frees an item KiCad still references
+            # and corrupts SWIG state process-wide (#247).
+            delete_board_item(self.board, module)
 
             return {"success": True, "message": f"Deleted component: {reference}"}
 

--- a/python/commands/routing.py
+++ b/python/commands/routing.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import pcbnew
+from utils.board_items import delete_board_item
 
 logger = logging.getLogger("kicad_interface")
 
@@ -762,7 +763,7 @@ class RoutingCommands:
 
                 deleted_count = len(tracks_to_remove)
                 for track in tracks_to_remove:
-                    self.board.Remove(track)
+                    delete_board_item(self.board, track)
                 tracks_to_remove.clear()
                 self.board.SetModified()
 
@@ -787,7 +788,7 @@ class RoutingCommands:
                         "errorDetails": f"Could not find track with UUID: {trace_uuid}",
                     }
 
-                self.board.Remove(track)
+                delete_board_item(self.board, track)
                 track = None
                 self.board.SetModified()
                 return {"success": True, "message": f"Deleted track: {trace_uuid}"}
@@ -821,7 +822,7 @@ class RoutingCommands:
                         closest_track = track
 
                 if closest_track and min_distance < 1000000:  # Within 1mm
-                    self.board.Remove(closest_track)
+                    delete_board_item(self.board, closest_track)
                     closest_track = None
                     self.board.SetModified()
                     return {

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -1481,12 +1481,41 @@ class KiCADInterface(SchematicHandlersMixin):
         "GetFileName",
     )
 
+    # Probing the BOARD alone is not enough. SWIG dehydration can leave the
+    # BOARD dispatching fine while every child item it hands back is a raw
+    # SwigPyObject — that is exactly the #247 shape, and it is why this check
+    # silently passed while users' next command died on a dead footprint
+    # proxy. Sample one child item as well.
+    _ITEM_HEALTH_METHODS = ("GetPosition",)
+
     def _is_board_healthy(self, board: Optional[Any] = None) -> bool:
-        """Return True if the board (default self.board) has live SWIG dispatch."""
+        """Return True if the board (default self.board) has live SWIG dispatch.
+
+        Checks the BOARD *and* a sampled child item: the two can rot
+        independently, and a healthy BOARD with dead children is the more
+        common failure (#247).
+        """
         target = board if board is not None else self.board
         if target is None:
             return False
-        return all(hasattr(target, m) for m in self._BOARD_HEALTH_METHODS)
+        if not all(hasattr(target, m) for m in self._BOARD_HEALTH_METHODS):
+            return False
+
+        # Child probe is best-effort: a board with no footprints is healthy,
+        # and a backend whose GetFootprints is absent (IPC doubles, mocks)
+        # must not be reported as broken on that basis alone.
+        get_footprints = getattr(target, "GetFootprints", None)
+        if not callable(get_footprints):
+            return True
+        try:
+            footprints = get_footprints()
+            first = next(iter(footprints), None)
+        except Exception:
+            # Iteration itself blowing up is the damage we are looking for.
+            return False
+        if first is None:
+            return True
+        return all(hasattr(first, m) for m in self._ITEM_HEALTH_METHODS)
 
     def _safe_load_board(self, path: str) -> Optional[Any]:
         """Load a board from disk, recovering from SWIG dehydration if pcbnew is broken.

--- a/python/utils/board_items.py
+++ b/python/utils/board_items.py
@@ -1,0 +1,73 @@
+"""Safe deletion of items from a pcbnew BOARD.
+
+Why this module exists (issue #247)
+-----------------------------------
+``BOARD.Remove()`` is **not** the API for deleting an item. KiCad's own SWIG
+wrapper documents what it does (``pcbnew.py``, ``BOARD_ITEM_CONTAINER``)::
+
+    def Remove(self, item):
+        \"\"\"Remove a BOARD_ITEM ... set the thisdown flag so that the python
+        wrapper owns the C++ BOARD_ITEM\"\"\"
+        self.RemoveNative(item)
+        if (not IsActionRunning()):
+            item.thisown = 1          # <-- Python now owns the C++ object
+
+    def Delete(self, item):
+        \"\"\"Remove a BOARD_ITEM ... set the thisdown flag so that the python
+        wrapper does not owns the C++ BOARD_ITEM\"\"\"
+        item.thisown = 0              # C++ will free it
+        self.DeleteNative(item)
+        item.this = None
+
+``Remove()`` hands ownership to Python because it is meant for *detaching* an
+item you intend to keep or re-add. Code that removes an item and then drops
+the reference makes the interpreter run the C++ destructor on an object
+KiCad's structures still point at.
+
+Observed consequence on KiCad 10.0 (reproduced against a real install):
+
+* a single ``delete_component`` followed by the next board operation raises
+  ``'SwigPyObject' object has no attribute 'thisown'``,
+* pure reads fail too — ``'SwigPyObject' object has no attribute 'GetPosition'``,
+* the damage is **process-wide**, not board-scoped: even ``pcbnew.FootprintLoad``
+  degrades, because SWIG's type registry itself is corrupted,
+* on some builds the process segfaults outright instead.
+
+The board object keeps working, which is why the existing
+``_is_board_healthy()`` probe never noticed: it only checks BOARD-level
+methods, and the BOARD is fine. It is the items it hands back that are dead.
+
+Using ``Delete()`` avoids the whole failure mode: ownership stays in C++, and
+the item is freed by the code that knows how.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("kicad_interface")
+
+
+def delete_board_item(board: Any, item: Any) -> None:
+    """Detach ``item`` from ``board`` and let C++ destroy it.
+
+    Prefers ``BOARD.Delete()``. Falls back to ``Remove()`` plus an explicit
+    ``thisown = False`` on builds (or test doubles) that expose no ``Delete``
+    — that combination was verified to be equally safe, since the danger is
+    solely Python owning and then freeing the C++ object.
+
+    Never raises for a missing ``thisown`` attribute; a caller deleting an
+    item must not fail because a proxy lacked a SWIG bookkeeping field.
+    """
+    delete = getattr(board, "Delete", None)
+    if callable(delete):
+        delete(item)
+        return
+
+    logger.debug("BOARD.Delete unavailable; falling back to Remove + disown")
+    board.Remove(item)
+    try:
+        item.thisown = False
+    except AttributeError:
+        # Already a raw SwigPyObject, or a mock without the attribute. The
+        # Remove() above has still detached it; there is nothing more to do.
+        pass

--- a/tests/test_board_editing_closure_apis.py
+++ b/tests/test_board_editing_closure_apis.py
@@ -162,7 +162,10 @@ def test_board_outline_and_graphic_crud():
 
     deleted = cmd.delete_graphic({"uuid": "edge-1"})
     assert deleted["success"] is True
-    board.Remove.assert_called_with(edge)
+    # Delete(), not Remove(): Remove() transfers C++ ownership to Python and
+    # frees an item KiCad still references once the reference drops (#247).
+    board.Delete.assert_called_with(edge)
+    board.Remove.assert_not_called()
 
     cleared = cmd.clear_board_outline({})
     assert cleared["success"] is True

--- a/tests/test_board_item_deletion.py
+++ b/tests/test_board_item_deletion.py
@@ -1,0 +1,208 @@
+"""Regression tests for #247 — SWIG ownership on board-item deletion.
+
+Background: ``BOARD.Remove()`` transfers C++ ownership of the item to the
+Python wrapper (``item.thisown = 1``). Command handlers that removed an item
+and then dropped the reference made the interpreter free an object KiCad
+still referenced, corrupting SWIG state process-wide — or segfaulting.
+
+Verified against a real KiCad 10.0 install before this fix landed: one
+``delete_component`` poisoned the whole process, so the second one raised
+``'SwigPyObject' object has no attribute 'thisown'`` and even a pure read
+raised ``... has no attribute 'GetPosition'`` — matching the trace in #247.
+
+These tests pin the contract: deletion goes through ``BOARD.Delete()`` (which
+leaves ownership in C++), never bare ``Remove()``.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+from utils.board_items import delete_board_item
+
+PYTHON_ROOT = Path(__file__).resolve().parents[1] / "python"
+
+
+class _FakeBoard:
+    """Board exposing both APIs, recording which one the caller reached for."""
+
+    def __init__(self, has_delete=True):
+        self.deleted = []
+        self.removed = []
+        if not has_delete:
+            # Emulate a build with no Delete() at all.
+            del self.__class__.Delete
+
+    def Delete(self, item):
+        self.deleted.append(item)
+
+    def Remove(self, item):
+        self.removed.append(item)
+
+
+class _FakeItem:
+    def __init__(self):
+        self.thisown = True
+
+
+class TestDeleteBoardItem:
+    def test_prefers_delete_so_ownership_stays_in_cpp(self):
+        board = _FakeBoard()
+        item = _FakeItem()
+
+        delete_board_item(board, item)
+
+        assert board.deleted == [item]
+        assert board.removed == [], "Remove() would hand ownership to Python (#247)"
+
+    def test_falls_back_to_remove_plus_disown(self):
+        """On a build with no Delete(), ownership must still be disclaimed."""
+
+        class NoDelete:
+            def __init__(self):
+                self.removed = []
+
+            def Remove(self, item):
+                self.removed.append(item)
+
+        board = NoDelete()
+        item = _FakeItem()
+
+        delete_board_item(board, item)
+
+        assert board.removed == [item]
+        assert item.thisown is False, "Python must not be left owning the C++ item"
+
+    def test_missing_thisown_is_not_an_error(self):
+        """A proxy without thisown must not fail the user's delete."""
+
+        class NoDelete:
+            def Remove(self, item):
+                pass
+
+        class Bare:
+            __slots__ = ()
+
+        delete_board_item(NoDelete(), Bare())  # must not raise
+
+
+class TestNoBareRemoveRemains:
+    """The whole bug class, enforced statically.
+
+    delete_component was only one of six call sites — delete_trace and the
+    board-outline handlers had the identical defect. A grep-style guard is
+    what stops the next one from being reintroduced.
+    """
+
+    def _board_remove_calls(self, path: Path):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        hits = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute) or func.attr != "Remove":
+                continue
+            # self.board.Remove(...) / board.Remove(...)
+            target = func.value
+            name = None
+            if isinstance(target, ast.Attribute):
+                name = target.attr
+            elif isinstance(target, ast.Name):
+                name = target.id
+            if name in {"board", "pcb_board"}:
+                hits.append(f"{path.name}:{node.lineno}")
+        return hits
+
+    def test_no_command_module_calls_board_remove(self):
+        offenders = []
+        for path in PYTHON_ROOT.rglob("*.py"):
+            if path.name == "board_items.py":
+                continue  # the sanctioned fallback lives here
+            offenders.extend(self._board_remove_calls(path))
+
+        assert not offenders, (
+            "board.Remove() transfers C++ ownership to Python and corrupts SWIG "
+            "state when the reference is dropped (#247). Use "
+            "utils.board_items.delete_board_item() instead. Offenders: " + ", ".join(offenders)
+        )
+
+
+class TestBoardHealthProbeSeesDeadChildren:
+    """The probe blind spot that let #247 go undetected.
+
+    _is_board_healthy() checked BOARD methods only. In the real failure the
+    BOARD kept working and only the items it returned were dead, so the probe
+    passed and the existing auto-recovery never fired.
+    """
+
+    @pytest.fixture
+    def interface(self):
+        from kicad_interface import KiCADInterface
+
+        iface = KiCADInterface.__new__(KiCADInterface)  # no __init__: no pcbnew needed
+        iface.board = None
+        return iface
+
+    def _board(self, footprints):
+        class B:
+            def GetDesignSettings(self):
+                pass
+
+            def GetBoardEdgesBoundingBox(self):
+                pass
+
+            def GetFileName(self):
+                return "x.kicad_pcb"
+
+            def GetFootprints(self):
+                return footprints
+
+        return B()
+
+    def test_healthy_board_with_live_children(self, interface):
+        class LiveFp:
+            def GetPosition(self):
+                return (0, 0)
+
+        assert interface._is_board_healthy(self._board([LiveFp()])) is True
+
+    def test_healthy_board_with_dead_children_is_unhealthy(self, interface):
+        class DeadFp:
+            """What a dehydrated proxy looks like: no methods at all."""
+
+            __slots__ = ()
+
+        assert interface._is_board_healthy(self._board([DeadFp()])) is False
+
+    def test_empty_board_is_healthy(self, interface):
+        assert interface._is_board_healthy(self._board([])) is True
+
+    def test_board_without_getfootprints_is_not_penalised(self, interface):
+        class B:
+            def GetDesignSettings(self):
+                pass
+
+            def GetBoardEdgesBoundingBox(self):
+                pass
+
+            def GetFileName(self):
+                return "x.kicad_pcb"
+
+        assert interface._is_board_healthy(B()) is True
+
+    def test_iteration_blowing_up_is_unhealthy(self, interface):
+        class B:
+            def GetDesignSettings(self):
+                pass
+
+            def GetBoardEdgesBoundingBox(self):
+                pass
+
+            def GetFileName(self):
+                return "x.kicad_pcb"
+
+            def GetFootprints(self):
+                raise AttributeError("'SwigPyObject' object has no attribute 'GetFootprints'")
+
+        assert interface._is_board_healthy(B()) is False


### PR DESCRIPTION
Fixes #247.

## The symptom

`delete_component` works exactly once. The **next** board operation fails — including a pure read:

| Call | Result |
|---|---|
| `delete_component R_GATE1` | succeeds |
| `delete_component R_NPULLDOWN1` | `'SwigPyObject' object has no attribute 'thisown'` |
| `get_component_list` | `'SwigPyObject' object has no attribute 'GetPosition'` |

Recovering needs a full `close_project` / `open_project` cycle, so every delete costs a reload.

## The cause

Not a lifetime bug — an **ownership** bug. KiCad's own SWIG wrapper says so:

```python
def Remove(self, item):
    """Remove a BOARD_ITEM ... set the thisdown flag so that the python
    wrapper owns the C++ BOARD_ITEM"""
    self.RemoveNative(item)
    if (not IsActionRunning()):
        item.thisown = 1          # Python now owns the C++ object

def Delete(self, item):
    """Remove a BOARD_ITEM ... set the thisdown flag so that the python
    wrapper does not owns the C++ BOARD_ITEM"""
    item.thisown = 0              # C++ frees it
    self.DeleteNative(item)
```

`Remove()` is for **detaching** an item you intend to keep or re-add. Six handlers used it to *delete* and then dropped the reference, so the interpreter ran the C++ destructor on an object KiCad still pointed at.

## Reproduced against real KiCad 10.0

The trigger is neither `Remove()` nor the auto-save — it is dropping the last Python reference:

```
after LoadBoard                    n=8 type=FOOTPRINT    hasGetReference=True
after Remove (probe #1)            n=7 type=FOOTPRINT    hasGetReference=True
after SaveBoard (probe #1)         n=7 type=FOOTPRINT    hasGetReference=True
after `del fp`                     n=7 type=SwigPyObject hasGetReference=False   <-- here
```

Two things this showed that the issue report could not:

1. **The damage is process-wide, not board-scoped.** Immediately after, even module-level `pcbnew.FootprintLoad` fails — SWIG's *type registry* is corrupted, not just this board. That is also why `close_project`/`open_project` recovers: `_safe_load_board` reloads the `pcbnew` module and rebuilds the registry.
2. **On this build it segfaults outright** (exit 139) rather than degrading. Worse than reported.

Comparing strategies, one variant per process (they poison each other):

| Strategy | Consecutive deletes | `pcbnew` still usable | Result |
|---|---|---|---|
| `Remove()` + drop ref (current) | 1/4, then **segfault** | — | FAIL |
| `Remove()` + `thisown = False` | 4/4 | yes | PASS |
| `Delete()` | 4/4 | yes | PASS |

## The fix

All deletion goes through `utils.board_items.delete_board_item()`, which prefers `Delete()` and falls back to `Remove()` + explicit disown on builds without it.

`delete_component` was only one of **six** sites with this defect. Also fixed: `delete_trace` (all three deletion paths), `clear_board_outline`, `delete_graphic`. That matches the note already in `kicad_interface.py` naming `delete_trace` as an observed trigger.

Second change: `_is_board_healthy()` probed BOARD-level methods only. In this failure the BOARD keeps dispatching fine and only the items it returns are dead — so the check passed and the **existing** post-save auto-recovery never fired. It now samples a child item too. That is defence in depth; the ownership fix is what stops the corruption happening.

## Verification

- 5 consecutive `delete_board_item` calls against a real KiCad 10.0 install, board state correct on disk, `pcbnew` still healthy — where the old code crashed on the second.
- Full suite: **1586 passed, 4 skipped**, matching the v2.5.0 baseline. The 8 autoroute/freerouting failures are the known missing-JRE ones — confirmed by stashing this change and re-running.
- `pre-commit run --all-files` clean.
- New `tests/test_board_item_deletion.py` includes a **static guard** that fails the build if bare `board.Remove()` is reintroduced.
- One existing assertion in `test_board_editing_closure_apis.py` pinned the old API and was updated to the new contract.

## Credit

@Dewieinns' instrumented trace is what made this findable. The two errors named *different* methods — `thisown` on the delete path, `GetPosition` on the read path — and `GetPosition` being a footprint method is what pointed at child proxies rather than the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)