### PR TITLE
fix(jlcpcb): decode yaqwsx source-db-v2 prices and Basic flag

### DIFF
--- a/python/commands/jlcpcb_downloader.py
+++ b/python/commands/jlcpcb_downloader.py
@@ -62,16 +62,41 @@ def _progress(progress: ProgressFn, message: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _parse_price_csv(raw: str) -> List[Dict[str, Any]]:
+    """Decode yaqwsx ``source-db-v2`` price CSV into ``[{"qty","price"}]``.
+
+    Format is ``qFrom-qTo:unitPrice`` segments joined by commas, where an empty
+    ``qTo`` means the break is open-ended, e.g.::
+
+        1-199:0.0189,200-599:0.0163,20000-:0.0138
+
+    Malformed segments are skipped rather than discarding the whole row.
+    """
+    out: List[Dict[str, Any]] = []
+    for segment in raw.split(","):
+        range_text, sep, price_text = segment.strip().partition(":")
+        if not sep:
+            continue
+        q_from = range_text.partition("-")[0]
+        try:
+            out.append({"qty": int(q_from), "price": float(price_text)})
+        except ValueError:
+            continue
+    out.sort(key=lambda brk: brk["qty"])
+    return out
+
+
 def normalize_price_json(raw: Any) -> str:
     """Normalize a source price value into the manager's ``[{"qty","price"}]`` shape.
 
-    Handles both CDFER/jlcparts JSON arrays (``[{"qFrom","qTo","price"}, ...]``)
-    and a bare scalar price. Returns a JSON string (``"[]"`` when no price).
+    Handles CDFER/legacy-jlcparts JSON arrays (``[{"qFrom","qTo","price"}, ...]``),
+    the yaqwsx ``source-db-v2`` price CSV (``qFrom-qTo:unitPrice,...``), and a bare
+    scalar price. Returns a JSON string (``"[]"`` when no price).
     """
     if raw is None or raw == "":
         return json.dumps([])
 
-    # JSON array string (CDFER / jlcparts store price as TEXT JSON)
+    # JSON array string (CDFER / legacy jlcparts store price as TEXT JSON)
     if isinstance(raw, str) and raw.strip().startswith("["):
         try:
             arr = json.loads(raw)
@@ -87,6 +112,10 @@ def normalize_price_json(raw: Any) -> str:
             qty = item.get("qFrom", item.get("qty", 1)) or 1
             out.append({"qty": qty, "price": price})
         return json.dumps(out)
+
+    # yaqwsx source-db-v2 CSV ("1-199:0.0189,200-:0.0138")
+    if isinstance(raw, str) and ":" in raw:
+        return json.dumps(_parse_price_csv(raw))
 
     # Scalar numeric price
     try:
@@ -117,32 +146,36 @@ def _relation_names(src: sqlite3.Connection) -> List[str]:
 
 
 def _ensure_components_view(src: sqlite3.Connection) -> None:
-    """Create a denormalized ``v_components`` view for yaqwsx-style sources.
+    """Create a denormalized ``v_components`` view for the yaqwsx full catalog.
 
-    CDFER ships a ``v_components`` view, but yaqwsx's raw ``cache.sqlite3`` (the
-    FULL catalog) stores category/manufacturer as IDs in sibling ``categories``
-    and ``manufacturers`` tables. Without this join the full-catalog convert
-    would leave category/subcategory/manufacturer blank. We build the same view
-    shape CDFER exposes so the rest of the converter is source-agnostic.
+    CDFER ships a ``v_components`` view, but yaqwsx's ``cache.sqlite3`` (the FULL
+    catalog, ``meta.format = 'source-db-v2'``) keeps components in
+    ``jlc_components`` with a ``lcsc_components`` side table. We build the same
+    view shape CDFER exposes so the rest of the converter is source-agnostic.
+
+    That layout arrived in upstream commit "Introduce compact source cache"
+    (2026-05-31), which also renamed the flags this converter relies on: the
+    ``basic`` column became ``library_type`` (``'base'``/``'expand'``), and a
+    blank ``manufacturer`` falls back to ``lcsc_components``. The join mirrors
+    upstream's own read query (``iterCategoryComponents``), incl. the
+    ``present = 1`` filter that hides delisted parts.
     """
     names = _relation_names(src)
-    if "v_components" in names:
-        return
-    if not ({"components", "categories", "manufacturers"} <= set(names)):
-        return
-    comp_cols = {r[1] for r in src.execute("PRAGMA table_info([components])").fetchall()}
-    if not ({"category_id", "manufacturer_id"} <= comp_cols):
+    if "v_components" in names or "jlc_components" not in names:
         return
     try:
         src.execute("""
             CREATE TEMP VIEW v_components AS
