### PR TITLE
fix(routing): treat arcs as arcs in stitching-via collision checks (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,24 @@ symbols, and `repair_flat_symbols` fixes the common cause. See
 
 ### Bug Fixes
 
+- **`add_gnd_stitching_vias` treated arcs as their chord** (#192). Since
+  `route_arc_trace` landed, `board.GetTracks()` can return `PCB_ARC` items. The
+  obstacle loop distinguished only `PCB_VIA` from everything else, so an arc
+  was recorded as the straight chord between its endpoints — under-stating the
+  region it occupies. A candidate via sitting in the bulge between chord and
+  arc passed the clearance check and could short the trace.
+
+  Measured on a 10 mm-radius quarter arc against real KiCad: a point lying
+  exactly on the arc read as **2.93 mm** from the chord, so any via within that
+  bulge was waved through.
+
+  Arcs are now sampled into a chain of chords. The sampling radius is inflated
+  so the chain circumscribes the arc rather than cutting inside it —
+  over-approximating an obstacle is safe, under-approximating is the bug.
+
+  Thanks to @NiNjA-CodE, whose analysis in the issue identified the exact
+  branch and consequence.
+
 - **`.kicad_pro` net settings survive a board save** (#341, @rossvonfange).
   In a long-lived backend, pcbnew reuses a stale in-memory project model:
   `LoadBoard` does not re-read a hand-edited `.kicad_pro`, and the next save

--- a/python/commands/routing.py
+++ b/python/commands/routing.py
@@ -2127,8 +2127,20 @@ class RoutingCommands:
                     pass
                 obstacle_vias.append((pos.x, pos.y, max(width, drill) // 2))
             else:
-                s, e = track.GetStart(), track.GetEnd()
-                obstacle_tracks.append((s.x, s.y, e.x, e.y, track.GetWidth() // 2))
+                half_width = track.GetWidth() // 2
+                # A PCB_ARC recorded as the straight chord between its
+                # endpoints UNDER-estimates the region it occupies: a via
+                # sitting in the bulge between chord and arc passes the
+                # clearance check and shorts the trace (#192). Approximate the
+                # arc by a chain of short chords instead — over-approximating
+                # an obstacle is safe, under-approximating is the bug.
+                arc_points = _arc_polyline_points(track)
+                if arc_points:
+                    for (ax1, ay1), (ax2, ay2) in zip(arc_points, arc_points[1:]):
+                        obstacle_tracks.append((ax1, ay1, ax2, ay2, half_width))
+                else:
+                    s, e = track.GetStart(), track.GetEnd()
+                    obstacle_tracks.append((s.x, s.y, e.x, e.y, half_width))
 
         for fp in self.board.GetFootprints():
             for pad in fp.Pads():
@@ -2290,6 +2302,95 @@ class RoutingCommands:
 # ---------------------------------------------------------------------------
 # Module-level geometry helper (used by add_gnd_stitching_vias collision check)
 # ---------------------------------------------------------------------------
+
+
+# Chord count for arc approximation. 8 chords keeps the worst-case sagitta
+# (the gap between a chord and the arc it spans) under ~2% of the radius, which
+# is far below any realistic via-to-track clearance, while staying cheap in the
+# obstacle-gathering loop.
+_ARC_CHORD_SEGMENTS = 8
+
+
+def _arc_polyline_points(track: Any) -> List[Tuple[int, int]]:
+    """Sample a PCB_ARC into points for a chord-chain approximation.
+
+    Returns ``[]`` for anything that is not an arc, so the caller falls back to
+    its straight-segment handling. Never raises: an obstacle we cannot sample
+    must degrade to the chord rather than abort the whole stitching run.
+
+    The module checks item class by ``GetClass()`` string rather than
+    ``isinstance`` -- see the note in ``add_gnd_stitching_vias`` -- and the test
+    doubles set ``GetClass`` directly, so this matches that convention.
+    """
+    try:
+        if track.GetClass() != "PCB_ARC":
+            return []
+    except Exception:
+        return []
+
+    try:
+        centre = track.GetCenter()
+        cx, cy = int(centre.x), int(centre.y)
+        start, end = track.GetStart(), track.GetEnd()
+        sx, sy = int(start.x), int(start.y)
+        ex, ey = int(end.x), int(end.y)
+    except Exception:
+        return []
+
+    radius = math.hypot(sx - cx, sy - cy)
+    if radius <= 0:
+        return []
+
+    start_angle = math.atan2(sy - cy, sx - cx)
+    end_angle = math.atan2(ey - cy, ex - cx)
+    sweep = end_angle - start_angle
+
+    # Pick the sweep direction that passes through the arc's midpoint, so a
+    # major arc is not approximated by the minor one on the other side.
+    try:
+        mid = track.GetMid()
+        mid_angle = math.atan2(int(mid.y) - cy, int(mid.x) - cx)
+
+        def _normalise(a: float) -> float:
+            while a <= -math.pi:
+                a += 2 * math.pi
+            while a > math.pi:
+                a -= 2 * math.pi
+            return a
+
+        # If the midpoint does not lie within the shorter sweep, go the long way.
+        short = _normalise(sweep)
+        to_mid = _normalise(mid_angle - start_angle)
+        if short == 0 or (to_mid / short) < 0 or abs(to_mid) > abs(short):
+            sweep = short - math.copysign(2 * math.pi, short)
+        else:
+            sweep = short
+    except Exception:
+        # No usable midpoint: fall back to the shorter sweep.
+        while sweep <= -math.pi:
+            sweep += 2 * math.pi
+        while sweep > math.pi:
+            sweep -= 2 * math.pi
+
+    # Sample on a slightly LARGER radius so the chords circumscribe the arc
+    # instead of cutting inside it. Chords through points on the true arc are
+    # secants: their midpoints sag inward by r*(1 - cos(half_step)), which
+    # under-states the obstacle — the same defect as #192, just smaller.
+    # Dividing by cos(half_step) puts each chord's midpoint back on the true
+    # radius, so the chain never reads as further from a point than the arc is.
+    half_step = abs(sweep) / (2 * _ARC_CHORD_SEGMENTS)
+    sample_radius = radius / math.cos(half_step) if half_step else radius
+
+    points: List[Tuple[int, int]] = []
+    for i in range(_ARC_CHORD_SEGMENTS + 1):
+        angle = start_angle + sweep * (i / _ARC_CHORD_SEGMENTS)
+        points.append(
+            (
+                int(cx + sample_radius * math.cos(angle)),
+                int(cy + sample_radius * math.sin(angle)),
+            )
+        )
+    return points
 
 
 def _point_to_segment_distance_nm(px: int, py: int, x1: int, y1: int, x2: int, y2: int) -> float:

--- a/tests/test_add_gnd_stitching_vias.py
+++ b/tests/test_add_gnd_stitching_vias.py
@@ -461,3 +461,162 @@ def test_point_to_segment_distance_zero_length_segment():
     # Degenerate segment (start == end) -> distance to that point
     d = _point_to_segment_distance_nm(3, 4, 0, 0, 0, 0)
     assert d == pytest.approx(5)
+
+
+# ---------------------------------------------------------------------------
+# #192 — PCB_ARC obstacles
+# ---------------------------------------------------------------------------
+
+
+def _arc(net_code, cx, cy, radius_mm, start_deg, end_deg, width_mm=0.5):
+    """A PCB_ARC on the given net, centred at (cx, cy).
+
+    Mirrors _track/_via: the routing code checks item class by GetClass()
+    string, not isinstance, so the double just sets GetClass.
+    """
+    import math as _math
+
+    def _pt(deg):
+        rad = _math.radians(deg)
+        return _vector(cx + radius_mm * _math.cos(rad), cy + radius_mm * _math.sin(rad))
+
+    a = MagicMock()
+    a.GetNetCode.return_value = net_code
+    a.GetClass.return_value = "PCB_ARC"
+    a.GetStart.return_value = _pt(start_deg)
+    a.GetEnd.return_value = _pt(end_deg)
+    a.GetMid.return_value = _pt((start_deg + end_deg) / 2.0)
+    a.GetCenter.return_value = _vector(cx, cy)
+    a.GetWidth.return_value = _mm(width_mm)
+    return a
+
+
+@pytest.mark.unit
+def test_arc_polyline_circumscribes_the_arc():
+    """Sampled points sit ON or just OUTSIDE the true arc, never inside.
+
+    Chords between points taken exactly on the arc sag inward, which
+    under-states the obstacle — the same defect as #192, just smaller. The
+    sampling radius is inflated so the chain circumscribes instead.
+    """
+    from commands.routing import _arc_polyline_points
+
+    arc = _arc(net_code=2, cx=10, cy=10, radius_mm=5, start_deg=0, end_deg=90)
+    pts = _arc_polyline_points(arc)
+
+    assert len(pts) >= 3, "an arc must be sampled into a chord chain"
+    cx, cy, r = _mm(10), _mm(10), _mm(5)
+    for x, y in pts:
+        dist = ((x - cx) ** 2 + (y - cy) ** 2) ** 0.5
+        assert dist >= r - 1, f"sampled point ({x},{y}) cuts inside the arc"
+        assert dist < r * 1.02, f"sampled point ({x},{y}) is unreasonably far outside"
+
+
+@pytest.mark.unit
+def test_chord_chain_never_understates_distance_to_the_arc():
+    """For points all around the arc, the chain must never report a point as
+    FURTHER away than the true arc is — that is what lets a via through."""
+    import math as _math
+
+    from commands.routing import _arc_polyline_points
+
+    arc = _arc(net_code=2, cx=10, cy=10, radius_mm=5, start_deg=0, end_deg=90)
+    pts = _arc_polyline_points(arc)
+    cx, cy, r = _mm(10), _mm(10), _mm(5)
+
+    for deg in range(0, 91, 3):
+        rad = _math.radians(deg)
+        # A probe point 0.4mm outside the arc, i.e. within a via envelope.
+        probe_r = r + _mm(0.4)
+        px = int(cx + probe_r * _math.cos(rad))
+        py = int(cy + probe_r * _math.sin(rad))
+        true_dist = probe_r - r
+        chain_dist = min(
+            _point_to_segment_distance_nm(px, py, p1[0], p1[1], p2[0], p2[1])
+            for p1, p2 in zip(pts, pts[1:])
+        )
+        assert chain_dist <= true_dist + 1, (
+            f"at {deg} deg the chain reports {chain_dist} nm but the arc is "
+            f"only {true_dist} nm away — a via here would slip through"
+        )
+
+
+@pytest.mark.unit
+def test_straight_track_is_not_treated_as_an_arc():
+    from commands.routing import _arc_polyline_points
+
+    assert _arc_polyline_points(_track(net_code=2, x1=0, y1=0, x2=10, y2=0)) == []
+    assert _arc_polyline_points(_via(net_code=2, x=5, y=5)) == []
+
+
+@pytest.mark.unit
+def test_via_inside_the_arc_bulge_is_blocked():
+    """The #192 bug: an arc recorded as its chord under-estimates the region it
+    occupies, so a via between chord and arc passed the clearance check and
+    could short the trace.
+
+    The arc below spans 0deg->90deg at radius 5mm about (10,10). Its chord runs
+    from (15,10) to (10,15); the arc's midpoint is ~1.46mm outside that chord,
+    which is far beyond the ~0.75mm via+track+clearance envelope.
+    """
+    import math as _math
+
+    from commands.routing import _arc_polyline_points
+
+    arc = _arc(net_code=2, cx=10, cy=10, radius_mm=5, start_deg=0, end_deg=90)
+
+    # A point sitting exactly on the arc's midpoint — on the copper.
+    mid_x = _mm(10 + 5 * _math.cos(_math.radians(45)))
+    mid_y = _mm(10 + 5 * _math.sin(_math.radians(45)))
+
+    # Old behaviour: distance to the straight chord.
+    s, e = arc.GetStart(), arc.GetEnd()
+    chord_dist = _point_to_segment_distance_nm(mid_x, mid_y, s.x, s.y, e.x, e.y)
+
+    # New behaviour: distance to the nearest sampled chord.
+    pts = _arc_polyline_points(arc)
+    chain_dist = min(
+        _point_to_segment_distance_nm(mid_x, mid_y, p1[0], p1[1], p2[0], p2[1])
+        for p1, p2 in zip(pts, pts[1:])
+    )
+
+    assert chord_dist > _mm(1.0), "fixture should put the bulge well outside the chord"
+    assert chain_dist < _mm(0.05), "a point on the arc must be ~zero distance from the chain"
+    assert chain_dist < chord_dist, "the chord chain must be tighter than the chord"
+
+
+@pytest.mark.unit
+def test_arc_blocks_more_grid_points_than_its_chord_would():
+    """End-to-end: the same board with an arc must place no MORE vias than one
+    where that arc is (incorrectly) modelled as its chord."""
+    arc = _arc(net_code=2, cx=10, cy=10, radius_mm=6, start_deg=180, end_deg=360, width_mm=0.5)
+    with_arc = _cmd(_board(width_mm=20, height_mm=20, tracks=[arc])).add_gnd_stitching_vias(
+        {"strategies": ["grid"], "spacing": 2.0, "edgeMargin": 0.5, "dryRun": True}
+    )
+    clear = _cmd(_board(width_mm=20, height_mm=20)).add_gnd_stitching_vias(
+        {"strategies": ["grid"], "spacing": 2.0, "edgeMargin": 0.5, "dryRun": True}
+    )
+
+    assert len(with_arc["placed"]) < len(clear["placed"]), "the arc must block some grid points"
+
+    # No placed via may sit on the arc itself.
+    import math as _math
+
+    for p in with_arc["placed"]:
+        r = _math.hypot(p["x"] - 10, p["y"] - 10)
+        on_arc_angle = 180 <= (_math.degrees(_math.atan2(p["y"] - 10, p["x"] - 10)) % 360) <= 360
+        if on_arc_angle:
+            assert abs(r - 6) >= 0.7, f"via at ({p['x']},{p['y']}) sits on the arc (r={r:.2f})"
+
+
+@pytest.mark.unit
+def test_arc_on_gnd_does_not_block():
+    """GND-net arcs are obstacles we may touch, same as GND tracks."""
+    gnd_arc = _arc(net_code=1, cx=10, cy=10, radius_mm=6, start_deg=180, end_deg=360)
+    out = _cmd(_board(width_mm=20, height_mm=20, tracks=[gnd_arc])).add_gnd_stitching_vias(
+        {"strategies": ["grid"], "spacing": 2.0, "edgeMargin": 0.5, "dryRun": True}
+    )
+    clear = _cmd(_board(width_mm=20, height_mm=20)).add_gnd_stitching_vias(
+        {"strategies": ["grid"], "spacing": 2.0, "edgeMargin": 0.5, "dryRun": True}
+    )
+    assert len(out["placed"]) == len(clear["placed"])


### PR DESCRIPTION
Fixes #192.

Implemented from @NiNjA-CodE's diagnosis, which identified the exact branch and its consequence. They have been unavailable since May, so I have picked it up — the analysis is what made this small.

## The bug

Since `route_arc_trace` landed, `board.GetTracks()` can return `PCB_ARC` items. The obstacle loop distinguished only `PCB_VIA` from everything else, so an arc landed in the straight-track branch and was recorded as the **chord** between its endpoints.

That under-states the region the arc occupies. Measured against a real KiCad 10 `PCB_ARC` — 10 mm radius, quarter sweep — a point lying **exactly on the arc**:

```
distance to straight CHORD : 2.9289 mm   <- old code saw this
distance to CHORD CHAIN    : 0.0482 mm   <- new code sees this
```

Against a via+track+clearance envelope of well under 1 mm, every via in that bulge was waved through onto live copper.

## The fix

Sample the arc into a chain of chords and append each to the existing `obstacle_tracks` list. `_point_to_segment_distance_nm` and the rest of the collision maths are untouched, which keeps the change small and the failure mode conservative.

## One subtlety worth flagging

My first version sampled points **exactly on** the arc. That is wrong, and the test caught it.

Chords between points on a curve are secants: their midpoints sag *inward* by `r*(1 - cos(half_step))`. That is the same under-approximation as the original bug, just smaller — and on the test fixture it was still enough to let a via through at 0.67 mm from a 6 mm arc.

The sampling radius is now divided by `cos(half_step)` so the chain **circumscribes** the arc. Over-approximating an obstacle is safe; under-approximating is the defect being fixed. There is a test asserting the chain never reports a probe point as further from the arc than it truly is, which is the property that actually prevents the bug rather than a proxy for it.

## Conventions followed

- Class checked via `GetClass() == "PCB_ARC"`, matching the surrounding module — there is a note there explaining `isinstance` is unreliable under the test stubs, and the doubles set `GetClass` directly.
- `_arc_polyline_points` returns `[]` for anything that is not an arc, so callers fall back to straight-segment handling, and it never raises: an unsamplable obstacle degrades to the chord rather than aborting the run.

## Verification

- Against a real KiCad 10 `PCB_ARC`: sampled points confirmed on the correct radius and sweep, with the chord-vs-chain comparison above.
- New `_arc` double in the style of the existing `_track` / `_via` helpers.
- Full suite **1727 passed / 12 skipped**; the 8 autoroute/freerouting failures are the known missing-JRE ones.
- `pre-commit run --all-files` clean.

@NiNjA-CodE — I have unassigned the issue since it is being closed here, but review is very welcome if you are around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
