### PR TITLE
fix(board): add_layer resolved inner layers to the wrong ids (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the KiCAD MCP Server project are documented here.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **`add_layer` could not add inner copper layers, and corrupted an unrelated
+  layer trying** (#222). Four defects, of which the reported one — changes
+  never reaching disk — was the least damaging:
+  - `add_layer` was missing from the auto-save set, so it reported success and
+    wrote nothing.
+  - The layer was resolved as `In1_Cu + (number - 1)`, but KiCad's copper layer
+    IDs step by **2** (`F.Cu`=0, `B.Cu`=2, `In1.Cu`=4, `In2.Cu`=6). Asking for
+    a second inner layer resolved to id 5 — `F.SilkS` — and **renamed the front
+    silkscreen layer** to `In2.Cu`. Confirmed against a real KiCad 10.0 install.
+  - The copper-layer count was computed as `2 + number`, turning a request for
+    two inner layers into six, then eight.
+  - `tool_schemas.py` documented a different tool entirely (`layerName` /
+    `layerType`) from the one that exists (`name` / `type` / `position` /
+    `number`).
+
+  Inner layers are now derived from `SetCopperLayerCount`, which enables and
+  canonically names them; a custom name is stored alongside, exactly as KiCad
+  writes it (`(4 "In1.Cu" signal "PWR")`). `number` is documented as the
+  inner-layer ordinal (1 = In1.Cu) and the response echoes the resolved
+  `canonicalName` and `id`, so the interpretation is visible at the call site.
+  Non-copper `type` values are now rejected rather than silently retyping
+  `F.Cu` — KiCad's technical and user layers are a fixed set.
+
 ## [2.6.0] - 2026-07-28
 
 A minor bump: **10 new tools** take the registry from 136 to 146, and #343

--- a/python/commands/board/layers.py
+++ b/python/commands/board/layers.py
@@ -17,8 +17,25 @@ class BoardLayerCommands:
         """Initialize with optional board instance"""
         self.board = board
 
+    # Copper layer IDs are NOT contiguous: F.Cu=0, B.Cu=2, In1.Cu=4, In2.Cu=6,
+    # ... In30.Cu=62. They step by 2. Deriving an inner layer as
+    # `In1_Cu + (n - 1)` therefore lands on odd IDs that are not copper layers
+    # at all (#222) — n=4 gave layer 7. Step by 2 instead.
+    _MAX_INNER_LAYERS = 30  # In1.Cu .. In30.Cu, i.e. MAX_CU_LAYERS (32) minus F/B
+
+    # Copper layer types KiCad can actually store. "technical" and "user"
+    # layers are a fixed set in KiCad and cannot be added; accepting them here
+    # only ever retyped F.Cu (#222).
+    _COPPER_TYPES = ("copper", "signal", "power", "mixed", "jumper")
+
     def add_layer(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        """Add a new layer to the PCB"""
+        """Enable and name a copper layer on the board.
+
+        ``number`` is the **inner-layer ordinal**, 1-based: 1 = In1.Cu,
+        2 = In2.Cu. It is not a KiCad layer ID — the response echoes the
+        resolved ``canonicalName`` and ``id`` so the caller can see exactly
+        which layer was touched rather than having to know the convention.
+        """
         try:
             if not self.board:
                 return {
@@ -39,43 +56,88 @@ class BoardLayerCommands:
                     "errorDetails": "name, type, and position are required",
                 }
 
-            # Determine layer ID based on position and number
-            layer_id = None
+            if str(layer_type).lower() not in self._COPPER_TYPES:
+                return {
+                    "success": False,
+                    "message": f"Unsupported layer type: {layer_type}",
+                    "errorDetails": (
+                        "add_layer manages copper layers only. KiCad's technical and "
+                        "user layers (silkscreen, mask, courtyard, Dwgs.User, ...) are a "
+                        "fixed set that always exists and cannot be added. Use "
+                        f"set_active_layer or get_layer_list to work with them. "
+                        f"Valid types: {', '.join(self._COPPER_TYPES)}"
+                    ),
+                }
+
+            # Resolve the target copper layer.
             if position == "inner":
                 if number is None:
                     return {
                         "success": False,
                         "message": "Missing layer number",
-                        "errorDetails": "number is required for inner layers",
+                        "errorDetails": (
+                            "number is required for inner layers. It is the inner-layer "
+                            "ordinal: 1 = In1.Cu, 2 = In2.Cu, ..."
+                        ),
                     }
-                layer_id = pcbnew.In1_Cu + (number - 1)
+                try:
+                    ordinal = int(number)
+                except (TypeError, ValueError):
+                    return {
+                        "success": False,
+                        "message": f"Invalid layer number: {number!r}",
+                        "errorDetails": "number must be an integer inner-layer ordinal",
+                    }
+                if not 1 <= ordinal <= self._MAX_INNER_LAYERS:
+                    return {
+                        "success": False,
+                        "message": f"Inner layer number out of range: {ordinal}",
+                        "errorDetails": (
+                            f"number is the inner-layer ordinal and must be 1.."
+                            f"{self._MAX_INNER_LAYERS} (1 = In1.Cu). KiCad supports at most "
+                            f"{self._MAX_INNER_LAYERS + 2} copper layers."
+                        ),
+                    }
+                layer_id = pcbnew.In1_Cu + (ordinal - 1) * 2
+
+                # SetCopperLayerCount enables the inner layers AND gives them
+                # their canonical names — no manual naming needed for the
+                # default case.
+                needed_count = 2 + ordinal  # F.Cu + B.Cu + inner layers
+                if needed_count > self.board.GetCopperLayerCount():
+                    self.board.SetCopperLayerCount(needed_count)
             elif position == "top":
                 layer_id = pcbnew.F_Cu
             elif position == "bottom":
                 layer_id = pcbnew.B_Cu
-
-            if layer_id is None:
+            else:
                 return {
                     "success": False,
                     "message": "Invalid layer position",
                     "errorDetails": "position must be 'top', 'bottom', or 'inner'",
                 }
 
-            # Enable inner copper layers by increasing copper layer count (KiCAD 9.0 API)
-            if position == "inner":
-                current_count = self.board.GetCopperLayerCount()
-                needed_count = 2 + (number or 0)  # F.Cu + B.Cu + inner layers
-                if needed_count > current_count:
-                    self.board.SetCopperLayerCount(needed_count)
+            canonical_name = self.board.GetStandardLayerName(layer_id)
 
-            # Set layer properties directly on board (GetLayerStack removed in KiCAD 9.0)
-            self.board.SetLayerName(layer_id, name)
+            # A custom name is stored alongside the canonical one — KiCad writes
+            # `(4 "In1.Cu" signal "PWR")`. Only set it when it actually differs,
+            # so the common case leaves the file byte-identical to KiCad's own.
+            if name != canonical_name:
+                self.board.SetLayerName(layer_id, name)
             self.board.SetLayerType(layer_id, self._get_layer_type(layer_type))
 
             return {
                 "success": True,
-                "message": f"Added layer: {name}",
-                "layer": {"name": name, "type": layer_type, "position": position, "number": number},
+                "message": f"Enabled layer {canonical_name} (id {layer_id}) as '{name}'",
+                "layer": {
+                    "name": name,
+                    "canonicalName": canonical_name,
+                    "id": layer_id,
+                    "type": layer_type,
+                    "position": position,
+                    "number": number,
+                },
+                "copperLayerCount": self.board.GetCopperLayerCount(),
             }
 
         except Exception as e:

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -1169,6 +1169,9 @@ class KiCADInterface(SchematicHandlersMixin):
 
     # Board-mutating commands that trigger auto-save on SWIG path
     _BOARD_MUTATING_COMMANDS = {
+        # add_layer mutates the copper stackup in memory; without auto-save it
+        # reported success and wrote nothing to disk (#222).
+        "add_layer",
         "place_component",
         "move_component",
         "rotate_component",

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -404,22 +404,47 @@ BOARD_TOOLS = [
     },
     {
         "name": "add_layer",
-        "title": "Add Custom Layer",
-        "description": "Adds a new custom layer to the board stack (e.g., User.1, User.Comments).",
+        "title": "Enable Copper Layer",
+        "description": (
+            "Enables a copper layer in the board stackup and gives it a name. "
+            "Copper layers only — KiCad's technical and user layers (silkscreen, "
+            "mask, courtyard, Dwgs.User, ...) are a fixed set that always exists "
+            "and cannot be added."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
-                "layerName": {
+                "name": {
                     "type": "string",
-                    "description": "Name of the layer to add",
+                    "description": (
+                        "Name for the layer. Stored alongside KiCad's canonical name "
+                        "(e.g. name 'PWR' on In1.Cu is written as "
+                        '(4 "In1.Cu" signal "PWR")).'
+                    ),
                 },
-                "layerType": {
+                "type": {
                     "type": "string",
-                    "enum": ["signal", "power", "mixed", "jumper"],
-                    "description": "Type of layer (for copper layers)",
+                    "enum": ["copper", "signal", "power", "mixed", "jumper"],
+                    "description": "Copper layer type",
+                },
+                "position": {
+                    "type": "string",
+                    "enum": ["top", "bottom", "inner"],
+                    "description": "Which copper layer to target",
+                },
+                "number": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 30,
+                    "description": (
+                        "Inner-layer ORDINAL, 1-based: 1 = In1.Cu, 2 = In2.Cu. This is "
+                        "not a KiCad layer ID (In1.Cu's id is 4). Required when "
+                        "position is 'inner'. The response echoes the resolved "
+                        "canonicalName and id."
+                    ),
                 },
             },
-            "required": ["layerName"],
+            "required": ["name", "type", "position"],
         },
     },
     {

--- a/tests/test_add_layer.py
+++ b/tests/test_add_layer.py
@@ -1,0 +1,268 @@
+"""Regression tests for #222 — add_layer could not add inner copper layers.
+
+The report said the layers "do not persist". That was true — add_layer was
+missing from _BOARD_MUTATING_COMMANDS so no auto-save fired — but it was the
+least damaging of four defects:
+
+1. never saved (the reported symptom)
+2. ``In1_Cu + (number - 1)`` resolved to a NON-COPPER layer, because copper
+   layer IDs step by 2 (F.Cu=0, B.Cu=2, In1.Cu=4, In2.Cu=6). The reporter's
+   ``number: 4`` produced layer 7.
+3. ``needed_count = 2 + number`` turned two inner layers into six, then eight
+4. tool_schemas.py described a completely different tool (layerName/layerType)
+
+So even with the save fixed, the old code wrote layer names onto IDs that are
+not copper layers. These tests pin the arithmetic and the round-trip.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+# Real KiCad layer IDs — the whole point of #222 is that these are not
+# contiguous. Hard-coded rather than read from pcbnew so the expectation is
+# visible in the test rather than derived from the thing under test.
+F_CU, B_CU, IN1_CU, IN2_CU, IN3_CU = 0, 2, 4, 6, 8
+
+
+@pytest.fixture(autouse=True)
+def _real_layer_constants(monkeypatch):
+    """conftest stubs pcbnew with a MagicMock, so pcbnew.In1_Cu would be a mock
+    and the arithmetic under test would be meaningless. Pin the real KiCad 10
+    values — the non-contiguity is exactly what #222 is about."""
+    import pcbnew
+
+    for attr, value in (
+        ("F_Cu", F_CU),
+        ("B_Cu", B_CU),
+        ("In1_Cu", IN1_CU),
+        ("LT_SIGNAL", 0),
+        ("LT_POWER", 1),
+        ("LT_MIXED", 2),
+        ("LT_JUMPER", 3),
+    ):
+        monkeypatch.setattr(pcbnew, attr, value, raising=False)
+
+
+def _commands(copper_count=2):
+    """BoardLayerCommands with a mock board that tracks the copper count."""
+    from commands.board.layers import BoardLayerCommands
+
+    board = MagicMock()
+    state = {"count": copper_count}
+    board.GetCopperLayerCount.side_effect = lambda: state["count"]
+    board.SetCopperLayerCount.side_effect = lambda n: state.update(count=n)
+
+    def _canonical(lid):
+        if lid == F_CU:
+            return "F.Cu"
+        if lid == B_CU:
+            return "B.Cu"
+        return f"In{(lid - IN1_CU) // 2 + 1}.Cu"
+
+    board.GetStandardLayerName.side_effect = _canonical
+
+    cmd = BoardLayerCommands(board=board)
+    return cmd, board, state
+
+
+class TestInnerLayerResolution:
+    """The step-by-2 bug."""
+
+    @pytest.mark.parametrize(
+        "ordinal,expected_id,expected_name",
+        [(1, IN1_CU, "In1.Cu"), (2, IN2_CU, "In2.Cu"), (3, IN3_CU, "In3.Cu")],
+    )
+    def test_ordinal_maps_to_the_right_copper_layer(self, ordinal, expected_id, expected_name):
+        cmd, board, _ = _commands()
+        r = cmd.add_layer(
+            {"name": expected_name, "type": "copper", "position": "inner", "number": ordinal}
+        )
+        assert r["success"] is True
+        assert r["layer"]["id"] == expected_id
+        assert r["layer"]["canonicalName"] == expected_name
+
+    def test_resolved_layer_is_always_a_copper_id(self):
+        """The old formula produced odd IDs; copper layers are all even."""
+        for ordinal in range(1, 31):
+            cmd, _, _ = _commands()
+            r = cmd.add_layer(
+                {"name": "X", "type": "copper", "position": "inner", "number": ordinal}
+            )
+            assert r["success"] is True
+            assert (
+                r["layer"]["id"] % 2 == 0
+            ), f"ordinal {ordinal} resolved to an odd (non-copper) id"
+
+    def test_the_exact_reported_call_no_longer_hits_layer_seven(self):
+        """#222 used number: 4 and the old code computed layer 7."""
+        cmd, _, _ = _commands()
+        r = cmd.add_layer({"name": "In1.Cu", "type": "copper", "position": "inner", "number": 4})
+        assert r["success"] is True
+        assert r["layer"]["id"] != 7
+        assert r["layer"]["id"] == 10  # In4.Cu — ordinal 4, per the documented meaning
+
+    def test_top_and_bottom(self):
+        cmd, _, _ = _commands()
+        assert (
+            cmd.add_layer({"name": "F.Cu", "type": "copper", "position": "top"})["layer"]["id"]
+            == F_CU
+        )
+        assert (
+            cmd.add_layer({"name": "B.Cu", "type": "copper", "position": "bottom"})["layer"]["id"]
+            == B_CU
+        )
+
+
+class TestCopperLayerCount:
+    def test_two_inner_layers_gives_four_copper_layers(self):
+        """Old code: 2 + number, so number=4 asked for six copper layers."""
+        cmd, board, state = _commands()
+        cmd.add_layer({"name": "In1.Cu", "type": "copper", "position": "inner", "number": 1})
+        cmd.add_layer({"name": "In2.Cu", "type": "copper", "position": "inner", "number": 2})
+        assert state["count"] == 4
+
+    def test_count_is_never_reduced(self):
+        cmd, board, state = _commands(copper_count=8)
+        cmd.add_layer({"name": "In1.Cu", "type": "copper", "position": "inner", "number": 1})
+        assert state["count"] == 8
+
+    def test_top_layer_does_not_touch_the_count(self):
+        cmd, board, state = _commands()
+        cmd.add_layer({"name": "F.Cu", "type": "copper", "position": "top"})
+        board.SetCopperLayerCount.assert_not_called()
+
+
+class TestNaming:
+    def test_custom_name_is_set(self):
+        cmd, board, _ = _commands()
+        cmd.add_layer({"name": "PWR", "type": "copper", "position": "inner", "number": 1})
+        board.SetLayerName.assert_called_once_with(IN1_CU, "PWR")
+
+    def test_canonical_name_is_not_rewritten(self):
+        """Naming a layer what KiCad already calls it must leave the file alone."""
+        cmd, board, _ = _commands()
+        cmd.add_layer({"name": "In1.Cu", "type": "copper", "position": "inner", "number": 1})
+        board.SetLayerName.assert_not_called()
+
+
+class TestValidation:
+    @pytest.mark.parametrize("bad_type", ["technical", "user", "silkscreen"])
+    def test_non_copper_types_are_rejected(self, bad_type):
+        """These used to silently retype F.Cu."""
+        cmd, board, _ = _commands()
+        r = cmd.add_layer({"name": "X", "type": bad_type, "position": "top"})
+        assert r["success"] is False
+        assert "copper" in r["errorDetails"].lower()
+        board.SetLayerType.assert_not_called()
+
+    @pytest.mark.parametrize("bad", [0, -1, 31, 99])
+    def test_out_of_range_ordinal_rejected(self, bad):
+        cmd, _, _ = _commands()
+        r = cmd.add_layer({"name": "X", "type": "copper", "position": "inner", "number": bad})
+        assert r["success"] is False
+        assert "ordinal" in r["errorDetails"]
+
+    def test_non_integer_ordinal_rejected(self):
+        cmd, _, _ = _commands()
+        r = cmd.add_layer({"name": "X", "type": "copper", "position": "inner", "number": "abc"})
+        assert r["success"] is False
+
+    def test_inner_without_number_rejected(self):
+        cmd, _, _ = _commands()
+        r = cmd.add_layer({"name": "X", "type": "copper", "position": "inner"})
+        assert r["success"] is False
+        assert "number is required" in r["errorDetails"]
+
+    def test_bad_position_rejected(self):
+        cmd, _, _ = _commands()
+        r = cmd.add_layer({"name": "X", "type": "copper", "position": "sideways"})
+        assert r["success"] is False
+
+
+class TestAutoSaveRegistration:
+    def test_add_layer_is_a_board_mutating_command(self):
+        """Without this, add_layer reports success and writes nothing (#222)."""
+        from kicad_interface import KiCADInterface
+
+        assert "add_layer" in KiCADInterface._BOARD_MUTATING_COMMANDS
+
+
+class TestSchemaMatchesTheRealTool:
+    def test_schema_declares_the_parameters_the_handler_reads(self):
+        """tool_schemas.py described layerName/layerType; the tool takes
+        name/type/position/number (#222)."""
+        from schemas.tool_schemas import TOOL_SCHEMAS
+
+        entry = TOOL_SCHEMAS["add_layer"]
+        props = entry["inputSchema"]["properties"]
+        assert set(props) == {"name", "type", "position", "number"}
+        assert entry["inputSchema"]["required"] == ["name", "type", "position"]
+
+
+# --------------------------------------------------------------------------
+# Real KiCad round-trip — the check that would have caught the original report
+# --------------------------------------------------------------------------
+
+_KICAD_PY = Path(r"C:\KiCad\10.0\bin\python.exe")
+
+_ROUNDTRIP = r"""
+import os, re, sys, tempfile
+import pcbnew
+sys.path.insert(0, sys.argv[1])
+from commands.board.layers import BoardLayerCommands
+
+d = tempfile.mkdtemp(); p = os.path.join(d, "t.kicad_pcb")
+board = pcbnew.BOARD()
+cmd = BoardLayerCommands(board=board)
+r1 = cmd.add_layer({"name": "PWR",  "type": "copper", "position": "inner", "number": 1})
+r2 = cmd.add_layer({"name": "In2.Cu", "type": "copper", "position": "inner", "number": 2})
+assert r1["success"] and r2["success"], (r1, r2)
+pcbnew.SaveBoard(p, board)
+
+txt = open(p, encoding="utf-8").read()
+block = re.search(r"\(layers(.*?)\n\s*\)\n", txt, re.S).group(1)
+print("BLOCK_START")
+print(block.strip()[:400])
+print("BLOCK_END")
+print("IDS:", r1["layer"]["id"], r2["layer"]["id"])
+print("COUNT:", pcbnew.LoadBoard(p).GetCopperLayerCount())
+"""
+
+
+@pytest.mark.skipif(not _KICAD_PY.exists(), reason="real KiCad 10 not installed")
+def test_inner_layers_actually_reach_the_file():
+    """#222's core complaint: the (layers) table on disk lacked the inner layers."""
+    python_root = str(Path(__file__).parent.parent / "python")
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, encoding="utf-8") as fh:
+        fh.write(_ROUNDTRIP)
+        script = fh.name
+    try:
+        proc = subprocess.run(
+            [str(_KICAD_PY), script, python_root],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    finally:
+        os.unlink(script)
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    out = proc.stdout
+    block = out.split("BLOCK_START")[1].split("BLOCK_END")[0]
+
+    # Both inner layers present, on the correct (even) copper IDs, with the
+    # custom name stored alongside the canonical one.
+    assert '(4 "In1.Cu" signal "PWR")' in block, block
+    assert '(6 "In2.Cu" signal)' in block, block
+    assert "IDS: 4 6" in out, out
+    assert "COUNT: 4" in out, out


### PR DESCRIPTION
Fixes #222.

## The report understated it

@ptr727 reported that `add_layer` returns success but the layers never reach the file, and guessed the cause was an unflushed in-memory board. That's correct and it's fixed — but it was the **least damaging** of four defects.

## Four defects

**1. Never persisted.** `add_layer` was missing from `_BOARD_MUTATING_COMMANDS`, so no auto-save fired. The reported symptom.

**2. Wrong layer id — it corrupted an unrelated layer.** KiCad's copper layer ids are **not contiguous**; they step by 2:

```
F.Cu=0   B.Cu=2   In1.Cu=4   In2.Cu=6   In3.Cu=8 ...
```

The code computed `layer_id = pcbnew.In1_Cu + (number - 1)`. Running the old code against a real KiCad 10.0 install for the same two calls:

```
old code: number=1 -> layer_id=4 named 'PWR'
old code: number=2 -> layer_id=5 named 'In2.Cu'
```

Layer 5 is **F.SilkS**. The resulting file:

```
(4 "In1.Cu" signal "PWR")
(6 "In2.Cu" signal)
...
(5 "F.SilkS" user "In2.Cu")        <-- front silkscreen, renamed
```

So asking for a second inner copper layer silently renamed the user's front silkscreen layer. The reporter's own `number: 4` resolved to id **7**, which is not a copper layer at all.

This matters for the fix order: had we only added the auto-save, we would have started *persisting* that corruption.

**3. Wrong copper count.** `needed_count = 2 + number` turned a request for two inner layers into six, then eight.

**4. The schema described a different tool.** `tool_schemas.py` declared `layerName` / `layerType`, requiring only `layerName`. The real tool takes `name` / `type` / `position` / `number`.

## The fix got simpler, not more complex

`SetCopperLayerCount(n)` already enables **and canonically names** the inner layers. The manual arithmetic was both wrong and unnecessary:

```
after SetCopperLayerCount(4) + save:
    0  F.Cu     signal
    4  In1.Cu   signal
    6  In2.Cu   signal
    2  B.Cu     signal
```

A custom name is layered on top and KiCad stores it as a fourth token, keeping the canonical name intact — `(4 "In1.Cu" signal "PWR")`. Verified to survive a save/load round-trip.

## Two judgement calls

**`number` means the inner-layer ordinal** (1 = In1.Cu). It was genuinely ambiguous — the reporter read it as a KiCad layer id, which is a perfectly reasonable reading of "layer number". Rather than just documenting it, the response now echoes the resolved `canonicalName` and `id`, so a caller can see which layer was actually touched instead of having to know the convention.

**Non-copper `type` is now rejected.** `position` only admits top/bottom/inner, so `type: "technical"` previously just retyped `F.Cu`. KiCad's technical and user layers are a fixed set that always exists; the tool can't add them, and pretending otherwise corrupted the board.

## Verification

- **Real KiCad 10.0 round-trip** asserting the `(layers ...)` table on disk contains both inner layers on ids 4 and 6 with the custom name attached. This is the test that would have caught the original report, and it fails against the old code (which produces id 5).
- A sweep over all 30 inner ordinals asserting every resolved id is **even** — i.e. actually a copper layer.
- Full suite **1745 passed / 12 skipped**; the 8 autoroute/freerouting failures are the known missing-JRE ones.
- `pre-commit run --all-files` clean.

There were **no tests for `add_layer`** before this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