-            SELECT c.*, cat.category AS category, cat.subcategory AS subcategory,
-                   m.name AS manufacturer
-            FROM components c
-            LEFT JOIN categories cat ON cat.id = c.category_id
-            LEFT JOIN manufacturers m ON m.id = c.manufacturer_id
+            SELECT j.lcsc, j.category, j.subcategory, j.mfr, j.package, j.joints,
+                   COALESCE(NULLIF(j.manufacturer, ''), NULLIF(l.manufacturer, ''), '')
+                       AS manufacturer,
+                   CASE WHEN j.library_type = 'base' THEN 1 ELSE 0 END AS basic,
+                   j.preferred, j.description, j.datasheet, j.stock, j.price
+            FROM jlc_components j
+            LEFT JOIN lcsc_components l ON l.lcsc = j.lcsc
+            WHERE j.present = 1
             """)
-        logger.info("Built v_components join view for yaqwsx-style source")
+        logger.info("Built v_components join view for yaqwsx source-db-v2")
     except sqlite3.Error as exc:  # pragma: no cover - defensive
         logger.debug(f"could not build v_components view: {exc}")
 

--- a/tests/test_jlcpcb_downloader.py
+++ b/tests/test_jlcpcb_downloader.py
@@ -167,27 +167,25 @@ def _make_yaqwsx_source(path: Path) -> None:
         """)
     con.execute("INSERT INTO meta VALUES ('format', 'source-db-v2')")
 
-    def _jlc(lcsc, category, sub, mfr, pkg, manufacturer, lib_type, preferred, desc, stock, price):
+    def _jlc(lcsc, mfr, manufacturer, lib_type, preferred, desc, stock, price):
+        """Insert a 0603 Ferrite Bead; only the fields under test vary per row."""
         con.execute(
-            "INSERT INTO jlc_components VALUES (?,0,1,0,?,?,?,?,2,?,?,?,0,?,'http://ds',?,?,"
+            "INSERT INTO jlc_components VALUES "
+            "(?,0,1,0,'Filters','Ferrite Beads',?,'0603',2,?,?,?,0,?,'http://ds',?,?,"
             "'{}',NULL,'',NULL,NULL,NULL,NULL,'{}')",
-            (lcsc, category, sub, mfr, pkg, manufacturer, lib_type, preferred, desc, stock, price),
+            (lcsc, mfr, manufacturer, lib_type, preferred, desc, stock, price),
         )
 
+    prices = "1-199:0.0189,200-599:0.0163,20000-:0.0138"
     # Basic ("base") part with the v2 CSV price, incl. an open-ended last break.
-    _jlc(
-        1002, "Filters", "Ferrite Beads", "GZ1608D601TF", "0603", "Sunlord", "base", 0,
-        "ferrite bead 600R", 892564, "1-199:0.0189,200-599:0.0163,20000-:0.0138",
-    )
+    _jlc(1002, "GZ1608D601TF", "Sunlord", "base", 0, "ferrite bead 600R", 892564, prices)
     # Extended part whose jlc manufacturer is blank -> must fall back to lcsc_components.
-    _jlc(1005, "Filters", "Ferrite Beads", "CBG160808U820T", "0603", "", "expand", 0,
-         "ferrite bead 82R", 0, "1-999:0.0039")
+    _jlc(1005, "CBG160808U820T", "", "expand", 0, "ferrite bead 82R", 0, "1-999:0.0039")
     con.execute(
         "INSERT INTO lcsc_components VALUES (1005, 0, 'Fenghua Advanced', '{}', NULL, NULL)"
     )
     # Preferred part with no price at all.
