### PR TITLE
feat(routing): add route_net — obstacle-aware A* net routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the KiCAD MCP Server project are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **`route_net` — obstacle-aware net routing** (new). `route_trace` and
+  `route_pad_to_pad` draw a trace exactly where they are told, so the caller
+  has to know a legal path before asking. For an LLM driving a board that is
+  the hard part: it can read the netlist and the DRC report, but it cannot see
+  the free space. `route_net` builds a per-layer occupancy model of the board —
+  every other net's pads, tracks, zones and rule areas, grown by clearance —
+  and runs an A\* search over it.
+
+  Use it when a connection has to be made but no legal path is known, when
+  `route_trace` produced a short or a clearance violation, or when the
+  autorouter left a net unrouted. Pads are routed to whatever copper the net
+  already has, so it repairs a partially routed net as well as building one.
+
+  The search encodes a few things that are wrong in the obvious implementation
+  and expensive to notice on real copper:
+  - **Vias get their own occupancy map.** A via is fatter than a trace;
+    checking a layer change against the trace map is how one ends up a tenth of
+    a millimetre from another net. A via also punches the whole stack, so it
+    must clear every layer, not the two it nominally joins.
+  - **Diagonal steps may not squeeze between two blocked cells.** On the grid
+    it looks clear; in copper it clips the corner.
+  - **A pad terminal is every free cell inside the pad, not its centre.** On a
+    0.65 mm pitch package the neighbours' clearance covers the centre cell, so
+    a centre-only terminal never enters the search even though the pad is
+    1.5 mm long and its far end is wide open.
+  - **Per-layer costs.** Make 2 oz outer copper dear and an empty inner signal
+    layer cheap and the router stops carving through power planes to save a
+    via.
+  - **`relaxedArea` mirrors a `.kicad_dru` rule area** so the router agrees
+    with DRC about local clearance. Without it, fine-pitch escapes that DRC
+    would accept are refused.
+
+  No new dependencies: the grids are `bytearray`, and Pillow (already required)
+  rasterises the polygons. The pathfinding core lives in
+  `python/commands/net_router.py` and imports no pcbnew, so it is unit-testable
+  without KiCad installed.
+
 ## [2.6.0] - 2026-07-28
 
 A minor bump: **10 new tools** take the registry from 136 to 146, and #343

