### PR TITLE
perf(sync): load each distinct footprint once, clone per component (#248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### Performance
+
+- **`sync_schematic_to_board` loads each distinct footprint once** (#248).
+  The footprint loop called `pcbnew.FootprintLoad` per component with no
+  memoization anywhere downstream, so a board with thirteen identical
+  resistors paid for thirteen identical disk reads. Each distinct
+  `(library, footprint)` is now loaded once and cloned per component.
+
+  On the reporter's measured component mix, warm cache: 29 loads to 6, and
+  the loop runs roughly twice as fast. The saving is larger cold, where a
+  first read of an untouched `.pretty` dominated everything else.
+
+  Cloning is version-tolerant: `Duplicate()` gained a required argument in
+  KiCad 10, and it returns a `BOARD_ITEM` that SWIG does not down-cast, so
+  the result is passed through `Cast_to_FOOTPRINT`. Verified against a real
+  KiCad 10.0 install.
+
+  Thanks to @Dewieinns for the instrumented per-library timing table, which
+  is what showed repeated loads into the same library costing the same as
+  the first.
+
 ### Bug Fixes
 
 - **Deleting anything from a board no longer breaks the session** (#247).

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -25,6 +25,7 @@ import sexpdata
 from commands.library_schematic import LibraryManager as SchematicLibraryManager
 from commands.schematic import SchematicLoadError, SchematicManager
 from commands.wire_manager import WireManager
+from utils.board_items import clone_footprint
 from utils.interactive_schematic import reload_kicad_schematic
 from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
 from utils.project_settings_guard import preserve_project_settings
@@ -3151,6 +3152,14 @@ class SchematicHandlersMixin:
         project_dir = Path(schematic_path).parent
         library_manager = self._get_project_library_manager(project_dir)
 
+        # One FootprintLoad per distinct (library, footprint), cloned per use.
+        # Measured on a 40-component board (#248): FootprintLoad costs the same
+        # every time -- nothing downstream memoizes it -- so a board with 13
+        # identical resistors paid for 13 identical disk reads. Scoped to this
+        # call rather than process-wide so an edited library is never served
+        # stale.
+        proto_cache: Dict[Tuple[str, str], Any] = {}
+
         for comp in components:
             ref = comp["reference"]
             fp_str = comp["footprint"]
@@ -3181,8 +3190,17 @@ class SchematicHandlersMixin:
                 )
                 continue
 
+            cache_key = (library_path, fp_name)
             try:
-                module = pcbnew.FootprintLoad(library_path, fp_name)
+                if cache_key not in proto_cache:
+                    proto_cache[cache_key] = pcbnew.FootprintLoad(library_path, fp_name)
+                prototype = proto_cache[cache_key]
+                # Always clone, including the first use: the prototype must
+                # never be handed to board.Add(), or the cache would be left
+                # holding a board-owned object that later gets mutated and
+                # invalidated on save/reload. Cloning costs ~0.01 ms against
+                # ~15 ms for a FootprintLoad.
+                module = clone_footprint(prototype) if prototype is not None else None
             except Exception as e:
                 skipped.append(
                     {"reference": ref, "footprint": fp_str, "reason": f"FootprintLoad failed: {e}"}

--- a/python/utils/board_items.py
+++ b/python/utils/board_items.py
@@ -47,6 +47,39 @@ from typing import Any
 logger = logging.getLogger("kicad_interface")
 
 
+def clone_footprint(footprint: Any) -> Any:
+    """Return an independent copy of ``footprint``, ready for ``board.Add()``.
+
+    Used to load a footprint from disk once and stamp out many instances
+    (#248): ``FootprintLoad`` costs the same on every call, so a board with
+    thirteen identical resistors otherwise paid for thirteen identical disk
+    reads. Cloning is ~1000x cheaper than reloading.
+
+    Two portability wrinkles, both verified against a real KiCad 10.0 install:
+
+    * ``Duplicate()`` gained a required ``addToParentGroup`` argument in
+      KiCad 10; KiCad 8/9 take none.
+    * It returns a ``BOARD_ITEM`` — SWIG does not down-cast automatically, so
+      the result has no ``SetReference``/``SetValue`` until it is passed
+      through ``Cast_to_FOOTPRINT``.
+
+    The caller must keep the prototype out of the board: handing it to
+    ``board.Add()`` would leave the cache holding a board-owned object.
+    """
+    import pcbnew  # local: keeps this module importable without KiCad
+
+    try:
+        duplicate = footprint.Duplicate(False)  # KiCad 10
+    except TypeError:
+        duplicate = footprint.Duplicate()  # KiCad 8/9
+
+    if not hasattr(duplicate, "SetReference"):
+        cast = getattr(pcbnew, "Cast_to_FOOTPRINT", None)
+        if cast is not None:
+            duplicate = cast(duplicate)
+    return duplicate
+
+
 def delete_board_item(board: Any, item: Any) -> None:
     """Detach ``item`` from ``board`` and let C++ destroy it.
 

--- a/tests/test_footprint_clone_cache.py
+++ b/tests/test_footprint_clone_cache.py
@@ -78,9 +78,8 @@ class TestLoadIsMemoized:
 
     def _run(self, monkeypatch, footprints):
         """Drive the real loop with N schematic components, return load count."""
-        from commands.schematic_handlers import SchematicHandlersMixin
-
         import pcbnew
+        from commands.schematic_handlers import SchematicHandlersMixin
 
         load_calls = []
 
@@ -95,15 +94,15 @@ class TestLoadIsMemoized:
         monkeypatch.setattr(pcbnew, "FootprintLoad", fake_load)
 
         handler = SchematicHandlersMixin.__new__(SchematicHandlersMixin)
-        components = [
-            {"reference": ref, "footprint": fp, "value": "x"} for ref, fp in footprints
-        ]
+        components = [{"reference": ref, "footprint": fp, "value": "x"} for ref, fp in footprints]
         monkeypatch.setattr(
             handler, "_extract_components_from_schematic", lambda _p: components, raising=False
         )
         lib_mgr = MagicMock()
-        lib_mgr.libraries = {"Resistor_SMD": "/libs/Resistor_SMD.pretty",
-                             "Capacitor_SMD": "/libs/Capacitor_SMD.pretty"}
+        lib_mgr.libraries = {
+            "Resistor_SMD": "/libs/Resistor_SMD.pretty",
+            "Capacitor_SMD": "/libs/Capacitor_SMD.pretty",
+        }
         monkeypatch.setattr(
             handler, "_get_project_library_manager", lambda _d: lib_mgr, raising=False
         )

--- a/tests/test_footprint_clone_cache.py
+++ b/tests/test_footprint_clone_cache.py
@@ -1,0 +1,157 @@
+"""Regression tests for #248 — one FootprintLoad per distinct footprint.
+
+Reporter's instrumented data on a 40-component board showed repeated
+FootprintLoad into the *same* library costing the same as the first
+(Resistor_SMD: first 18 ms, rest-mean 20 ms) — nothing downstream memoized
+it, so 13 identical resistors paid for 13 identical disk reads.
+
+_add_missing_footprints_from_schematic now loads each distinct
+(library, footprint) once and clones per component.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from utils.board_items import clone_footprint  # noqa: E402
+
+
+class TestCloneFootprint:
+    def test_kicad10_signature_is_tried_first(self):
+        fp = MagicMock()
+        fp.Duplicate.return_value = MagicMock()  # has SetReference via MagicMock
+        clone_footprint(fp)
+        fp.Duplicate.assert_called_once_with(False)
+
+    def test_falls_back_to_kicad8_9_signature(self):
+        """KiCad 8/9 Duplicate() takes no argument."""
+        fp = MagicMock()
+        result = MagicMock()
+
+        calls = []
+
+        def duplicate(*args):
+            calls.append(args)
+            if args:
+                raise TypeError("Duplicate() takes 1 positional argument but 2 were given")
+            return result
+
+        fp.Duplicate = duplicate
+        assert clone_footprint(fp) is result
+        assert calls == [(False,), ()]
+
+    def test_casts_when_duplicate_returns_a_bare_board_item(self, monkeypatch):
+        """SWIG does not down-cast: Duplicate returns BOARD_ITEM, which has no
+        SetReference until passed through Cast_to_FOOTPRINT."""
+        import pcbnew
+
+        class BareBoardItem:
+            __slots__ = ()
+
+        bare = BareBoardItem()
+        casted = MagicMock()
+        monkeypatch.setattr(pcbnew, "Cast_to_FOOTPRINT", lambda item: casted, raising=False)
+
+        fp = MagicMock()
+        fp.Duplicate.return_value = bare
+        assert clone_footprint(fp) is casted
+
+    def test_no_cast_available_returns_duplicate_unchanged(self, monkeypatch):
+        import pcbnew
+
+        class BareBoardItem:
+            __slots__ = ()
+
+        bare = BareBoardItem()
+        monkeypatch.delattr(pcbnew, "Cast_to_FOOTPRINT", raising=False)
+        fp = MagicMock()
+        fp.Duplicate.return_value = bare
+        assert clone_footprint(fp) is bare
+
+
+class TestLoadIsMemoized:
+    """The behaviour #248 is actually about."""
+
+    def _run(self, monkeypatch, footprints):
+        """Drive the real loop with N schematic components, return load count."""
+        from commands.schematic_handlers import SchematicHandlersMixin
+
+        import pcbnew
+
+        load_calls = []
+
+        def fake_load(library_path, fp_name):
+            load_calls.append((library_path, fp_name))
+            proto = MagicMock(name=f"proto:{fp_name}")
+            # A fresh object per call -- a shared return_value would make the
+            # independence assertion below test the mock, not the code.
+            proto.Duplicate.side_effect = lambda *_a: MagicMock(name=f"clone:{fp_name}")
+            return proto
+
+        monkeypatch.setattr(pcbnew, "FootprintLoad", fake_load)
+
+        handler = SchematicHandlersMixin.__new__(SchematicHandlersMixin)
+        components = [
+            {"reference": ref, "footprint": fp, "value": "x"} for ref, fp in footprints
+        ]
+        monkeypatch.setattr(
+            handler, "_extract_components_from_schematic", lambda _p: components, raising=False
+        )
+        lib_mgr = MagicMock()
+        lib_mgr.libraries = {"Resistor_SMD": "/libs/Resistor_SMD.pretty",
+                             "Capacitor_SMD": "/libs/Capacitor_SMD.pretty"}
+        monkeypatch.setattr(
+            handler, "_get_project_library_manager", lambda _d: lib_mgr, raising=False
+        )
+
+        board = MagicMock()
+        board.GetFootprints.return_value = []
+        added, skipped = handler._add_missing_footprints_from_schematic(
+            board, str(Path("x") / "t.kicad_sch")
+        )
+        return load_calls, added, skipped, board
+
+    def test_identical_footprints_load_once(self, monkeypatch):
+        """13 identical resistors -> 1 disk read, not 13."""
+        fps = [(f"R{i}", "Resistor_SMD:R_0603_1608Metric") for i in range(1, 14)]
+        load_calls, added, skipped, board = self._run(monkeypatch, fps)
+
+        assert len(load_calls) == 1, f"expected 1 FootprintLoad, got {len(load_calls)}"
+        assert len(added) == 13, "all 13 components must still be added"
+        assert board.Add.call_count == 13
+
+    def test_each_distinct_footprint_loads_once(self, monkeypatch):
+        fps = [
+            ("R1", "Resistor_SMD:R_0603_1608Metric"),
+            ("R2", "Resistor_SMD:R_0603_1608Metric"),
+            ("R3", "Resistor_SMD:R_0805_2012Metric"),
+            ("C1", "Capacitor_SMD:C_0603_1608Metric"),
+            ("C2", "Capacitor_SMD:C_0603_1608Metric"),
+        ]
+        load_calls, added, _, board = self._run(monkeypatch, fps)
+
+        assert len(load_calls) == 3, f"expected 3 distinct loads, got {load_calls}"
+        assert len(added) == 5
+        assert board.Add.call_count == 5
+
+    def test_every_component_gets_its_own_object(self, monkeypatch):
+        """A shared object would mean the last SetReference wins and the board
+        ends up with N references to one footprint."""
+        fps = [(f"R{i}", "Resistor_SMD:R_0603_1608Metric") for i in range(1, 5)]
+        _, _, _, board = self._run(monkeypatch, fps)
+
+        added_objects = [c.args[0] for c in board.Add.call_args_list]
+        assert len(set(id(o) for o in added_objects)) == 4, "the same object was added twice"
+
+    def test_prototype_is_never_added_to_the_board(self, monkeypatch):
+        """Handing the cached prototype to board.Add() would leave the cache
+        holding a board-owned object."""
+        fps = [("R1", "Resistor_SMD:R_0603_1608Metric")]
+        _, _, _, board = self._run(monkeypatch, fps)
+
+        added = board.Add.call_args_list[0].args[0]
+        assert "clone:" in added._mock_name, "the prototype itself was added, not a clone"

--- a/tests/test_sync_schematic_to_board_footprints.py
+++ b/tests/test_sync_schematic_to_board_footprints.py
@@ -89,10 +89,16 @@ class TestAddMissingFootprintsFromSchematic:
         assert added[0]["reference"] == "R99"
         assert added[0]["footprint"] == "Resistor_SMD:R_0603_1608Metric"
         assert skipped == []
-        # Footprint was added to the board.
-        board.Add.assert_called_once_with(loaded_module)
-        loaded_module.SetReference.assert_called_with("R99")
-        loaded_module.SetValue.assert_called_with("10k")
+        # Footprint was added to the board. Since #248 the loaded footprint is
+        # a cached prototype and a CLONE is what gets added — the prototype
+        # must never be handed to board.Add(), or the cache would end up
+        # holding a board-owned object.
+        board.Add.assert_called_once()
+        added_object = board.Add.call_args.args[0]
+        assert added_object is not loaded_module, "prototype was added instead of a clone"
+        assert added_object is loaded_module.Duplicate.return_value
+        added_object.SetReference.assert_called_with("R99")
+        added_object.SetValue.assert_called_with("10k")
 
     def test_skips_reference_already_on_board(self, tmp_path: Any) -> None:
         sch = tmp_path / "test.kicad_sch"


### PR DESCRIPTION
Addresses the remaining half of #248.

## Context: the issue is already most of the way fixed

@Dewieinns re-measured on current main and their own numbers say the hang is gone:

| Phase | Cold disk cache | Warm |
|---|---:|---:|
| kicad-cli netlist extract | 3752 ms | 451 ms |
| `LibraryManager` init (the #310 target) | 487 ms | 481 ms |
| **`FootprintLoad` loop (40 loads)** | **23874 ms** | **1708 ms** |
| **total** | **~28.1 s** | **~2.2 s** |

> On this board, current build, cold, the whole op **completes in ~28 s** — it no longer hangs or approaches the 600 s ceiling.

So this is an optimization, not a bug fix. It closes out the residual they identified.

## The residual

Their per-library table shows the actual finding:

```
library                      n   first  rest-mean
Resistor_SMD                13    18.0       20.2
Capacitor_SMD                9    30.2       28.9
Package_TO_SOT_SMD           4    48.7       46.5
```

> Repeated `FootprintLoad` into the *same* library costs the same as the first — **nothing is memoized across the 40 calls.**

Correct. `_add_missing_footprints_from_schematic` called `FootprintLoad` once per component, and nothing downstream caches it. Thirteen identical resistors meant thirteen identical disk reads.

## The change

Load each distinct `(library, footprint)` once; clone per component. Reproducing their component mix, warm cache:

```
  reporter's mix: 29 components, 6 distinct footprints

  BEFORE  29 FootprintLoad calls   2208.0 ms
  AFTER    6 FootprintLoad calls   1160.5 ms
  ---> 1.9x faster, 23 fewer disk reads
```

Cold is where it matters more — their slowest single load was **7614 ms** for one `Inductor_SMD` read, and any duplicate of that was paying full price again.

**The cache is per-call, not process-wide.** A sync must never serve a footprint from a library the user edited between runs, and the win is within-board duplicate collapse, which is where the cost actually was. Process-wide caching would add staleness risk for a much smaller marginal gain.

## Two things found against real KiCad rather than assumed

`clone_footprint()` has to handle both:

1. **`Duplicate()` gained a required argument in KiCad 10.** `FOOTPRINT.Duplicate() missing 1 required positional argument: 'addToParentGroup'`. KiCad 8/9 take none, and this repo's CI tests against 8, 9 and 10 — so it tries the new signature and falls back on `TypeError`.
2. **It returns a `BOARD_ITEM`, not a `FOOTPRINT`.** SWIG does not down-cast, so the result has no `SetReference`/`SetValue` until passed through `Cast_to_FOOTPRINT`. Missing this fails immediately and loudly, but only at runtime.

## One design point worth stating

The prototype is **never** handed to `board.Add()`, including on first use. Doing so would leave the cache holding a board-owned object that then gets mutated by the next component and invalidated on save/reload — a close cousin of the ownership bug in #344. Cloning costs ~0.01 ms against ~15 ms for a load, so always-clone is both the cheap option and the safe one. There's a test asserting specifically that the prototype is not what gets added.

## Verification

- Real KiCad 10.0: four clones added to a board, saved, reloaded — four distinct references at four distinct positions, prototype still usable afterward.
- Full suite: **1721 passed / 12 skipped**. The 8 autoroute/freerouting failures are the known missing-JRE ones.
- 70 TypeScript tests, `pre-commit run --all-files` clean.
- One existing assertion pinned the old behaviour (asserting the *loaded* object was added) and now asserts a clone is added and the prototype isn't.

Credit to @Dewieinns — the per-library first-vs-rest table is what identified this precisely enough to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)