-    _jlc(1006, "Filters", "Ferrite Beads", "CBG160808U600T", "0603", "FH", "expand", 1,
-         "ferrite bead 60R", 33781, "")
+    _jlc(1006, "CBG160808U600T", "FH", "expand", 1, "ferrite bead 60R", 33781, "")
     con.commit()
     con.close()
 

--- a/tests/test_jlcpcb_downloader.py
+++ b/tests/test_jlcpcb_downloader.py
@@ -118,63 +118,141 @@ def test_convert_source_sqlite_produces_manager_schema(tmp_path):
     con.close()
 
 
-def _make_yaqwsx_like_source(path: Path) -> None:
-    """Create a SQLite mirroring yaqwsx's FULL-catalog schema: normalized, NO view.
+def _make_yaqwsx_source(path: Path) -> None:
+    """Create a SQLite mirroring yaqwsx's ``source-db-v2`` cache.sqlite3.
 
-    category/manufacturer are IDs in sibling tables (no v_components view), which
-    is what the real ~10GB cache.sqlite3 looks like.
+    Upstream commit "Introduce compact source cache" (2026-05-31) replaced the
+    ``components``/``categories``/``manufacturers`` layout with a denormalized
+    ``jlc_components`` plus a ``lcsc_components`` side table, and re-encoded
+    ``price`` from a JSON array into a compact CSV (``qFrom-qTo:unitPrice``).
     """
     con = sqlite3.connect(str(path))
     con.executescript("""