--- a/python/commands/net_router.py
+++ b/python/commands/net_router.py
@@ -1,0 +1,257 @@
+"""Grid A* net router — the pathfinding layer under ``route_net``.
+
+``route_trace`` and ``route_pad_to_pad`` draw a trace where you tell them to.
+They do not look at what is already on the board, so the caller has to know a
+legal path before asking. For an LLM driving the board that is the hard part:
+it can see the netlist and the DRC report, but not the free space.
+
+This module supplies the missing piece — an occupancy model of the board and an
+A* search over it — with no dependency beyond Pillow, which is already required.
+Grids are ``bytearray`` rather than numpy arrays deliberately: a 100 x 80 mm
+board at 0.1 mm is ~800k cells per layer, which indexes fast enough in CPython
+and costs the project nothing new.
+
+Nothing here imports pcbnew. The board-facing glue lives in
+``commands.routing.RoutingCommands.route_net``; everything below is plain
+geometry so it can be tested without KiCad installed.
+"""
+
+from __future__ import annotations
+
+import heapq
+import math
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+Cell = Tuple[int, int, int]  # (layer_id, x, y)
+
+DIAG = math.sqrt(2.0)
+
+# 8-way movement. Diagonals cost sqrt(2) so the search does not prefer a
+# staircase of orthogonal steps over the 45-degree run a PCB actually wants.
+_NEIGHBOURS: Sequence[Tuple[int, int, float]] = (
+    (1, 0, 1.0),
+    (-1, 0, 1.0),
+    (0, 1, 1.0),
+    (0, -1, 1.0),
+    (1, 1, DIAG),
+    (1, -1, DIAG),
+    (-1, 1, DIAG),
+    (-1, -1, DIAG),
+)
+
+
+class OccupancyGrid:
+    """Per-layer maps of where a new trace on one net may and may not go.
+
+    Three maps per copper layer:
+
+    ``blocked``      cells a trace of this net cannot occupy — every other
+                     net's copper, grown by (clearance + trace_width / 2), plus
+                     rule areas that bar tracks and everything off-board.
+    ``via_blocked``  the same for vias, grown by (clearance + via_diameter / 2).
+                     A via is fatter than a trace; checking a layer change
+                     against the trace map is how a via ends up sitting a tenth
+                     of a millimetre from somebody else's copper.
+    ``target``       this net's existing copper. Reaching any of it is what
+                     "connected" means, so it is a goal, never an obstacle.
+    """
+
+    __slots__ = ("width", "height", "layers", "origin", "pitch", "blocked", "via_blocked", "target")
+
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        layers: Sequence[int],
+        origin: Tuple[int, int],
+        pitch: int,
+    ) -> None:
+        self.width = int(width)
+        self.height = int(height)
+        self.layers = list(layers)
+        self.origin = origin
+        self.pitch = int(pitch)
+        size = self.width * self.height
+        self.blocked: Dict[int, bytearray] = {L: bytearray(size) for L in self.layers}
+        self.via_blocked: Dict[int, bytearray] = {L: bytearray(size) for L in self.layers}
+        self.target: Dict[int, bytearray] = {L: bytearray(size) for L in self.layers}
+
+    # -- coordinates ------------------------------------------------------
+    def index(self, x: int, y: int) -> int:
+        return y * self.width + x
+
+    def to_cell(self, x_nm: int, y_nm: int) -> Tuple[int, int]:
+        return (
+            int(round((x_nm - self.origin[0]) / self.pitch)),
+            int(round((y_nm - self.origin[1]) / self.pitch)),
+        )
+
+    def to_nm(self, x: int, y: int) -> Tuple[int, int]:
+        return (self.origin[0] + x * self.pitch, self.origin[1] + y * self.pitch)
+
+    def in_bounds(self, x: int, y: int) -> bool:
+        return 0 <= x < self.width and 0 <= y < self.height
+
+    def is_blocked(self, layer: int, x: int, y: int) -> bool:
+        return bool(self.blocked[layer][self.index(x, y)])
+
+    def is_target(self, layer: int, x: int, y: int) -> bool:
+        return bool(self.target[layer][self.index(x, y)])
+
+    def via_fits(self, x: int, y: int) -> bool:
+        """A via punches every layer, so it must clear all of them."""
+        i = self.index(x, y)
+        return not any(self.via_blocked[L][i] for L in self.layers)
+
+    def free_cells_in(self, layer: int, cx: int, cy: int, rx: int, ry: int) -> List[Cell]:
+        """Unblocked cells in a rectangle — used to find where a pad can start.
+
+        Taking the pad centre alone fails on fine-pitch parts: on a 0.65 mm
+        pitch package the neighbouring pads' clearance covers the centre cell
+        entirely, so a centre-only terminal never enters the search even though
+        the pad is 1.5 mm long and its far end is wide open.
+        """
+        out: List[Cell] = []
+        for x in range(cx - rx, cx + rx + 1):
+            for y in range(cy - ry, cy + ry + 1):
+                if self.in_bounds(x, y) and not self.blocked[layer][self.index(x, y)]:
+                    out.append((layer, x, y))
+        return out
+
+
+def _octile(x: int, y: int, goals_xy: Sequence[Tuple[int, int]]) -> float:
+    """Admissible heuristic for 8-way movement: nearest goal, octile distance."""
+    best = float("inf")
+    for gx, gy in goals_xy:
+        dx = abs(gx - x)
+        dy = abs(gy - y)
+        lo, hi = (dx, dy) if dx < dy else (dy, dx)
+        d = (hi - lo) + lo * DIAG
+        if d < best:
+            best = d
+    return best
+
+
+def astar(
+    grid: OccupancyGrid,
+    starts: Iterable[Cell],
+    goals: Iterable[Cell],
+    layer_costs: Optional[Dict[int, float]] = None,
+    via_cost: float = 40.0,
+) -> Optional[List[Cell]]:
+    """Cheapest legal path from any start cell to any goal cell.
+
+    ``layer_costs`` is where board intent lives: make 2 oz outer copper dear and
+    an empty inner signal layer cheap and the router stops carving through the
+    power planes to save a via. ``via_cost`` is in grid steps — layer changes
+    are not free, they cost area and inductance.
+    """
+    layer_costs = layer_costs or {}
+    goal_set = set(goals)
+    if not goal_set:
+        return None
+    goals_xy = list({(g[1], g[2]) for g in goal_set})
+
+    open_heap: List[Tuple[float, float, Cell]] = []
+    best_g: Dict[Cell, float] = {}
+    came: Dict[Cell, Optional[Cell]] = {}
+
+    for s in starts:
+        if s[0] not in grid.blocked or not grid.in_bounds(s[1], s[2]):
+            continue
+        best_g[s] = 0.0
+        heapq.heappush(open_heap, (_octile(s[1], s[2], goals_xy), 0.0, s))
+        came[s] = None
+    if not open_heap:
+        return None
+
+    closed: set = set()
+    while open_heap:
+        _, g, cur = heapq.heappop(open_heap)
+        if cur in closed:
+            continue
+        closed.add(cur)
+        if cur in goal_set:
+            path: List[Cell] = []
+            node: Optional[Cell] = cur
+            while node is not None:
+                path.append(node)
+                node = came[node]
+            path.reverse()
+            return path
+
+        layer, x, y = cur
+        step_cost = layer_costs.get(layer, 1.0)
+        blocked = grid.blocked[layer]
+
+        for dx, dy, dist in _NEIGHBOURS:
+            nx, ny = x + dx, y + dy
+            if not grid.in_bounds(nx, ny):
+                continue
+            if blocked[grid.index(nx, ny)]:
+                continue
+            # A diagonal step must not squeeze between two blocked cells: on the
+            # grid it looks clear, in copper it clips the corner.
+            if dx and dy:
+                if blocked[grid.index(x + dx, y)] or blocked[grid.index(x, y + dy)]:
+                    continue
+            nxt = (layer, nx, ny)
+            if nxt in closed:
+                continue
+            ng = g + dist * step_cost
+            if ng < best_g.get(nxt, float("inf")):
+                best_g[nxt] = ng
+                came[nxt] = cur
+                heapq.heappush(open_heap, (ng + _octile(nx, ny, goals_xy), ng, nxt))
+
+        if grid.via_fits(x, y):
+            for other in grid.layers:
+                if other == layer:
+                    continue
+                nxt = (other, x, y)
+                if nxt in closed:
+                    continue
+                ng = g + via_cost
+                if ng < best_g.get(nxt, float("inf")):
+                    best_g[nxt] = ng
+                    came[nxt] = cur
+                    heapq.heappush(open_heap, (ng + _octile(x, y, goals_xy), ng, nxt))
+
+    return None
+
+
+def simplify_path(path: Sequence[Cell]) -> List[Cell]:
+    """Collapse a cell-by-cell path into corner points.
+
+    Keeps every layer change and every change of direction and drops everything
+    in between, so a straight run becomes one segment instead of a hundred.
+    """
+    if len(path) < 2:
+        return list(path)
+    out: List[Cell] = [path[0]]
+    for i in range(1, len(path) - 1):
+        pl, px, py = out[-1]
+        cl, cx, cy = path[i]
+        nl, nx, ny = path[i + 1]
+        if cl != pl or nl != cl:
+            out.append(path[i])
+            continue
+        d1 = ((cx > px) - (cx < px), (cy > py) - (cy < py))
+        d2 = ((nx > cx) - (nx < cx), (ny > cy) - (ny < cy))
+        if d1 != d2:
+            out.append(path[i])
+    out.append(path[-1])
+    return out
+
+
+def path_segments(path: Sequence[Cell]) -> Tuple[List[Tuple[Cell, Cell]], List[Cell]]:
+    """Split a simplified path into (track segments, via locations)."""
+    tracks: List[Tuple[Cell, Cell]] = []
+    vias: List[Cell] = []
+    for a, b in zip(path, path[1:]):
+        if a[0] == b[0]:
+            if a[1:] != b[1:]:
+                tracks.append((a, b))
+        else:
+            vias.append(a)
+    return tracks, vias

