### PR TITLE
fix(schematic): stop the symbol writer corrupting KiCad 8/9 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **Placing a symbol corrupted any KiCad 8 or KiCad 9 schematic, including the
+  server's own templates.** Three defects in the shared schematic writer, all of
+  which surfaced only as `Failed to load schematic` from eeschema and
+  `kicad-cli` — no token, no line number, and long after the offending call:
+  - `create_component_instance` wrote the KiCad 10-only `(body_style 1)` and
+    `(in_pos_files yes)` attributes into every placed symbol. KiCad dispatches to
+    a parser per declared format version, so a v10 token inside a file declaring
+    20231120 (KiCad 8) or 20250114 (KiCad 9) is rejected outright — by KiCad 10
+    too. This hit `minimal.kicad_sch`, `empty.kicad_sch` and
+    `template_with_symbols*.kicad_sch`, which all declare 20250114. Both tokens
+    are now gated on the target file's own `(version ...)`; a file with no
+    version token keeps the previous KiCad 10 output.
+  - Property values were interpolated into the s-expression **unescaped**. Stock
+    library descriptions embed double quotes — `power:GND` is
+    `Power symbol creates a global label with name "GND" , ground` — so the first
+    inner quote closed the token early and the rest of the block became garbage.
+    Parentheses still balanced afterwards and `sexpdata` still parsed the result,
+    which is why this went unnoticed; only KiCad objected. Values now go through
+    `escape_sexpr_string`.
+  - `add_schematic_component` silently dropped its documented `angle` and
+    `mirrorY` arguments: the TypeScript layer nests them inside `component`
+    (`src/tools/schematic.ts`) and the Python handler never read them back out.
+    Every symbol landed at 0° unrotated, so callers had to follow up with
+    `rotate_schematic_component`.
+
+  Covered by `tests/test_schematic_writer_format_compat.py`, including an
+  integration test that asserts real `kicad-cli` accepts the generated v8 and v9
+  files. `test_symbol_instance_completeness.py` asserted the v10 attributes while
+  placing into the v9 `empty.kicad_sch`; it now uses a v10 fixture for those two
+  tokens.
+
 - **`add_layer` could not add inner copper layers, and corrupted an unrelated
   layer trying** (#222). Four defects, of which the reported one — changes
   never reaching disk — was the least damaging:

--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -14,9 +14,21 @@ import uuid
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from utils.sexpr_format import QUOTED_VALUE, QUOTED_VALUE_SKIP, unescape_sexpr_string
+from utils.sexpr_format import (
+    QUOTED_VALUE,
+    QUOTED_VALUE_SKIP,
+    escape_sexpr_string,
+    unescape_sexpr_string,
+)
 
 logger = logging.getLogger("kicad_interface")
+
+#: First schematic file-format version that accepts ``(body_style ...)`` and
+#: ``(in_pos_files ...)`` inside a placed ``(symbol ...)``. Both tokens are
+#: KiCad 10 additions: writing them into a KiCad 8 (20231120) or KiCad 9
+#: (20250114) file makes eeschema and kicad-cli reject the whole schematic with
+#: a bare "Failed to load schematic", naming neither the token nor the line.
+_KICAD10_SCH_VERSION = 20260101
 
 # Module-level caches shared across DynamicSymbolLoader instances.
 # A fresh loader is created for every add_component call (see
@@ -823,6 +835,29 @@ class DynamicSymbolLoader:
         except Exception:
             return []
 
+    @staticmethod
+    def _read_sch_version(content: str) -> Optional[int]:
+        """Return the ``(version NNNNNNNN)`` token of a schematic, or None.
+
+        The file's own declared version — not the installed KiCad version —
+        decides which tokens are legal, because KiCad dispatches to a parser per
+        format version. A KiCad 10 binary still refuses a v10-only token inside a
+        file that declares 20231120.
+        """
+        m = re.search(r"\(version\s+(\d+)\)", content)
+        return int(m.group(1)) if m else None
+
+    @classmethod
+    def _supports_kicad10_symbol_tokens(cls, content: str) -> bool:
+        """Whether this schematic accepts ``body_style`` / ``in_pos_files``.
+
+        Unknown/absent version is treated as KiCad 10 to preserve the previous
+        behaviour for freshly generated files, which is what the templates and
+        the create_schematic fallback emit.
+        """
+        version = cls._read_sch_version(content)
+        return version is None or version >= _KICAD10_SCH_VERSION
+
     def _build_instance_path(self, schematic_path: Path) -> str:
         """Return the symbol instance path for symbols placed in ``schematic_path``.
 
@@ -1013,10 +1048,18 @@ class DynamicSymbolLoader:
             """Build a KiCad-10 (property ...) block.
 
             Field order: at, [hide yes], show_name no, do_not_autoplace no, effects.
+
+            ``value`` is escaped: it comes from the library symbol, and several
+            stock descriptions embed double quotes (power:GND is
+            ``Power symbol creates a global label with name "GND" , ground``).
+            Interpolated raw, the first inner quote closes the token and the
+            remainder of the block becomes garbage — while the file's parentheses
+            still balance, so paren-counting sanity checks pass and sexpdata
+            parses it happily. Only KiCad notices, and only as "Failed to load".
             """
             hide_line = "      (hide yes)\n" if hide else ""
             return (
-                f'    (property "{name}" "{value}"\n'
+                f'    (property "{escape_sexpr_string(name)}" "{escape_sexpr_string(value)}"\n'
                 f"      (at {_fmt(px)} {_fmt(py)} {_fmt(pa)})\n"
                 f"{hide_line}"
                 f"      (show_name no)\n"
@@ -1070,19 +1113,28 @@ class DynamicSymbolLoader:
 
         body = "\n".join(part for part in [properties_str, pins_str, instances_str] if part)
 
+        with open(schematic_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Emit the KiCad 10-only symbol attributes only into files that declare a
+        # format version accepting them. Everything else here is common to v8/v9/v10.
+        if self._supports_kicad10_symbol_tokens(content):
+            attrs_line = (
+                "    (body_style 1) (exclude_from_sim no) (in_bom yes) (on_board yes)"
+                " (in_pos_files yes) (dnp no)\n"
+            )
+        else:
+            attrs_line = "    (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)\n"
+
         mirror_str = " (mirror y)" if mirror_y else ""
         instance_block = (
             f'  (symbol (lib_id "{full_lib_id}") (at {_fmt(x)} {_fmt(y)} {_fmt(angle)})'
             f"{mirror_str} (unit {unit})\n"
-            "    (body_style 1) (exclude_from_sim no) (in_bom yes) (on_board yes)"
-            " (in_pos_files yes) (dnp no)\n"
+            f"{attrs_line}"
             f'    (uuid "{new_uuid}")\n'
             f"{body}\n"
             "  )"
         )
-
-        with open(schematic_path, "r", encoding="utf-8") as f:
-            content = f.read()
 
         # Insert before (sheet_instances using direct string search.
         # This works for both pretty-printed and sexpdata-compacted single-line files.

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -246,6 +246,12 @@ class SchematicHandlersMixin:
             x = component.get("x", 0)
             y = component.get("y", 0)
             unit = component.get("unit", 1)
+            # The TS layer puts these inside `component` alongside x/y/unit
+            # (src/tools/schematic.ts). Dropping them here silently ignored the
+            # documented angle/mirrorY arguments, so every symbol landed at 0°
+            # and callers had to follow up with rotate_schematic_component.
+            angle = component.get("angle", 0)
+            mirror_y = bool(component.get("mirrorY", False))
 
             # Derive project path from schematic path for project-local library resolution.
             # Walk up from the schematic file to find the directory that owns the project
@@ -270,6 +276,8 @@ class SchematicHandlersMixin:
                 x=x,
                 y=y,
                 unit=unit,
+                angle=angle,
+                mirror_y=mirror_y,
                 project_path=derived_project_path,
             )
 

--- a/tests/test_schematic_writer_format_compat.py
+++ b/tests/test_schematic_writer_format_compat.py
@@ -1,0 +1,376 @@
+"""
+Tests for schematic-writer output compatibility.
+
+Three regressions, all of which made KiCad reject the whole schematic with a
+bare "Failed to load schematic" that names neither a token nor a line:
+
+1. ``(body_style ...)`` / ``(in_pos_files ...)`` were written into every placed
+   symbol. Both are KiCad 10 additions, so any KiCad 8 (20231120) or KiCad 9
+   (20250114) file became unloadable -- including this repo's own
+   ``minimal``/``empty``/``template_with_symbols`` templates, which declare
+   20250114.
+2. Property values were interpolated into the s-expression unescaped. Several
+   stock library descriptions embed double quotes (``power:GND`` is
+   ``Power symbol creates a global label with name "GND" , ground``), so the
+   first inner quote closed the token early and corrupted the block. Note the
+   file's parentheses still balance afterwards and sexpdata still parses it,
+   which is what made this silent.
+3. ``add_schematic_component`` dropped the documented ``angle`` and ``mirrorY``
+   arguments: the TS layer nests them inside ``component``, and the Python
+   handler never read them back out.
+"""
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+TEMPLATES_DIR = Path(__file__).parent.parent / "python" / "templates"
+
+_KICAD_CLI = shutil.which("kicad-cli")
+
+# Format version tokens, by the KiCad release that introduced them.
+V8 = 20231120
+V9 = 20250114
+V10 = 20260101
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sch_with_version(tmp_path: Path, version: int, name: str = "s.kicad_sch") -> Path:
+    """A minimal but structurally complete schematic declaring ``version``."""
+    dest = tmp_path / name
+    dest.write_text(
+        f'(kicad_sch (version {version}) (generator "eeschema")'
+        ' (generator_version "9.0")\n\n'
+        "  (uuid 4f7d1c66-1f9e-4a2b-9d3c-0f1a2b3c4d5e)\n\n"
+        '  (paper "A4")\n\n'
+        "  (lib_symbols\n  )\n\n"
+        '  (sheet_instances\n    (path "/" (page "1"))\n  )\n'
+        ")\n",
+        encoding="utf-8",
+    )
+    return dest
+
+
+def _sch_without_version(tmp_path: Path) -> Path:
+    """A schematic with no ``(version ...)`` token at all."""
+    dest = tmp_path / "noversion.kicad_sch"
+    dest.write_text(
+        '(kicad_sch (generator "eeschema")\n'
+        "  (uuid 4f7d1c66-1f9e-4a2b-9d3c-0f1a2b3c4d5e)\n"
+        '  (paper "A4")\n'
+        "  (lib_symbols\n  )\n"
+        '  (sheet_instances\n    (path "/" (page "1"))\n  )\n'
+        ")\n",
+        encoding="utf-8",
+    )
+    return dest
+
+
+def _place(sch: Path, library: str, symbol: str, reference: str, **kwargs: Any) -> bool:
+    from commands.dynamic_symbol_loader import DynamicSymbolLoader
+
+    loader = DynamicSymbolLoader()
+    loader.inject_symbol_into_schematic(sch, library, symbol)
+    return loader.create_component_instance(sch, library, symbol, reference=reference, **kwargs)
+
+
+def _placed_symbol_header(content: str, lib_id: str) -> str:
+    """The ``(symbol (lib_id ...) ...)`` opening line plus its attribute line."""
+    m = re.search(
+        r"\(symbol \(lib_id \"" + re.escape(lib_id) + r"\"\)[^\n]*\n[^\n]*",
+        content,
+    )
+    assert m is not None, f"no placed symbol for {lib_id} in:\n{content[:2000]}"
+    return m.group(0)
+
+
+# ---------------------------------------------------------------------------
+# 1. Version-gated KiCad 10 symbol attributes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestKicad10TokensAreVersionGated:
+    """body_style / in_pos_files must only reach files that accept them."""
+
+    @pytest.mark.parametrize("version", [V8, V9])
+    def test_legacy_versions_omit_kicad10_tokens(self, tmp_path: Path, version: int) -> None:
+        sch = _sch_with_version(tmp_path, version)
+        assert _place(sch, "Device", "R", "R1", value="10k", x=100, y=100)
+
+        header = _placed_symbol_header(sch.read_text(), "Device:R")
+        assert "body_style" not in header, f"v{version} file got a KiCad 10 token: {header}"
+        assert "in_pos_files" not in header, f"v{version} file got a KiCad 10 token: {header}"
+
+        # The attributes that ARE common to v8/v9/v10 must still be present.
+        for token in ("(exclude_from_sim no)", "(in_bom yes)", "(on_board yes)", "(dnp no)"):
+            assert token in header, f"{token} missing from {header}"
+
+    def test_kicad10_version_keeps_kicad10_tokens(self, tmp_path: Path) -> None:
+        sch = _sch_with_version(tmp_path, V10)
+        assert _place(sch, "Device", "R", "R1", value="10k", x=100, y=100)
+
+        header = _placed_symbol_header(sch.read_text(), "Device:R")
+        assert "(body_style 1)" in header
+        assert "(in_pos_files yes)" in header
+
+    def test_missing_version_is_treated_as_kicad10(self, tmp_path: Path) -> None:
+        """Absent version keeps the pre-fix behaviour rather than silently downgrading."""
+        sch = _sch_without_version(tmp_path)
+        assert _place(sch, "Device", "R", "R1", value="10k", x=100, y=100)
+
+        header = _placed_symbol_header(sch.read_text(), "Device:R")
+        assert "(body_style 1)" in header
+        assert "(in_pos_files yes)" in header
+
+    @pytest.mark.parametrize(
+        "version,expected",
+        [(V8, False), (V9, False), (V10, True), (V10 + 1, True)],
+    )
+    def test_support_predicate(self, version: int, expected: bool) -> None:
+        from commands.dynamic_symbol_loader import DynamicSymbolLoader
+
+        content = f'(kicad_sch (version {version}) (generator "eeschema"))'
+        assert DynamicSymbolLoader._supports_kicad10_symbol_tokens(content) is expected
+
+    def test_read_sch_version(self) -> None:
+        from commands.dynamic_symbol_loader import DynamicSymbolLoader
+
+        assert DynamicSymbolLoader._read_sch_version("(kicad_sch (version 20250114)") == V9
+        assert DynamicSymbolLoader._read_sch_version("(kicad_sch (generator x)") is None
+
+
+@pytest.mark.unit
+class TestShippedTemplatesStayLoadable:
+    """The repo's own templates declare a mix of v9 and v10 -- both must work."""
+
+    @pytest.mark.parametrize("template", ["minimal", "empty", "template_with_symbols", "blank"])
+    def test_template_gets_tokens_matching_its_own_version(
+        self, tmp_path: Path, template: str
+    ) -> None:
+        src = TEMPLATES_DIR / f"{template}.kicad_sch"
+        if not src.exists():
+            pytest.skip(f"template {template} not present")
+        sch = tmp_path / f"{template}.kicad_sch"
+        sch.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+        declared = re.search(r"\(version\s+(\d+)\)", sch.read_text())
+        assert declared is not None, f"{template} has no version token"
+        version = int(declared.group(1))
+
+        assert _place(sch, "Device", "R", "R1", value="10k", x=100, y=100)
+        header = _placed_symbol_header(sch.read_text(), "Device:R")
+
+        if version >= V10:
+            assert "(body_style 1)" in header
+        else:
+            assert (
+                "body_style" not in header
+            ), f"{template} declares {version} but was given a KiCad 10 token"
+
+
+# ---------------------------------------------------------------------------
+# 2. Property-value escaping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPropertyValuesAreEscaped:
+    """A quote inside a property value must not terminate the token."""
+
+    def test_library_description_with_quotes_is_escaped(self, tmp_path: Path) -> None:
+        """power:GND's stock Description embeds "GND" -- the original trigger."""
+        from utils.sexpr_format import QUOTED_VALUE, unescape_sexpr_string
+
+        sch = _sch_with_version(tmp_path, V9)
+        assert _place(sch, "power", "GND", "#PWR01", value="GND", x=50, y=50)
+
+        content = sch.read_text()
+        # Look at the *placed instance* property, not the lib_symbols one.
+        instance = content[content.index('(symbol (lib_id "power:GND")') :]
+        m = re.search(r'\(property "Description" ' + QUOTED_VALUE, instance)
+        assert m is not None, "no Description property on the placed symbol"
+
+        raw = m.group(1)
+        assert '\\"GND\\"' in raw, f"quotes not escaped: {raw!r}"
+        # And it must survive a round trip back to the original text.
+        assert unescape_sexpr_string(raw) == (
+            'Power symbol creates a global label with name "GND" , ground'
+        )
+
+    def test_user_supplied_value_with_quotes_is_escaped(self, tmp_path: Path) -> None:
+        from utils.sexpr_format import QUOTED_VALUE, unescape_sexpr_string
+
+        sch = _sch_with_version(tmp_path, V9)
+        assert _place(sch, "Device", "R", "R1", value='1/4" 10k', x=100, y=100)
+
+        instance = sch.read_text()
+        instance = instance[instance.index('(symbol (lib_id "Device:R")') :]
+        m = re.search(r'\(property "Value" ' + QUOTED_VALUE, instance)
+        assert m is not None
+        assert unescape_sexpr_string(m.group(1)) == '1/4" 10k'
+
+    def test_backslash_in_value_survives(self, tmp_path: Path) -> None:
+        """Backslash must be escaped before the quote, or the pair cancels out."""
+        from utils.sexpr_format import QUOTED_VALUE, unescape_sexpr_string
+
+        sch = _sch_with_version(tmp_path, V9)
+        assert _place(sch, "Device", "R", "R1", value="a\\b", x=100, y=100)
+
+        instance = sch.read_text()
+        instance = instance[instance.index('(symbol (lib_id "Device:R")') :]
+        m = re.search(r'\(property "Value" ' + QUOTED_VALUE, instance)
+        assert m is not None
+        assert unescape_sexpr_string(m.group(1)) == "a\\b"
+
+    def test_every_property_value_token_ends_where_it_should(self, tmp_path: Path) -> None:
+        """Each property's value token must be followed by its ``(at ...)`` child.
+
+        This is the structural tell for a value that terminated early: the text
+        after the closing quote is then the *remainder of the description* rather
+        than the next s-expression. Counting parens does not catch it (they stay
+        balanced) and neither does counting quotes (a description with two inner
+        quotes keeps the total even), so assert on what actually breaks.
+        """
+        sch = _sch_with_version(tmp_path, V9)
+        assert _place(sch, "power", "GND", "#PWR01", value="GND", x=50, y=50)
+
+        content = sch.read_text()
+        instance = content[content.index('(symbol (lib_id "power:GND")') :]
+
+        properties = list(
+            re.finditer(r'\(property "(?:[^"\\]|\\.)*" ((?:"(?:[^"\\]|\\.)*"))', instance)
+        )
+        assert len(properties) == 5, f"expected 5 properties, found {len(properties)}"
+        for m in properties:
+            tail = instance[m.end() : m.end() + 40].lstrip()
+            assert tail.startswith(
+                "(at "
+            ), f"property value token ran on -- followed by {tail[:30]!r} instead of '(at '"
+
+
+# ---------------------------------------------------------------------------
+# 3. angle / mirrorY plumbed through the handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAddComponentHonoursOrientation:
+    """The handler must forward the nested angle/mirrorY to the loader."""
+
+    def _handler(self) -> Any:
+        from commands.schematic_handlers import SchematicHandlersMixin
+
+        class _H(SchematicHandlersMixin):
+            def _reload_kicad_schematic(self, *a: Any, **k: Any) -> None:
+                return None
+
+        return _H()
+
+    def _add(self, sch: Path, **component: Any) -> Any:
+        params = {
+            "schematicPath": str(sch),
+            "component": {
+                "library": "Device",
+                "type": "R",
+                "reference": "R1",
+                "value": "10k",
+                "x": 100,
+                "y": 100,
+                "unit": 1,
+                **component,
+            },
+        }
+        return self._handler()._handle_add_schematic_component(params)
+
+    def test_angle_is_written(self, tmp_path: Path) -> None:
+        sch = _sch_with_version(tmp_path, V9)
+        result = self._add(sch, angle=90)
+        assert result["success"] is True, result
+
+        header = _placed_symbol_header(sch.read_text(), "Device:R")
+        assert re.search(r"\(at [\d.]+ [\d.]+ 90\)", header), header
+
+    def test_angle_defaults_to_zero(self, tmp_path: Path) -> None:
+        sch = _sch_with_version(tmp_path, V9)
+        assert self._add(sch)["success"] is True
+
+        header = _placed_symbol_header(sch.read_text(), "Device:R")
+        assert re.search(r"\(at [\d.]+ [\d.]+ 0\)", header), header
+
+    def test_mirror_y_is_written(self, tmp_path: Path) -> None:
+        sch = _sch_with_version(tmp_path, V9)
+        assert self._add(sch, mirrorY=True)["success"] is True
+
+        header = _placed_symbol_header(sch.read_text(), "Device:R")
+        assert "(mirror y)" in header, header
+
+    def test_no_mirror_token_when_not_requested(self, tmp_path: Path) -> None:
+        sch = _sch_with_version(tmp_path, V9)
+        assert self._add(sch, mirrorY=False)["success"] is True
+
+        header = _placed_symbol_header(sch.read_text(), "Device:R")
+        assert "(mirror" not in header, header
+
+    def test_angle_and_mirror_together(self, tmp_path: Path) -> None:
+        sch = _sch_with_version(tmp_path, V9)
+        assert self._add(sch, angle=270, mirrorY=True)["success"] is True
+
+        header = _placed_symbol_header(sch.read_text(), "Device:R")
+        assert re.search(r"\(at [\d.]+ [\d.]+ 270\)", header), header
+        assert "(mirror y)" in header, header
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the file KiCad itself has to accept
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(_KICAD_CLI is None, reason="KiCad CLI not installed")
+class TestRealKicadLoadsTheResult:
+    """The unit tests above assert on tokens; this asserts on KiCad's verdict.
+
+    Only exercises versions at or below the installed CLI's own format -- a
+    newer-format file is legitimately refused and would prove nothing.
+    """
+
+    @staticmethod
+    def _cli_major() -> int:
+        out = subprocess.run(
+            [str(_KICAD_CLI), "version"], capture_output=True, text=True, timeout=60
+        )
+        m = re.match(r"\s*(\d+)", out.stdout)
+        return int(m.group(1)) if m else 0
+
+    @pytest.mark.parametrize("version", [V8, V9])
+    def test_placed_symbols_load(self, tmp_path: Path, version: int) -> None:
+        if self._cli_major() < 9:
+            pytest.skip("needs KiCad >= 9 to read a 20250114 file")
+
+        sch = _sch_with_version(tmp_path, version)
+        # power:GND exercises escaping, Device:R exercises the attribute line.
+        assert _place(sch, "power", "GND", "#PWR01", value="GND", x=50, y=50)
+        assert _place(sch, "Device", "R", "R1", value="10k", x=100, y=100, angle=90)
+
+        out = subprocess.run(
+            [str(_KICAD_CLI), "sch", "export", "svg", str(sch), "-o", str(tmp_path / "svg")],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        assert out.returncode == 0, (
+            f"KiCad refused a v{version} schematic it should accept.\n"
+            f"stdout: {out.stdout}\nstderr: {out.stderr}"
+        )

--- a/tests/test_symbol_instance_completeness.py
+++ b/tests/test_symbol_instance_completeness.py
@@ -40,6 +40,23 @@ EMPTY_SCH = TEMPLATES_DIR / "empty.kicad_sch"
 # --------------------------------------------------------------------------- #
 
 
+def _project_v10(tmp_path: Path, project_stem: str = "myproj") -> Path:
+    """Like :func:`_project`, but the schematic declares the KiCad 10 format.
+
+    ``empty.kicad_sch`` declares 20250114 (KiCad 9), and the writer now only emits
+    the v10-only ``(body_style ...)``/``(in_pos_files ...)`` attributes into files
+    whose version accepts them -- writing them into a v9 file makes KiCad reject
+    the schematic outright. Tests that assert on those two tokens therefore have to
+    say so by using a v10 file.
+    """
+    sch = _project(tmp_path, project_stem)
+    sch.write_text(
+        re.sub(r"\(version\s+\d+\)", "(version 20260101)", sch.read_text(encoding="utf-8")),
+        encoding="utf-8",
+    )
+    return sch
+
+
 def _project(tmp_path: Path, project_stem: str = "myproj") -> Path:
     """Create a flat project (one .kicad_sch + matching .kicad_pro) and return the sch."""
     sch = tmp_path / f"{project_stem}.kicad_sch"
@@ -117,7 +134,7 @@ _DUAL_SCH = """(kicad_sch (version 20250114) (generator "x")
 @pytest.mark.unit
 class TestHeaderFieldSet:
     def test_header_has_v10_fields_in_order(self, tmp_path: Any) -> None:
-        sch = _project(tmp_path)
+        sch = _project_v10(tmp_path)
         DynamicSymbolLoader().create_component_instance(
             sch, "Device", "R", reference="R1", value="10k", x=100, y=100
         )


### PR DESCRIPTION
Hiya, I've been using claude to work with PCBs and doing some edits came up with some potential issues with the MCP server?

Here's claude's summary:

Placing a symbol made any KiCad 8 or KiCad 9 schematic unloadable, including this repo's own minimal/empty/template_with_symbols templates (all declare 20250114). Every failure surfaced only as a bare "Failed to load schematic" from eeschema and kicad-cli, naming neither token nor line.

Three defects in the shared writer:

- create_component_instance emitted the KiCad 10-only (body_style 1) and (in_pos_files yes) attributes unconditionally. KiCad dispatches to a parser per declared format version, so a v10 token inside a 20231120 or 20250114 file is refused - by a KiCad 10 binary too. Both are now gated on the target file's own (version ...); a file with no version token keeps v10 output.

- Property values were interpolated unescaped. Stock library descriptions embed double quotes - power:GND is 'Power symbol creates a global label with name "GND" , ground' - so the first inner quote closed the token early and the rest of the block became garbage. Parentheses still balanced and sexpdata still parsed the result, which is why this stayed silent; only KiCad objected. Values now go through escape_sexpr_string.

- add_schematic_component dropped its documented angle and mirrorY arguments: the TS layer nests them inside `component` (src/tools/schematic.ts) and the Python handler never read them back out, so symbols always landed at 0deg and callers had to follow up with rotate_schematic_component.

Adds tests/test_schematic_writer_format_compat.py (24 tests; 17 fail before this change), including an integration test asserting real kicad-cli accepts the generated v8 and v9 files. test_symbol_instance_completeness.py asserted the v10 attributes while placing into the v9 empty.kicad_sch; it now uses a v10 fixture for those two tokens.