-        CREATE TABLE manufacturers (id INTEGER PRIMARY KEY, name TEXT);
-        CREATE TABLE categories (id INTEGER PRIMARY KEY, category TEXT, subcategory TEXT);
-        CREATE TABLE components (
-            lcsc INTEGER PRIMARY KEY,
-            category_id INTEGER,
-            mfr TEXT,
-            package TEXT,
-            joints INTEGER,
-            manufacturer_id INTEGER,
-            basic INTEGER,
-            preferred INTEGER,
-            description TEXT,
-            datasheet TEXT,
-            stock INTEGER,
-            price TEXT
+        CREATE TABLE meta (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL);
+        CREATE TABLE jlc_components (
+            lcsc INTEGER PRIMARY KEY NOT NULL,
+            fetched_at INTEGER NOT NULL,
+            present INTEGER NOT NULL,
+            sync_seen INTEGER NOT NULL DEFAULT 0,
+            category TEXT NOT NULL,
+            subcategory TEXT NOT NULL,
+            mfr TEXT NOT NULL,
+            package TEXT NOT NULL,
+            joints INTEGER NOT NULL,
+            manufacturer TEXT NOT NULL,
+            library_type TEXT NOT NULL,
+            preferred INTEGER NOT NULL,
+            last_on_stock INTEGER NOT NULL,
+            description TEXT NOT NULL,
+            datasheet TEXT NOT NULL,
+            stock INTEGER NOT NULL,
+            price TEXT NOT NULL,
+            attributes TEXT NOT NULL,
+            rohs INTEGER,
+            eccn TEXT NOT NULL,
+            assembly INTEGER,
+            assembly_process TEXT,
+            assembly_mode TEXT,
+            website_component_id TEXT,
+            attrition TEXT NOT NULL
+        );
+        CREATE TABLE lcsc_components (
+            lcsc INTEGER PRIMARY KEY NOT NULL,
+            fetched_at INTEGER NOT NULL,
+            manufacturer TEXT NOT NULL,
+            attributes TEXT NOT NULL,
+            image TEXT,
+            url_slug TEXT
         );
         """)
-    con.execute("INSERT INTO manufacturers VALUES (7, 'Texas Instruments')")
-    con.execute("INSERT INTO categories VALUES (3, 'ICs', 'LDO Regulators')")
-    con.execute(
-        "INSERT INTO components VALUES (12345, 3, 'TLV70033', 'SOT-23-5', 5, 7, 0, 0, "
-        "'3.3V LDO', 'http://ds/12345', 0, ?)",
-        (json.dumps([{"qFrom": 1, "qTo": None, "price": 0.12}]),),
+    con.execute("INSERT INTO meta VALUES ('format', 'source-db-v2')")
+
+    def _jlc(lcsc, category, sub, mfr, pkg, manufacturer, lib_type, preferred, desc, stock, price):
+        con.execute(
+            "INSERT INTO jlc_components VALUES (?,0,1,0,?,?,?,?,2,?,?,?,0,?,'http://ds',?,?,"
+            "'{}',NULL,'',NULL,NULL,NULL,NULL,'{}')",
+            (lcsc, category, sub, mfr, pkg, manufacturer, lib_type, preferred, desc, stock, price),
+        )
+
+    # Basic ("base") part with the v2 CSV price, incl. an open-ended last break.
+    _jlc(
+        1002, "Filters", "Ferrite Beads", "GZ1608D601TF", "0603", "Sunlord", "base", 0,
+        "ferrite bead 600R", 892564, "1-199:0.0189,200-599:0.0163,20000-:0.0138",
     )
+    # Extended part whose jlc manufacturer is blank -> must fall back to lcsc_components.
+    _jlc(1005, "Filters", "Ferrite Beads", "CBG160808U820T", "0603", "", "expand", 0,
+         "ferrite bead 82R", 0, "1-999:0.0039")
+    con.execute(
+        "INSERT INTO lcsc_components VALUES (1005, 0, 'Fenghua Advanced', '{}', NULL, NULL)"
+    )
+    # Preferred part with no price at all.
+    _jlc(1006, "Filters", "Ferrite Beads", "CBG160808U600T", "0603", "FH", "expand", 1,
+         "ferrite bead 60R", 33781, "")
     con.commit()
     con.close()
 
 
-def test_convert_yaqwsx_schema_populates_category_and_manufacturer(tmp_path):
-    """Full-catalog (yaqwsx) source has no v_components view; the join must be built."""
+def test_convert_yaqwsx_schema_populates_prices_and_library_type(tmp_path):
+    """Regression: the source-db-v2 catalog must not convert to empty price_json.
+
+    Before the fix, ``_pick_source_relation`` fell back to the largest table
+    (``jlc_components``) but the converter still looked for a JSON ``price`` and a
+    ``basic`` column, so EVERY row landed with ``price_json == '[]'`` and no part
+    was ever classified Basic.
+    """
     source = tmp_path / "cache.sqlite3"
     target = tmp_path / "jlcpcb_parts.db"
-    _make_yaqwsx_like_source(source)
+    _make_yaqwsx_source(source)
 
     stats = jlcpcb_downloader.convert_source_sqlite(source, target)
-    assert stats["total"] == 1
+    assert stats["total"] == 3
+    assert stats["basic"] == 1  # library_type == 'base'
 
     con = sqlite3.connect(str(target))
     con.row_factory = sqlite3.Row
-    row = dict(con.execute("SELECT * FROM components WHERE lcsc='C12345'").fetchone())
+    rows = {r["lcsc"]: dict(r) for r in con.execute("SELECT * FROM components")}
     con.close()
 
-    # These would be blank without the built v_components join:
-    assert row["category"] == "ICs"
-    assert row["subcategory"] == "LDO Regulators"
-    assert row["manufacturer"] == "Texas Instruments"
-    assert row["mfr_part"] == "TLV70033"
-    assert row["library_type"] == "Extended"
-    assert json.loads(row["price_json"]) == [{"qty": 1, "price": 0.12}]
+    basic = rows["C1002"]
+    assert basic["library_type"] == "Basic"
+    assert basic["category"] == "Filters"
+    assert basic["subcategory"] == "Ferrite Beads"
+    assert basic["manufacturer"] == "Sunlord"
+    assert basic["mfr_part"] == "GZ1608D601TF"
+    assert basic["stock"] == 892564
+    # The v2 CSV price must be decoded into the manager's [{"qty","price"}] shape.
+    assert json.loads(basic["price_json"]) == [
+        {"qty": 1, "price": 0.0189},
+        {"qty": 200, "price": 0.0163},
+        {"qty": 20000, "price": 0.0138},
+    ]
+
+    # Blank jlc manufacturer falls back to the lcsc_components side table.
+    assert rows["C1005"]["manufacturer"] == "Fenghua Advanced"
+    assert json.loads(rows["C1005"]["price_json"]) == [{"qty": 1, "price": 0.0039}]
+
+    assert rows["C1006"]["library_type"] == "Preferred"
+    assert json.loads(rows["C1006"]["price_json"]) == []
+
+
+def test_normalize_price_json_handles_yaqwsx_csv():
+    """source-db-v2 encodes price as ``qFrom-qTo:unitPrice`` pairs joined by commas."""
+    norm = jlcpcb_downloader.normalize_price_json
+    assert json.loads(norm("1-199:0.0189,200-599:0.0163,20000-:0.0138")) == [
+        {"qty": 1, "price": 0.0189},
+        {"qty": 200, "price": 0.0163},
+        {"qty": 20000, "price": 0.0138},
+    ]
+    # Single open-ended break.
+    assert json.loads(norm("1-:0.5")) == [{"qty": 1, "price": 0.5}]
+    # Breaks are sorted by quantity even if the source is out of order.
+    assert json.loads(norm("100-:0.2,1-99:0.4")) == [
+        {"qty": 1, "price": 0.4},
+        {"qty": 100, "price": 0.2},
+    ]
+    # Malformed segments are skipped, not fatal.
+    assert json.loads(norm("garbage,1-9:0.1")) == [{"qty": 1, "price": 0.1}]
+    assert json.loads(norm("totally bogus")) == []
 
 
 def test_normalize_price_json_handles_scalar_and_array_and_empty():


### PR DESCRIPTION
Fixes #352.

The yaqwsx source stopped producing prices: every converted part landed with `price_json == '[]'`, and `basic_parts` was always 0. Upstream re-shaped the published `cache.sqlite3` (`meta.format = 'source-db-v2'`) — full analysis in the issue.

## Changes

**`_ensure_components_view`** — builds `v_components` from `jlc_components LEFT JOIN lcsc_components` instead of the old `components`/`categories`/`manufacturers` join. Mirrors upstream's own read query (`sourceDb.iterCategoryComponents`): `basic` derived from `library_type = 'base'`, manufacturer falling back to `lcsc_components` when the JLC field is blank, and the `present = 1` filter that hides delisted parts.

**`normalize_price_json`** — new `_parse_price_csv` branch for the `qFrom-qTo:unitPrice,...` encoding. Placed after the JSON-array branch and before the scalar one, so no input that previously worked changes path. Malformed segments are skipped rather than discarding the row.

The old-layout branch is **removed** rather than kept alongside: upstream migrated, and the archive being served has only the new format.

## What is deliberately untouched

- **The target schema.** No change to the `components` table, its indexes or the FTS index, so `JLCPCBPartsManager` consumes the result unchanged. Verified on a freshly built database: same 13 columns in the same order, same 5 indexes, and `get_part_info("C1002")` returns populated `price_breaks`.
- **The CDFER path.** CDFER ships its own `v_components` view and JSON prices — verified by reading its `sqlite_master` directly — so it returns at the first guard and still needs the JSON branch. Removing that branch would have broken the default source.

## Verification

Full conversion of the real 5.3 GB catalog:

```
7,157,071 parts in 5.1 min
empty price_json: 146 / 7,157,071
basic: 351
```

Both residuals are exact: 146 matches the source rows with `price = ''`, and 351 matches the source's `library_type = 'base'` count. Nothing is lost by the converter.

Tests: 2 added (`source-db-v2` conversion end-to-end, and the CSV decoder incl. open-ended breaks, out-of-order breaks and malformed input). The obsolete legacy-layout test and its fixture are removed. 14/14 in the file; full suite 1776 passing — the 3 failures in `test_kicad_3rd_party_env_resolution.py` are pre-existing on `main`.

## Note for reviewers

The full yaqwsx catalog is now **7.1 M parts / ~5.1 GB**, against 616 k / 465 MB from CDFER — upstream growth, not this change. Only 685 k have stock > 0. If that size is unwanted, a `stock > 0` filter in the view would cut it, but that changes what `--source yaqwsx` has always delivered, so it is not part of this fix.
