### PR TITLE
fix(sexpr): read and write quoted property values escape-aware (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,23 @@ symbols, and `repair_flat_symbols` fixes the common cause. See
 
 ### Bug Fixes
 
+- **Symbol property values containing an escaped quote were silently
+  truncated** (#336). KiCad escapes a quote inside a double-quoted token as
+  `\"`. Readers using the obvious `"([^"]*)"` stop at that escaped quote, so
+  the value came back as a lone backslash — and emitting that back out escapes
+  the closing quote, running the token on and swallowing the rest of the file.
+
+  This was not theoretical: **419 of the 22,712 stock KiCad 10 symbol files**
+  across 13 libraries have a Description wrapped in escaped quotes, including
+  every `Connector_Generic` part. Reading one returned `\` rather than the
+  description.
+
+  Reading and writing now share one escape-aware implementation in
+  `utils.sexpr_format` (`QUOTED_VALUE`, `escape_sexpr_string`,
+  `unescape_sexpr_string`), replacing five ad-hoc readers and three writers.
+  The three writers escaped quotes but not backslashes, which is a no-op on
+  precisely the values that break — order matters, and they had it wrong.
+
 - **`.kicad_pro` net settings survive a board save** (#341, @rossvonfange).
   In a long-lived backend, pcbnew reuses a stale in-memory project model:
   `LoadBoard` does not re-read a hand-edited `.kicad_pro`, and the next save

--- a/python/commands/datasheet_manager.py
+++ b/python/commands/datasheet_manager.py
@@ -14,6 +14,8 @@ import re
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from utils.sexpr_format import QUOTED_VALUE, unescape_sexpr_string
+
 logger = logging.getLogger("kicad_interface")
 
 LCSC_DATASHEET_URL = "https://www.lcsc.com/datasheet/{lcsc}.pdf"
@@ -97,14 +99,14 @@ class DatasheetManager:
         for k in range(block_start, block_end + 1):
             line = lines[k]
 
-            lcsc_match = re.search(r'\(property\s+"LCSC"\s+"([^"]*)"', line)
+            lcsc_match = re.search(r'\(property\s+"LCSC"\s+' + QUOTED_VALUE, line)
             if lcsc_match:
-                lcsc_value = lcsc_match.group(1)
+                lcsc_value = unescape_sexpr_string(lcsc_match.group(1))
 
-            ds_match = re.search(r'\(property\s+"Datasheet"\s+"([^"]*)"', line)
+            ds_match = re.search(r'\(property\s+"Datasheet"\s+' + QUOTED_VALUE, line)
             if ds_match:
                 datasheet_line_idx = k
-                datasheet_current = ds_match.group(1)
+                datasheet_current = unescape_sexpr_string(ds_match.group(1))
 
         return {
             "lcsc": lcsc_value,

--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -14,6 +14,8 @@ import uuid
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from utils.sexpr_format import QUOTED_VALUE, QUOTED_VALUE_SKIP, unescape_sexpr_string
+
 logger = logging.getLogger("kicad_interface")
 
 # Module-level caches shared across DynamicSymbolLoader instances.
@@ -673,7 +675,10 @@ class DynamicSymbolLoader:
             search_pos = 0
             while True:
                 m = re.search(
-                    r'\(property\s+"([^"]+)"\s+"[^"]*"\s+\(at\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)\)',
+                    r"\(property\s+" + QUOTED_VALUE + r"\s+"
+                    # Non-capturing: the value is not needed here, and a
+                    # capturing form would shift the coordinate groups below.
+                    + QUOTED_VALUE_SKIP + r"\s+\(at\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)\)",
                     sym_block[search_pos:],
                 )
                 if not m:
@@ -681,7 +686,7 @@ class DynamicSymbolLoader:
                 abs_start = search_pos + m.start()
                 prop_block = self._extract_paren_block(sym_block, abs_start)
 
-                name = m.group(1)
+                name = unescape_sexpr_string(m.group(1))
                 dx = float(m.group(2))
                 dy = float(m.group(3))
                 angle = float(m.group(4))
@@ -903,8 +908,10 @@ class DynamicSymbolLoader:
             if sym_start == -1:
                 return None
             sym_block = self._extract_paren_block(content, sym_start)
-            m = re.search(r'\(property\s+"' + re.escape(prop_name) + r'"\s+"([^"]*)"', sym_block)
-            return m.group(1) if m else None
+            m = re.search(
+                r'\(property\s+"' + re.escape(prop_name) + r'"\s+' + QUOTED_VALUE, sym_block
+            )
+            return unescape_sexpr_string(m.group(1)) if m else None
         except Exception:
             return None
 

--- a/python/commands/eagle.py
+++ b/python/commands/eagle.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from commands.symbol_creator import KICAD9_SYMBOL_LIB_VERSION
+from utils.sexpr_format import escape_sexpr_string
 
 logger = logging.getLogger("kicad_interface")
 
@@ -72,7 +73,8 @@ def _fmt(v: float) -> str:
 
 
 def _escape(s: str) -> str:
-    return str(s).replace('"', '\\"')
+    """Escape a value for an S-expression double-quoted token (#336)."""
+    return escape_sexpr_string(str(s))
 
 
 def _sanitize(s: str) -> str:

--- a/python/commands/footprint.py
+++ b/python/commands/footprint.py
@@ -15,6 +15,8 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from utils.sexpr_format import escape_sexpr_string
+
 logger = logging.getLogger("kicad_interface")
 
 KICAD9_FOOTPRINT_VERSION = "20241229"  # .kicad_mod footprint files
@@ -637,8 +639,13 @@ class FootprintCreator:
 
 
 def _esc(s: str) -> str:
-    """Escape double-quotes inside S-Expression string values."""
-    return s.replace('"', '\\"')
+    """Escape a value for an S-expression double-quoted token.
+
+    Delegates so there is one implementation: escaping quotes without
+    escaping backslashes first is a no-op on exactly the values that break
+    the file (#336).
+    """
+    return escape_sexpr_string(s)
 
 
 def _new_uuid() -> str:

--- a/python/commands/library_symbol.py
+++ b/python/commands/library_symbol.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional
 
 from utils.kicad_roots import kicad_install_roots
 from utils.platform_helper import PlatformHelper
+from utils.sexpr_format import QUOTED_VALUE, unescape_sexpr_string
 
 logger = logging.getLogger("kicad_interface")
 
@@ -420,11 +421,11 @@ class SymbolLibraryManager:
         properties = {}
 
         # Pattern for properties: (property "KEY" "VALUE" ...)
-        prop_pattern = r'\(property\s+"([^"]+)"\s+"([^"]*)"'
+        prop_pattern = r"\(property\s+" + QUOTED_VALUE + r"\s+" + QUOTED_VALUE
 
         for match in re.finditer(prop_pattern, symbol_block):
-            key = match.group(1)
-            value = match.group(2)
+            key = unescape_sexpr_string(match.group(1))
+            value = unescape_sexpr_string(match.group(2))
             properties[key] = value
 
         return properties

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -30,6 +30,7 @@ from utils.interactive_schematic import reload_kicad_schematic
 from utils.kicad_cli import kicad_cli_not_found_message, resolve_kicad_cli
 from utils.project_settings_guard import preserve_project_settings
 from utils.sexpr_format import dumps as kicad_dumps
+from utils.sexpr_format import escape_sexpr_string
 
 logger = logging.getLogger("kicad_interface")
 
@@ -571,8 +572,12 @@ class SchematicHandlersMixin:
 
     @staticmethod
     def _escape_sexpr_string(value: str) -> str:
-        """Escape a string for safe insertion into an S-expression double-quoted token."""
-        return value.replace("\\", "\\\\").replace('"', '\\"')
+        """Escape a string for safe insertion into an S-expression double-quoted token.
+
+        Delegates to the shared helper so escaping and unescaping cannot drift
+        apart (#336). Kept as a method because callers use it via ``self``.
+        """
+        return escape_sexpr_string(value)
 
     @staticmethod
     def _find_matching_paren(s: str, start: int) -> int:

--- a/python/commands/schematic_hierarchy.py
+++ b/python/commands/schematic_hierarchy.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List
 
 import sexpdata
 from sexpdata import Symbol
+from utils.sexpr_format import QUOTED_VALUE, unescape_sexpr_string
 
 logger = logging.getLogger("kicad_interface")
 
@@ -475,13 +476,11 @@ class SchematicHierarchyCommands:
                 block = content[start:end]
                 properties: Dict[str, str] = {}
                 for m in re.finditer(
-                    r'\(property\s+"((?:[^"\\]|\\.)*)"\s+"((?:[^"\\]|\\.)*)"', block
+                    r"\(property\s+" + QUOTED_VALUE + r"\s+" + QUOTED_VALUE, block
                 ):
-
-                    def unescape(s: str) -> str:
-                        return s.replace('\\"', '"').replace("\\\\", "\\")
-
-                    properties[unescape(m.group(1))] = unescape(m.group(2))
+                    properties[unescape_sexpr_string(m.group(1))] = unescape_sexpr_string(
+                        m.group(2)
+                    )
                 uuid_match = re.search(r'\(uuid\s+"?([0-9a-fA-F-]+)"?\)', block)
                 at_match = re.search(r"\(at\s+(-?[\d.]+)\s+(-?[\d.]+)", block)
                 sheets.append(

--- a/python/commands/schematic_text_utils.py
+++ b/python/commands/schematic_text_utils.py
@@ -11,6 +11,8 @@ import re
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
+from utils.sexpr_format import QUOTED_VALUE, unescape_sexpr_string
+
 _KICAD_INTERNAL_PROPS = frozenset(
     {"ki_keywords", "ki_description", "ki_fp_filters", "ki_locked", "ki_model"}
 )
@@ -71,8 +73,9 @@ def _find_placed_symbol_block(content: str, reference: str) -> Tuple[Optional[st
 def _extract_component_properties(block_text: str, exclude_internal: bool = True) -> Dict[str, str]:
     """Extract {name: value} for all (property "name" "value" ...) entries in a symbol block."""
     props = {}
-    for m in re.finditer(r'\(property\s+"([^"]*)"\s+"([^"]*)"', block_text):
-        name, value = m.group(1), m.group(2)
+    for m in re.finditer(r"\(property\s+" + QUOTED_VALUE + r"\s+" + QUOTED_VALUE, block_text):
+        name = unescape_sexpr_string(m.group(1))
+        value = unescape_sexpr_string(m.group(2))
         if exclude_internal and name in _KICAD_INTERNAL_PROPS:
             continue
         props[name] = value

--- a/python/commands/symbol_creator.py
+++ b/python/commands/symbol_creator.py
@@ -18,6 +18,8 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from utils.sexpr_format import escape_sexpr_string
+
 logger = logging.getLogger("kicad_interface")
 
 KICAD9_SYMBOL_LIB_VERSION = "20241209"
@@ -77,7 +79,8 @@ def _fmt(v: float) -> str:
 
 
 def _esc(s: str) -> str:
-    return s.replace('"', '\\"')
+    """Escape a value for an S-expression double-quoted token (#336)."""
+    return escape_sexpr_string(s)
 
 
 class SymbolCreator:

--- a/python/utils/sexpr_format.py
+++ b/python/utils/sexpr_format.py
@@ -43,10 +43,55 @@ round-trip, so a formatter change can never corrupt schematic data.
 from __future__ import annotations
 
 import logging
+import re
 
 import sexpdata
 
 logger = logging.getLogger("kicad_interface")
+
+
+# ---------------------------------------------------------------------------
+# Quoted-value escaping (#336)
+# ---------------------------------------------------------------------------
+#
+# KiCad double-quoted tokens escape a backslash as ``\\`` and a quote as
+# ``\"``. Code that reads them with the obvious ``"([^"]*)"`` stops at the
+# FIRST quote character, including an escaped one -- so a value containing
+# ``\"`` is silently truncated and left ending in a lone backslash. Emitting
+# that back out escapes the closing quote, the token runs on, and the rest of
+# the file is swallowed.
+#
+# Both halves of the pair matter, and so does their ORDER: escaping quotes
+# without escaping backslashes first is a no-op on exactly the values that
+# break.
+
+#: Matches one KiCad double-quoted token, capturing the raw (still-escaped)
+#: contents. Use with :func:`unescape_sexpr_string` on the captured group.
+QUOTED_VALUE = r'"((?:[^"\\]|\\.)*)"'
+
+#: Same match, capturing nothing. Use this to *skip* a quoted token in a
+#: pattern that has later positional groups — substituting the capturing form
+#: shifts every subsequent group index, which fails silently rather than
+#: loudly (a coordinate group starts returning a property value).
+QUOTED_VALUE_SKIP = r'"(?:[^"\\]|\\.)*"'
+
+
+def escape_sexpr_string(value: str) -> str:
+    """Escape a string for insertion into a KiCad double-quoted token.
+
+    Backslash first, then quote -- reversing the order double-escapes the
+    backslash that :func:`unescape_sexpr_string` then removes.
+    """
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def unescape_sexpr_string(value: str) -> str:
+    """Inverse of :func:`escape_sexpr_string`.
+
+    Quote first, then backslash -- the mirror image of the escape order.
+    """
+    return value.replace('\\"', '"').replace("\\\\", "\\")
+
 
 # Formatting constants, mirrored from KiCad's Prettify().
 _QUOTE_CHAR = '"'

--- a/tests/test_sexpr_escaping.py
+++ b/tests/test_sexpr_escaping.py
@@ -1,0 +1,153 @@
+"""Regression tests for #336 — S-expression property values were not escape-aware.
+
+KiCad escapes a backslash as ``\\\\`` and a quote as ``\\"`` inside double-quoted
+tokens. Readers using the obvious ``"([^"]*)"`` stop at the FIRST quote,
+including an escaped one, so a value containing ``\\"`` is truncated and left
+ending in a lone backslash. Written back out, that trailing backslash escapes
+the closing quote: the token runs on and swallows the rest of the file.
+
+``power:GND``'s Description in the stock KiCad library is the value that
+surfaced this — it contains an escaped quote.
+
+Two halves have to be right, and so does their ORDER. Escaping quotes without
+escaping backslashes first is a no-op on exactly the values that break, which
+is why three writers appeared to escape and did not.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+import sexpdata  # noqa: E402
+from utils.sexpr_format import (  # noqa: E402
+    QUOTED_VALUE,
+    QUOTED_VALUE_SKIP,
+    escape_sexpr_string,
+    unescape_sexpr_string,
+)
+
+BS = "\\"
+QT = '"'
+
+NASTY_VALUES = [
+    "plain",
+    f"has{QT}quote",
+    f"has{BS}backslash",
+    f"both{BS}{QT}together",
+    f"trailing{BS}",
+    f"{BS}leading",
+    f"{BS}{BS}doubled",
+    'Ground "GND" reference',  # the power:GND Description shape
+    f"C:{BS}path{BS}to{BS}file",  # a Windows path in a Datasheet property
+]
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize("value", NASTY_VALUES)
+    def test_escape_then_unescape_is_identity(self, value):
+        assert unescape_sexpr_string(escape_sexpr_string(value)) == value
+
+    @pytest.mark.parametrize("value", NASTY_VALUES)
+    def test_round_trip_through_the_regex(self, value):
+        """The reader must recover exactly what the writer emitted."""
+        token = f'"{escape_sexpr_string(value)}"'
+        m = re.search(QUOTED_VALUE, token)
+        assert m is not None, f"pattern did not match {token!r}"
+        assert unescape_sexpr_string(m.group(1)) == value
+
+    @pytest.mark.parametrize("value", NASTY_VALUES)
+    def test_emitted_property_parses_as_sexpr(self, value):
+        """The check that fails on the old code: a truncated value leaves a
+        trailing backslash that escapes the closing quote, so the whole
+        remainder of the file is swallowed into one token."""
+        fragment = f'(property "Description" "{escape_sexpr_string(value)}") (symbol "after")'
+        parsed = sexpdata.loads(f"(root {fragment})")
+        # The sentinel after the property must survive as its own form.
+        assert len(parsed) == 3, f"the property token ran on: {parsed!r}"
+
+
+class TestOldPatternWasBroken:
+    """Pin the failure so the fix cannot be quietly reverted."""
+
+    @pytest.mark.parametrize("value", [f"has{QT}quote", f"both{BS}{QT}together"])
+    def test_naive_pattern_truncates(self, value):
+        token = f'"{escape_sexpr_string(value)}"'
+        naive = re.search(r'"([^"]*)"', token)
+        assert naive is not None
+        assert naive.group(1) != value, "this value would not have exposed the bug"
+
+    def test_quote_only_escaper_is_a_noop_on_backslashes(self):
+        """What footprint.py / symbol_creator.py / eagle.py used to do."""
+        value = f"path{BS}"
+        quote_only = value.replace('"', '\\"')
+        assert quote_only == value  # nothing escaped at all
+        # ...and emitting it escapes the closing quote.
+        with pytest.raises(Exception):
+            sexpdata.loads(f'(root (property "P" "{quote_only}") (after))')
+        # The correct escaper does not.
+        sexpdata.loads(f'(root (property "P" "{escape_sexpr_string(value)}") (after))')
+
+
+class TestSkipVariant:
+    """QUOTED_VALUE_SKIP exists so substituting the pattern cannot silently
+    shift later positional group indices — the bug this fix nearly introduced
+    into dynamic_symbol_loader's (at x y angle) capture."""
+
+    def test_skip_captures_nothing(self):
+        pattern = (
+            r"\(property\s+" + QUOTED_VALUE + r"\s+" + QUOTED_VALUE_SKIP + r"\s+\(at\s+(\d+)\)"
+        )
+        m = re.search(pattern, '(property "Name" "Value" (at 42)')
+        assert m is not None
+        assert m.group(1) == "Name"
+        assert m.group(2) == "42", "the coordinate group must stay at index 2"
+
+    def test_skip_still_spans_escaped_quotes(self):
+        value = escape_sexpr_string(f"has{QT}quote")
+        pattern = (
+            r"\(property\s+" + QUOTED_VALUE + r"\s+" + QUOTED_VALUE_SKIP + r"\s+\(at\s+(\d+)\)"
+        )
+        m = re.search(pattern, f'(property "Name" "{value}" (at 42)')
+        assert m is not None and m.group(2) == "42"
+
+
+class TestCallSitesAreConverted:
+    """A grep-style guard: the naive pattern must not come back in the modules
+    that read user-controlled property values."""
+
+    CONVERTED = [
+        "dynamic_symbol_loader.py",
+        "library_symbol.py",
+        "schematic_text_utils.py",
+        "datasheet_manager.py",
+        "schematic_hierarchy.py",
+    ]
+
+    @pytest.mark.parametrize("filename", CONVERTED)
+    def test_no_naive_property_value_pattern_remains(self, filename):
+        path = Path(__file__).parent.parent / "python" / "commands" / filename
+        source = path.read_text(encoding="utf-8")
+        offenders = [
+            line
+            for line in source.splitlines()
+            if r'\(property\s+"([^"]' in line or r'"\s+"([^"]*)"' in line
+        ]
+        assert not offenders, (
+            f"{filename} still reads property values with a non-escape-aware "
+            f"pattern (#336). Use QUOTED_VALUE + unescape_sexpr_string. "
+            f"Offenders: {offenders}"
+        )
+
+    @pytest.mark.parametrize(
+        "filename", ["footprint.py", "symbol_creator.py", "eagle.py", "schematic_handlers.py"]
+    )
+    def test_writers_do_not_hand_roll_a_quote_only_escaper(self, filename):
+        path = Path(__file__).parent.parent / "python" / "commands" / filename
+        source = path.read_text(encoding="utf-8")
+        assert (
+            """replace('"', '\\\\"')""" not in source
+        ), f"{filename} escapes quotes without escaping backslashes first (#336)"


### PR DESCRIPTION
Fixes #336.

## This is not theoretical

I filed this issue from a code read. Checking it against a real KiCad 10 install turned it into something more concrete:

**419 of the 22,712 stock KiCad symbol files, across 13 libraries, have a Description wrapped in escaped quotes** — including every `Connector_Generic` part. Reading one with the old code:

```
Conn_01x41_Pin.kicad_sym  property 'Description'
   escape-aware read : '"Generic connector, single row, 01x41, script generated"'
   old naive read    : '\'
```

The value came back as a **lone backslash**. Written back out, that trailing backslash escapes the closing quote, the token runs on, and the rest of the file is swallowed into it. So placing a generic connector could corrupt the schematic.

## The mechanism

KiCad escapes a quote inside a double-quoted token as `\"` and a backslash as `\`. `"([^"]*)"` stops at the first quote character — including an escaped one.

Both halves have to be right, and **so does their order**. Three writers escaped quotes without escaping backslashes first:

```python
return s.replace('"', '\\"')     # footprint.py, symbol_creator.py, eagle.py
```

That is a no-op on exactly the values that break, which is why they looked like they were escaping and were not.

## Promoting, not inventing

Two correct implementations already existed in-tree, which is what this consolidates:

- the escaper in `schematic_handlers.py` (backslash first, then quote)
- the escape-aware matcher and unescape that #342 added to `schematic_hierarchy.py`

Both now delegate to `utils.sexpr_format`, so there is one implementation instead of three. I checked the unescape order against the awkward cases (`a\b"c`, `a\"b`, `a\b`, trailing backslash) — it round-trips.

**Converted:** 5 readers (`dynamic_symbol_loader` ×2, `library_symbol`, `schematic_text_utils`, `datasheet_manager` ×2, `schematic_hierarchy`) and 3 writers.

**Deliberately left alone:** `schematic_lint`'s `(symbol "LIB:NAME"` matcher and `symbol_pins`' structural token patterns match KiCad-restricted identifiers rather than user text. Converting them would add risk for no gain.

## A bug this fix nearly introduced

`QUOTED_VALUE_SKIP` exists for a reason worth stating. Substituting the capturing pattern into an existing regex **shifts every later positional group**. `dynamic_symbol_loader` reads `(at x y angle)` as groups 2/3/4; adding a capture for the property value silently made group 2 the value instead. `float("some description")` would then raise inside a broad `except`, so property positions would have gone quietly missing.

The non-capturing variant makes "skip this token" explicit, and a test pins the group indices so the next person cannot make the same substitution.

## Verification

- Against real KiCad library data — the 419-file scan above, comparing naive vs escape-aware reads.
- 41 new tests: round-trip over nasty values (embedded quote, backslash, both, leading/trailing backslash, a Windows path, the `power:GND` shape), `sexpdata.loads()` on the emitted fragment (the check that fails on the old code), and grep-style guards so the naive pattern and the quote-only escaper cannot return.
- Full suite **1762 passed / 12 skipped**; the 8 autoroute/freerouting failures are the known missing-JRE ones.
- `pre-commit run --all-files` clean.

An AST audit confirmed all nine consumer modules import what they use — two of them were initially missed because my edit script saw an existing `from utils.sexpr_format import` line and skipped them, which the test suite caught as 43 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