--- a/python/commands/routing.py
+++ b/python/commands/routing.py
@@ -550,6 +550,358 @@ class RoutingCommands:
                 "errorDetails": str(e),
             }
 
+    # ------------------------------------------------------------------
+    # route_net — obstacle-aware pathfinding
+    #
+    # route_trace and route_pad_to_pad draw a trace where the caller says.
+    # That leaves the hard part — finding a legal path — outside the server,
+    # which is exactly the part an LLM driving the board cannot see. This
+    # builds an occupancy model of the board and searches it.
+    # ------------------------------------------------------------------
+
+    def _build_occupancy(
+        self,
+        net_name,
+        layer_ids,
+        clearance_nm,
+        width_nm,
+        via_dia_nm,
+        pitch_nm,
+        relaxed_area=None,
+        relaxed_clearance_nm=None,
+        relaxed_width_nm=None,
+    ):
+        """Rasterise the board into per-layer occupancy maps for one net."""
+        from PIL import Image, ImageDraw
+
+        from commands.net_router import OccupancyGrid
+
+        bbox = self.board.GetBoardEdgesBoundingBox()
+        origin = (bbox.GetLeft(), bbox.GetTop())
+        width = int(bbox.GetWidth() / pitch_nm) + 2
+        height = int(bbox.GetHeight() / pitch_nm) + 2
+        grid = OccupancyGrid(width, height, layer_ids, origin, pitch_nm)
+
+        trace_grow = clearance_nm + width_nm // 2
+        via_grow = clearance_nm + via_dia_nm // 2
+        relaxed_grow = None
+        if relaxed_area and relaxed_clearance_nm is not None:
+            relaxed_grow = relaxed_clearance_nm + (relaxed_width_nm or width_nm) // 2
+
+        def draw(drawer, poly, grow):
+            shape = pcbnew.SHAPE_POLY_SET(poly)
+            if grow:
+                shape.Inflate(int(grow), pcbnew.CORNER_STRATEGY_CHAMFER_ALL_CORNERS, 5000)
+            shape.Fracture()
+            for oi in range(shape.OutlineCount()):
+                outline = shape.Outline(oi)
+                pts = [
+                    (
+                        (outline.CPoint(i).x - origin[0]) / pitch_nm,
+                        (outline.CPoint(i).y - origin[1]) / pitch_nm,
+                    )
+                    for i in range(outline.PointCount())
+                ]
+                if len(pts) >= 3:
+                    drawer.polygon(pts, fill=1)
+
+        def shape_of(item, layer):
+            poly = pcbnew.SHAPE_POLY_SET()
+            item.TransformShapeToPolygon(poly, layer, 0, 5000, pcbnew.ERROR_OUTSIDE)
+            return poly
+
+        # cells inside a named rule area, where a looser clearance applies —
+        # the board's .kicad_dru does this for fine-pitch packages and the
+        # router has to agree with it or it refuses legal escapes
+        relaxed_mask = None
+        if relaxed_grow is not None:
+            acc = pcbnew.SHAPE_POLY_SET()
+            for zone in self.board.Zones():
+                if zone.GetIsRuleArea() and zone.GetZoneName() == relaxed_area:
+                    acc.BooleanAdd(pcbnew.SHAPE_POLY_SET(zone.Outline()))
+            if acc.OutlineCount():
+                img = Image.new("L", (width, height), 0)
+                draw(ImageDraw.Draw(img), acc, 0)
+                relaxed_mask = img.tobytes()
+
+        for layer in layer_ids:
+            blk = Image.new("L", (width, height), 0)
+            rlx = Image.new("L", (width, height), 0)
+            via = Image.new("L", (width, height), 0)
+            tgt = Image.new("L", (width, height), 0)
+            d_blk, d_rlx, d_via, d_tgt = (
+                ImageDraw.Draw(blk),
+                ImageDraw.Draw(rlx),
+                ImageDraw.Draw(via),
+                ImageDraw.Draw(tgt),
+            )
+
+            for footprint in self.board.Footprints():
+                for pad in footprint.Pads():
+                    if layer not in pad.GetLayerSet().Seq():
+                        continue
+                    shape = shape_of(pad, layer)
+                    if pad.GetNetname() == net_name:
+                        draw(d_tgt, shape, 0)
+                    else:
+                        draw(d_blk, shape, trace_grow)
+                        draw(d_via, shape, via_grow)
+                        if relaxed_grow is not None:
+                            draw(d_rlx, shape, relaxed_grow)
+
+            for track in self.board.GetTracks():
+                if layer not in track.GetLayerSet().Seq():
+                    continue
+                shape = shape_of(track, layer)
+                if track.GetNetname() == net_name:
+                    draw(d_tgt, shape, 0)
+                else:
+                    draw(d_blk, shape, trace_grow)
+                    draw(d_via, shape, via_grow)
+                    if relaxed_grow is not None:
+                        draw(d_rlx, shape, relaxed_grow)
+
+            for zone in self.board.Zones():
+                if layer not in zone.GetLayerSet().Seq():
+                    continue
+                if zone.GetIsRuleArea():
+                    outline = pcbnew.SHAPE_POLY_SET(zone.Outline())
+                    if zone.GetDoNotAllowTracks():
+                        draw(d_blk, outline, 0)
+                        if relaxed_grow is not None:
+                            draw(d_rlx, outline, 0)
+                    if zone.GetDoNotAllowVias():
+                        draw(d_via, outline, 0)
+                    continue
+                if zone.GetNetname() == net_name:
+                    draw(d_tgt, zone.GetFilledPolysList(layer), 0)
+
+            blocked = bytearray(blk.tobytes())
+            if relaxed_mask is not None:
+                loose = rlx.tobytes()
+                for i, relaxed_here in enumerate(relaxed_mask):
+                    if relaxed_here:
+                        blocked[i] = loose[i]
+            grid.blocked[layer] = blocked
+            grid.via_blocked[layer] = bytearray(via.tobytes())
+            grid.target[layer] = bytearray(tgt.tobytes())
+
+        # everything outside the board edge is blocked on every layer
+        edge = pcbnew.SHAPE_POLY_SET()
+        self.board.GetBoardPolygonOutlines(edge)
+        edge.Deflate(
+            int(trace_grow + 500000),
+            pcbnew.CORNER_STRATEGY_CHAMFER_ALL_CORNERS,
+            5000,
+        )
+        inside_img = Image.new("L", (width, height), 0)
+        draw(ImageDraw.Draw(inside_img), edge, 0)
+        inside = inside_img.tobytes()
+        for layer in layer_ids:
+            blocked = grid.blocked[layer]
+            via_blocked = grid.via_blocked[layer]
+            for i, is_inside in enumerate(inside):
+                if not is_inside:
+                    blocked[i] = 1
+                    via_blocked[i] = 1
+        return grid
+
+    def route_net(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Route a net around existing copper instead of straight through it.
+
+        Builds an occupancy model of the board for this net and runs an A*
+        search over it, so the caller does not have to know a legal path in
+        advance. Pads already joined to the net are left alone; each remaining
+        pad is routed to the copper the net already has.
+        """
+        try:
+            if not self.board:
+                return {
+                    "success": False,
+                    "message": "No board is loaded",
+                    "errorDetails": "Load or create a board first",
+                }
+
+            from commands.net_router import astar, path_segments, simplify_path
+
+            net_name = params.get("net")
+            if not net_name:
+                return {
+                    "success": False,
+                    "message": "Missing parameter: net",
+                    "errorDetails": "Specify the net name to route",
+                }
+
+            mm = 1000000
+            layer_names = params.get("layers") or ["F.Cu", "B.Cu"]
+            layer_ids = []
+            for name in layer_names:
+                lid = self.board.GetLayerID(name)
+                if lid < 0:
+                    return {
+                        "success": False,
+                        "message": f"Unknown layer: {name}",
+                        "errorDetails": f"'{name}' is not enabled on this board",
+                    }
+                layer_ids.append(lid)
+
+            width_nm = int(float(params.get("width", 0.25)) * mm)
+            clearance_nm = int(float(params.get("clearance", 0.2)) * mm)
+            via_dia_nm = int(float(params.get("viaDiameter", 0.6)) * mm)
+            via_drill_nm = int(float(params.get("viaDrill", 0.3)) * mm)
+            pitch_nm = int(float(params.get("gridPitch", 0.1)) * mm)
+            via_cost = float(params.get("viaCost", 40.0))
+            dry_run = bool(params.get("dryRun", False))
+            only = params.get("pads")
+
+            layer_costs = {}
+            for name, cost in (params.get("layerCosts") or {}).items():
+                lid = self.board.GetLayerID(name)
+                if lid >= 0:
+                    layer_costs[lid] = float(cost)
+
+            relaxed_area = params.get("relaxedArea")
+            relaxed_clearance = params.get("relaxedClearance")
+            relaxed_width = params.get("relaxedWidth")
+
+            grid = self._build_occupancy(
+                net_name,
+                layer_ids,
+                clearance_nm,
+                width_nm,
+                via_dia_nm,
+                pitch_nm,
+                relaxed_area=relaxed_area,
+                relaxed_clearance_nm=(
+                    int(float(relaxed_clearance) * mm) if relaxed_clearance is not None else None
+                ),
+                relaxed_width_nm=(
+                    int(float(relaxed_width) * mm) if relaxed_width is not None else None
+                ),
+            )
+
+            net = None
+            terminals = []
+            for footprint in self.board.Footprints():
+                for pad in footprint.Pads():
+                    if pad.GetNetname() != net_name:
+                        continue
+                    net = pad.GetNet()
+                    ref = f"{footprint.GetReference()}.{pad.GetPadName()}"
+                    if only and ref not in only:
+                        continue
+                    pos = pad.GetPosition()
+                    cx, cy = grid.to_cell(pos.x, pos.y)
+                    rx = max(0, int(pad.GetSizeX() / 2 / pitch_nm))
+                    ry = max(0, int(pad.GetSizeY() / 2 / pitch_nm))
+                    cells = []
+                    for layer in pad.GetLayerSet().Seq():
+                        if layer in layer_ids:
+                            cells.extend(grid.free_cells_in(layer, cx, cy, rx, ry))
+                    if cells:
+                        terminals.append((ref, cells))
+
+            if net is None:
+                return {
+                    "success": False,
+                    "message": f"Net not found: {net_name}",
+                    "errorDetails": "No pad on the board carries that net name",
+                }
+            if len(terminals) < 1:
+                return {
+                    "success": False,
+                    "message": f"No reachable pads on {net_name}",
+                    "errorDetails": (
+                        "Every pad of this net is boxed in at the requested "
+                        "clearance. On fine-pitch parts this usually means the "
+                        "board's clearance rule is wider than the pad gap — see "
+                        "relaxedArea."
+                    ),
+                }
+
+            routed, failed, added_tracks, added_vias = [], [], 0, 0
+            for ref, cells in terminals:
+                start = set(cells)
+                xs = [c[1] for c in cells]
+                ys = [c[2] for c in cells]
+                x0, x1 = min(xs) - 12, max(xs) + 12
+                y0, y1 = min(ys) - 12, max(ys) + 12
+                goals = set()
+                for layer in layer_ids:
+                    tgt = grid.target[layer]
+                    for y in range(grid.height):
+                        row = y * grid.width
+                        if y0 <= y <= y1:
+                            for x in range(grid.width):
+                                if x0 <= x <= x1:
+                                    continue
+                                if tgt[row + x]:
+                                    goals.add((layer, x, y))
+                        else:
+                            for x in range(grid.width):
+                                if tgt[row + x]:
+                                    goals.add((layer, x, y))
+                goals -= start
+                if not goals:
+                    failed.append({"pad": ref, "reason": "no other copper on this net"})
+                    continue
+
+                path = astar(grid, start, goals, layer_costs, via_cost)
+                if path is None:
+                    failed.append({"pad": ref, "reason": "no legal path"})
+                    continue
+
+                simple = simplify_path(path)
+                segments, vias = path_segments(simple)
+                if not dry_run:
+                    for a, b in segments:
+                        track = pcbnew.PCB_TRACK(self.board)
+                        ax, ay = grid.to_nm(a[1], a[2])
+                        bx, by = grid.to_nm(b[1], b[2])
+                        track.SetStart(pcbnew.VECTOR2I(ax, ay))
+                        track.SetEnd(pcbnew.VECTOR2I(bx, by))
+                        track.SetWidth(width_nm)
+                        track.SetLayer(a[0])
+                        track.SetNet(net)
+                        self.board.Add(track)
+                    for v in vias:
+                        via = pcbnew.PCB_VIA(self.board)
+                        vx, vy = grid.to_nm(v[1], v[2])
+                        via.SetPosition(pcbnew.VECTOR2I(vx, vy))
+                        via.SetViaType(pcbnew.VIATYPE_THROUGH)
+                        via.SetLayerPair(layer_ids[0], layer_ids[-1])
+                        via.SetWidth(via_dia_nm)
+                        via.SetDrill(via_drill_nm)
+                        via.SetNet(net)
+                        self.board.Add(via)
+                added_tracks += len(segments)
+                added_vias += len(vias)
+                routed.append({"pad": ref, "segments": len(segments), "vias": len(vias)})
+                # the new copper is now a legal destination for the next pad
+                for cell in path:
+                    grid.target[cell[0]][grid.index(cell[1], cell[2])] = 1
+
+            return {
+                "success": True,
+                "message": (
+                    f"{net_name}: routed {len(routed)} of {len(terminals)} pad(s)"
+                    + (" (dry run)" if dry_run else "")
+                ),
+                "net": net_name,
+                "routed": routed,
+                "failed": failed,
+                "tracksAdded": added_tracks,
+                "viasAdded": added_vias,
+                "dryRun": dry_run,
+            }
+        except Exception as exc:
+            logger.error(f"Error in route_net: {str(exc)}")
+            return {
+                "success": False,
+                "message": "Failed to route net",
+                "errorDetails": str(exc),
+            }
+
     def route_arc_trace(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Route a copper arc trace from start/mid/end points."""
         try:

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -517,6 +517,7 @@ class KiCADInterface(SchematicHandlersMixin):
             # Routing commands
             "add_net": self.routing_commands.add_net,
             "route_trace": self.routing_commands.route_trace,
+            "route_net": self.routing_commands.route_net,
             "route_arc_trace": self.routing_commands.route_arc_trace,
             "add_via": self.routing_commands.add_via,
             "delete_trace": self.routing_commands.delete_trace,

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -203,8 +203,8 @@ export const toolCategories: ToolCategory[] = [
   },
   {
     name: "routing",
-    description: "Advanced routing operations: vias, copper pours",
-    tools: ["add_via", "add_copper_pour"],
+    description: "Advanced routing operations: obstacle-aware net routing, vias, copper pours",
+    tools: ["route_net", "add_via", "add_copper_pour"],
   },
   {
     name: "autoroute",

--- a/src/tools/routing.ts
+++ b/src/tools/routing.ts
@@ -503,6 +503,71 @@ export function registerRoutingTools(server: McpServer, callKicadScript: Functio
     },
   );
 
+  // Obstacle-aware net router
+  server.tool(
+    "route_net",
+    "Route a net AROUND existing copper instead of straight through it. Unlike route_trace and route_pad_to_pad — which draw a trace exactly where you tell them and will happily cross other nets — this builds an occupancy model of the board (every other net's pads, tracks, zones and rule areas, grown by clearance) and runs an A* search over it. Use it when you need a connection made but do not know a legal path, when route_trace produced a short or a DRC clearance error, or when the autorouter left a net unrouted. Pads are routed to the copper the net already has, so it also works for repairing a partially routed net.",
+    {
+      net: z.string().describe("Net name to route (e.g. 'ESTOP_SENSE')"),
+      layers: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Copper layers the router may use, in stack order (default: ['F.Cu','B.Cu']). Give it an inner signal layer if the board has one.",
+        ),
+      pads: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Route only these pads, as 'REF.PAD' (e.g. ['U2.3']). Omit to route every pad of the net. Use this to repair one connection without redrawing the whole net.",
+        ),
+      width: z.number().optional().describe("Trace width in mm (default: 0.25)"),
+      clearance: z
+        .number()
+        .optional()
+        .describe("Clearance to other nets in mm (default: 0.2). Match the board's design rules."),
+      viaDiameter: z.number().optional().describe("Via diameter in mm (default: 0.6)"),
+      viaDrill: z.number().optional().describe("Via drill in mm (default: 0.3)"),
+      viaCost: z
+        .number()
+        .optional()
+        .describe(
+          "Cost of a layer change, in grid steps (default: 40). Raise it to get flatter routes with fewer vias.",
+        ),
+      layerCosts: z
+        .record(z.number())
+        .optional()
+        .describe(
+          "Per-layer cost multipliers, e.g. {'F.Cu': 3, 'In2.Cu': 1}. Make heavy outer power copper expensive and an empty inner signal layer cheap, and the router stops carving through the planes to save a via.",
+        ),
+      relaxedArea: z
+        .string()
+        .optional()
+        .describe(
+          "Name of a rule area inside which a looser clearance applies — mirror the board's .kicad_dru so the router agrees with DRC. Needed to escape fine-pitch packages, where the pad gap is narrower than the board's global clearance.",
+        ),
+      relaxedClearance: z
+        .number()
+        .optional()
+        .describe("Clearance in mm inside relaxedArea (e.g. 0.13)"),
+      relaxedWidth: z.number().optional().describe("Trace width in mm inside relaxedArea"),
+      gridPitch: z
+        .number()
+        .optional()
+        .describe("Search grid resolution in mm (default: 0.1). Finer is slower."),
+      dryRun: z
+        .boolean()
+        .optional()
+        .describe("Report what it would route without adding any copper (default: false)"),
+    },
+    async (args: any) => {
+      const result = await callKicadScript("route_net", args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
   // Copy routing pattern tool
   server.tool(
     "copy_routing_pattern",

--- a/tests/test_net_router.py
+++ b/tests/test_net_router.py
@@ -1,0 +1,168 @@
+"""Tests for the grid A* net router behind ``route_net``.
+
+The board-facing glue in ``RoutingCommands.route_net`` is a thin wrapper over
+these functions, so the pathfinding contract is what gets pinned here: it runs
+without pcbnew, without Pillow and without a board.
+
+Each test locks in a behaviour that is wrong in an obvious first implementation
+and expensive to notice on real copper.
+"""
+
+import sys
+from pathlib import Path
+
+PYTHON_DIR = Path(__file__).parent.parent / "python"
+sys.path.insert(0, str(PYTHON_DIR))
+
+from commands.net_router import (  # noqa: E402
+    OccupancyGrid,
+    astar,
+    path_segments,
+    simplify_path,
+)
+
+F_CU = 0
+B_CU = 2
+
+
+def _grid(width=40, height=40, layers=(F_CU, B_CU)):
+    return OccupancyGrid(width, height, list(layers), (0, 0), 100_000)
+
+
+def _block(grid, layer, x0, y0, x1, y1, vias_too=True):
+    for x in range(x0, x1 + 1):
+        for y in range(y0, y1 + 1):
+            grid.blocked[layer][grid.index(x, y)] = 1
+            if vias_too:
+                grid.via_blocked[layer][grid.index(x, y)] = 1
+
+
+class TestCoordinates:
+    def test_cell_and_nm_round_trip(self):
+        grid = OccupancyGrid(10, 10, [F_CU], (1_000_000, 2_000_000), 100_000)
+        assert grid.to_cell(1_500_000, 2_500_000) == (5, 5)
+        assert grid.to_nm(5, 5) == (1_500_000, 2_500_000)
+
+    def test_out_of_bounds_is_rejected(self):
+        grid = _grid()
+        assert not grid.in_bounds(-1, 0)
+        assert not grid.in_bounds(0, 40)
+
+
+class TestAStar:
+    def test_finds_a_path_across_open_space(self):
+        grid = _grid()
+        path = astar(grid, [(F_CU, 2, 2)], [(F_CU, 30, 30)])
+        assert path is not None
+        assert path[0] == (F_CU, 2, 2)
+        assert path[-1] == (F_CU, 30, 30)
+
+    def test_routes_around_an_obstacle_rather_than_through_it(self):
+        grid = _grid()
+        _block(grid, F_CU, 10, 0, 10, 30)  # wall with a gap at the bottom
+        path = astar(grid, [(F_CU, 2, 2)], [(F_CU, 20, 2)])
+        assert path is not None
+        assert all(not grid.is_blocked(*cell) for cell in path)
+        # it had to detour past the end of the wall
+        assert max(c[2] for c in path) > 30
+
+    def test_returns_none_when_fully_enclosed(self):
+        grid = _grid()
+        _block(grid, F_CU, 5, 3, 9, 3)
+        _block(grid, F_CU, 5, 7, 9, 7)
+        _block(grid, F_CU, 5, 3, 5, 7)
+        _block(grid, F_CU, 9, 3, 9, 7)
+        for layer in (F_CU, B_CU):
+            _block(grid, layer, 6, 4, 8, 6, vias_too=True)
+            for x in range(6, 9):
+                for y in range(4, 7):
+                    grid.blocked[layer][grid.index(x, y)] = 0
+        assert astar(grid, [(F_CU, 7, 5)], [(F_CU, 30, 30)]) is None
+
+    def test_changes_layer_to_get_past_a_full_height_wall(self):
+        grid = _grid()
+        _block(grid, F_CU, 10, 0, 10, 39, vias_too=False)
+        path = astar(grid, [(F_CU, 2, 2)], [(F_CU, 20, 2)])
+        assert path is not None
+        assert {c[0] for c in path} == {F_CU, B_CU}
+
+    def test_a_via_must_clear_every_layer_not_just_two(self):
+        """A via punches the whole stack, so one blocked layer forbids it."""
+        grid = _grid()
+        _block(grid, F_CU, 10, 0, 10, 39, vias_too=False)
+        for x in range(grid.width):
+            for y in range(grid.height):
+                grid.via_blocked[B_CU][grid.index(x, y)] = 1
+        assert astar(grid, [(F_CU, 2, 2)], [(F_CU, 20, 2)]) is None
+
+    def test_diagonal_step_cannot_squeeze_between_two_blocked_cells(self):
+        """On the grid it looks clear; in copper it clips the corner."""
+        grid = _grid(layers=(F_CU,))
+        _block(grid, F_CU, 6, 5, 6, 5)
+        _block(grid, F_CU, 5, 6, 5, 6)
+        path = astar(grid, [(F_CU, 5, 5)], [(F_CU, 6, 6)])
+        assert path is not None
+        assert (F_CU, 5, 5) in path and (F_CU, 6, 6) in path
+        # the direct diagonal is the corner cut, so the path must be longer
+        assert len(path) > 2
+
+    def test_layer_cost_steers_the_route(self):
+        grid = _grid()
+        cheap = astar(grid, [(F_CU, 2, 2)], [(B_CU, 20, 2)], {F_CU: 1.0, B_CU: 1.0}, 5.0)
+        assert cheap is not None
+        # make the far layer expensive and the via cheap: it should still get
+        # there, but a high layer cost must not break reachability
+        dear = astar(grid, [(F_CU, 2, 2)], [(B_CU, 20, 2)], {B_CU: 50.0}, 5.0)
+        assert dear is not None
+        assert dear[-1][0] == B_CU
+
+    def test_no_goals_is_not_an_error(self):
+        assert astar(_grid(), [(F_CU, 1, 1)], []) is None
+
+
+class TestPadTerminals:
+    def test_free_cells_finds_the_open_end_of_a_boxed_in_pad(self):
+        """Fine-pitch escape: the centre is covered, the far end is not.
+
+        On a 0.65 mm pitch package the neighbouring pads' clearance covers the
+        centre cell, so a centre-only terminal never enters the search even
+        though the pad is long and its far end is wide open.
+        """
+        grid = _grid()
+        _block(grid, F_CU, 18, 20, 20, 20)  # covers the pad centre at (20,20)
+        cells = grid.free_cells_in(F_CU, 20, 20, 4, 0)
+        assert cells, "a pad this long must still offer somewhere to start"
+        assert all(not grid.is_blocked(*c) for c in cells)
+        assert (F_CU, 21, 20) in cells
+
+
+class TestSimplify:
+    def test_straight_run_becomes_two_points(self):
+        path = [(F_CU, x, 0) for x in range(10)]
+        assert simplify_path(path) == [(F_CU, 0, 0), (F_CU, 9, 0)]
+
+    def test_corner_is_kept(self):
+        path = [(F_CU, x, 0) for x in range(5)] + [(F_CU, 4, y) for y in range(1, 5)]
+        simple = simplify_path(path)
+        assert (F_CU, 4, 0) in simple
+        assert len(simple) == 3
+
+    def test_layer_change_is_kept(self):
+        path = [(F_CU, 0, 0), (F_CU, 1, 0), (B_CU, 1, 0), (B_CU, 2, 0)]
+        assert simplify_path(path) == path
+
+    def test_short_paths_pass_through(self):
+        assert simplify_path([(F_CU, 0, 0)]) == [(F_CU, 0, 0)]
+        assert simplify_path([]) == []
+
+
+class TestSegments:
+    def test_splits_tracks_from_vias(self):
+        path = [(F_CU, 0, 0), (F_CU, 5, 0), (B_CU, 5, 0), (B_CU, 5, 5)]
+        tracks, vias = path_segments(path)
+        assert len(tracks) == 2
+        assert vias == [(F_CU, 5, 0)]
+
+    def test_zero_length_segments_are_dropped(self):
+        tracks, vias = path_segments([(F_CU, 3, 3), (F_CU, 3, 3)])
+        assert tracks == [] and vias == []


### PR DESCRIPTION
## The gap

`route_trace` and `route_pad_to_pad` draw a trace exactly where they are told. That leaves finding a legal path outside the server — which, for an LLM driving a board, is the hard part. It can read the netlist and the DRC report, but it cannot see the free space.

The only obstacle-aware option today is the Freerouting wrapper, and that is all-or-nothing: you hand it the whole board and take what comes back. There is nothing in between for "make this one connection, legally, and tell me if you can't."

(For what it's worth, Konnect has the same shape — `route_pad_to_pad` is L-bend geometry and `autoroute` wraps Freerouting — so this may be worth porting if the Rust rebuild wants it.)

## What this adds

`route_net` builds a per-layer occupancy model of the board — every other net's pads, tracks, zones and rule areas, grown by clearance — and runs A* over it, for one net, on demand. Pads are routed to whatever copper the net already has, so it repairs a partially routed net as well as building one.

```jsonc
{
  "net": "ESTOP_SENSE",
  "layers": ["F.Cu", "In2.Cu", "B.Cu"],
  "layerCosts": { "F.Cu": 3, "In2.Cu": 1, "B.Cu": 3 },
  "clearance": 0.2,
  "width": 0.26,
  "dryRun": true
}
```

`pads: ["U2.3"]` restricts it to one connection, which is the common repair case.

## Details that are wrong in the obvious implementation

Each of these is pinned by a test. They are all cheap to get wrong and expensive to notice on real copper:

- **Vias get their own occupancy map.** A via is fatter than a trace; checking a layer change against the trace map is how one lands a tenth of a millimetre from another net. A via also punches the whole stack, so it must clear *every* layer, not the two it nominally joins.
- **A diagonal step may not squeeze between two blocked cells.** On the grid it looks clear; in copper it clips the corner.
- **A pad terminal is every free cell inside the pad, not its centre.** On a 0.65 mm pitch package the neighbours' clearance covers the centre cell, so a centre-only terminal never enters the search — even though the pad is 1.5 mm long and its far end is wide open.
- **Per-layer costs**, so heavy outer copper can be made expensive and an empty inner signal layer cheap. Without it the router carves through power planes to save a via.
- **`relaxedArea` mirrors a `.kicad_dru` rule area** so the router agrees with DRC about local clearance. Without it, fine-pitch escapes that DRC would accept are refused.

## No new dependencies

Grids are `bytearray`; Pillow (already required) rasterises the polygons. numpy is deliberately not introduced — a 100×80 mm board at 0.1 mm is ~800k cells per layer, which indexes fast enough in CPython. Occupancy for a 4-layer board of that size builds in about 0.2 s.

The pathfinding core is `python/commands/net_router.py` and imports no pcbnew, so the new tests run under the existing conftest stub without KiCad installed.

## Validation

Exercised through `RoutingCommands` on a real 4-layer board (100×80 mm, 177 footprints, 49 A resonant power stage):

- routed **5 of 6 open pads** on a net Freerouting had left unrouted
- correctly reported `no legal path` for a pad whose only escape corridor is 0.3 mm tall — too narrow for a via. That is a placement problem, and the tool says so rather than drawing something illegal.

## Checks

- `npm run build` — clean
- `pytest tests/test_net_router.py` — 17 passed
- full `pytest tests/` — no new failures (14 pre-existing failures on `v2.6.0` are unchanged; verified by stashing this branch and re-running)
- `black`, `isort`, `flake8`, `mypy` clean on the new and edited files
- `eslint`, `prettier` clean

Registered in the `routing` category and dispatched as `route_net`.