### PR TITLE
fix(setup): detect KiCAD on any drive and pin bundled Python for v10

### DIFF
--- a/setup-windows-opencode.ps1
+++ b/setup-windows-opencode.ps1
@@ -167,6 +167,10 @@ function Find-KiCadInstallation {
             }
             if ($entry.DisplayIcon) {
                 $iconDir = Split-Path -Parent ([string]$entry.DisplayIcon).Trim('"')
+                if ($iconDir -and (Split-Path -Leaf $iconDir) -eq 'bin') {
+                    # DisplayIcon points at <root>\bin\kicad.exe; probe the version root, not the bin dir.
+                    $iconDir = Split-Path -Parent $iconDir
+                }
                 if ($iconDir) {
                     $candidateRoots += $iconDir
                 }
@@ -234,6 +238,7 @@ function Get-KiCadInfo {
         return $null
     }
 
+    # Keep candidate probing in sync with Get-KiCadInfo in setup-windows.ps1.
     $pythonExeCandidates = @(
         (Join-Path $Root 'bin\python.exe'),
         (Join-Path $Root 'bin\Python.exe')

--- a/setup-windows-opencode.ps1
+++ b/setup-windows-opencode.ps1
@@ -150,6 +150,49 @@ function Find-KiCadInstallation {
         return $null
     }
 
+    $uninstallRoots = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall'
+    )
+
+    foreach ($uninstallRoot in $uninstallRoots) {
+        $entries = Get-ItemProperty (Join-Path $uninstallRoot '*') -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -match '^KiCad' }
+
+        foreach ($entry in $entries) {
+            $candidateRoots = @()
+            if ($entry.InstallLocation) {
+                $candidateRoots += [string]$entry.InstallLocation
+            }
+            if ($entry.DisplayIcon) {
+                $iconDir = Split-Path -Parent ([string]$entry.DisplayIcon).Trim('"')
+                if ($iconDir) {
+                    $candidateRoots += $iconDir
+                }
+            }
+
+            foreach ($root in ($candidateRoots | Select-Object -Unique)) {
+                $info = Get-KiCadInfo -Root $root
+                if ($info) {
+                    return $info
+                }
+            }
+        }
+    }
+
+    foreach ($var in (Get-ChildItem env: -ErrorAction SilentlyContinue)) {
+        if ($var.Name -match '^KICAD\d+_' -and $var.Value) {
+            $shareIndex = $var.Value.IndexOf('\share\kicad')
+            if ($shareIndex -gt 0) {
+                $info = Get-KiCadInfo -Root $var.Value.Substring(0, $shareIndex)
+                if ($info) {
+                    return $info
+                }
+            }
+        }
+    }
+
     $basePaths = @(
         'C:\Program Files\KiCad',
         'C:\Program Files (x86)\KiCad',
@@ -288,6 +331,7 @@ function Set-McpEntry {
         [string]$ServerName,
         [string]$DistPath,
         [string]$PythonPath,
+        [string]$PythonExe,
         [string]$Backend
     )
 
@@ -305,6 +349,10 @@ function Set-McpEntry {
 
     if ($PythonPath) {
         $environment['PYTHONPATH'] = $PythonPath
+    }
+
+    if ($PythonExe) {
+        $environment['KICAD_PYTHON'] = $PythonExe
     }
 
     $Config['mcp'][$ServerName] = [ordered]@{
@@ -577,7 +625,8 @@ if (-not $Force) {
 if ($canGenerate) {
     $config = Read-OpenCodeConfig -Path $TargetConfigPath
     $pythonPath = if ($kicad) { $kicad.PythonLib } else { '' }
-    Set-McpEntry -Config $config -ServerName $Name -DistPath $DistPath -PythonPath $pythonPath -Backend $Backend
+    $pythonExe = if ($kicad) { $kicad.PythonExe } else { '' }
+    Set-McpEntry -Config $config -ServerName $Name -DistPath $DistPath -PythonPath $pythonPath -PythonExe $pythonExe -Backend $Backend
     $script:Results.ConfigReady = $true
 
     Write-Success "OpenCode MCP entry prepared for server name '$Name'."

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -72,6 +72,9 @@ $script:Results = @{
 # Get script directory (project root)
 $ProjectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 
+# KiCAD version directories to probe under an install root, newest first.
+$script:KnownVersions = @('10.0', '9.1', '9.0', '8.0')
+
 Write-Step "Step 1: Detecting KiCAD Installation"
 
 # Function to inspect a candidate KiCAD root and return install info if valid
@@ -91,24 +94,31 @@ function Get-KiCadInfo {
         ForEach-Object { $_.FullName })
 
     foreach ($dir in ($versionDirs | Select-Object -Unique)) {
-        $pythonExe = Join-Path $dir "bin\python.exe"
-        if (Test-Path -LiteralPath $pythonExe) {
-            $pythonLibCandidates = @(
-                (Join-Path $dir "lib\python3\dist-packages"),
-                (Join-Path $dir "bin\Lib\site-packages")
-            )
-            $pythonLib = $pythonLibCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
-            if (-not $pythonLib) {
-                $pythonLib = $pythonLibCandidates[0]
-            }
+        # Keep candidate probing in sync with Get-KiCadInfo in setup-windows-opencode.ps1.
+        $pythonExeCandidates = @(
+            (Join-Path $dir "bin\python.exe"),
+            (Join-Path $dir "bin\Python.exe")
+        )
+        $pythonExe = $pythonExeCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+        if (-not $pythonExe) {
+            continue
+        }
 
-            Write-Success "Found KiCAD $((Split-Path -Leaf $dir)) at: $dir"
-            return @{
-                Path = $dir
-                Version = Split-Path -Leaf $dir
-                PythonExe = $pythonExe
-                PythonLib = $pythonLib
-            }
+        $pythonLibCandidates = @(
+            (Join-Path $dir "lib\python3\dist-packages"),
+            (Join-Path $dir "bin\Lib\site-packages")
+        )
+        $pythonLib = $pythonLibCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+        if (-not $pythonLib) {
+            $pythonLib = $pythonLibCandidates[0]
+        }
+
+        Write-Success "Found KiCAD $((Split-Path -Leaf $dir)) at: $dir"
+        return @{
+            Path = $dir
+            Version = Split-Path -Leaf $dir
+            PythonExe = $pythonExe
+            PythonLib = $pythonLib
         }
     }
 
@@ -117,8 +127,6 @@ function Get-KiCadInfo {
 
 # Function to find KiCAD installation on any drive (registry + env vars + standard paths)
 function Find-KiCAD {
-    $script:KnownVersions = @("10.0", "9.1", "9.0", "8.0")
-
     # 1. Registry uninstall keys - covers any install drive, both all-users and per-user installs
     $uninstallRoots = @(
         "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
@@ -137,6 +145,10 @@ function Find-KiCAD {
             }
             if ($entry.DisplayIcon) {
                 $iconDir = Split-Path -Parent ([string]$entry.DisplayIcon).Trim('"')
+                if ($iconDir -and (Split-Path -Leaf $iconDir) -eq 'bin') {
+                    # DisplayIcon points at <root>\bin\kicad.exe; probe the version root, not the bin dir.
+                    $iconDir = Split-Path -Parent $iconDir
+                }
                 if ($iconDir) {
                     $candidateRoots += $iconDir
                 }

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -74,31 +74,112 @@ $ProjectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 Write-Step "Step 1: Detecting KiCAD Installation"
 
-# Function to find KiCAD installation
+# Function to inspect a candidate KiCAD root and return install info if valid
+function Get-KiCadInfo {
+    param([string]$Root)
+
+    if (-not $Root -or -not (Test-Path -LiteralPath $Root)) {
+        return $null
+    }
+
+    $versionDirs = @($Root)
+    foreach ($version in $script:KnownVersions) {
+        $versionDirs += (Join-Path $Root $version)
+    }
+    $versionDirs += (Get-ChildItem -LiteralPath $Root -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match '^\d+\.\d+' } |
+        ForEach-Object { $_.FullName })
+
+    foreach ($dir in ($versionDirs | Select-Object -Unique)) {
+        $pythonExe = Join-Path $dir "bin\python.exe"
+        if (Test-Path -LiteralPath $pythonExe) {
+            $pythonLibCandidates = @(
+                (Join-Path $dir "lib\python3\dist-packages"),
+                (Join-Path $dir "bin\Lib\site-packages")
+            )
+            $pythonLib = $pythonLibCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+            if (-not $pythonLib) {
+                $pythonLib = $pythonLibCandidates[0]
+            }
+
+            Write-Success "Found KiCAD $((Split-Path -Leaf $dir)) at: $dir"
+            return @{
+                Path = $dir
+                Version = Split-Path -Leaf $dir
+                PythonExe = $pythonExe
+                PythonLib = $pythonLib
+            }
+        }
+    }
+
+    return $null
+}
+
+# Function to find KiCAD installation on any drive (registry + env vars + standard paths)
 function Find-KiCAD {
+    $script:KnownVersions = @("10.0", "9.1", "9.0", "8.0")
+
+    # 1. Registry uninstall keys - covers any install drive, both all-users and per-user installs
+    $uninstallRoots = @(
+        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+        "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+        "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
+    )
+
+    foreach ($uninstallRoot in $uninstallRoots) {
+        $entries = Get-ItemProperty (Join-Path $uninstallRoot "*") -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -match '^KiCad' }
+
+        foreach ($entry in $entries) {
+            $candidateRoots = @()
+            if ($entry.InstallLocation) {
+                $candidateRoots += [string]$entry.InstallLocation
+            }
+            if ($entry.DisplayIcon) {
+                $iconDir = Split-Path -Parent ([string]$entry.DisplayIcon).Trim('"')
+                if ($iconDir) {
+                    $candidateRoots += $iconDir
+                }
+            }
+
+            foreach ($root in ($candidateRoots | Select-Object -Unique)) {
+                $info = Get-KiCadInfo -Root $root
+                if ($info) {
+                    return $info
+                }
+            }
+        }
+    }
+
+    # 2. Environment variables set by the KiCad installer (e.g. KICAD10_3DMOD_DIR)
+    $envRoots = @()
+    foreach ($var in (Get-ChildItem env: -ErrorAction SilentlyContinue)) {
+        if ($var.Name -match '^KICAD\d+_' -and $var.Value) {
+            $shareIndex = $var.Value.IndexOf('\share\kicad')
+            if ($shareIndex -gt 0) {
+                $envRoots += $var.Value.Substring(0, $shareIndex)
+            }
+        }
+    }
+
+    foreach ($root in ($envRoots | Select-Object -Unique)) {
+        $info = Get-KiCadInfo -Root $root
+        if ($info) {
+            return $info
+        }
+    }
+
+    # 3. Fallback: standard installation locations
     $possiblePaths = @(
         "C:\Program Files\KiCad",
-        "C:\Program Files (x86)\KiCad"
+        "C:\Program Files (x86)\KiCad",
         "$env:USERPROFILE\AppData\Local\Programs\KiCad"
     )
 
-    $versions = @("9.0", "9.1", "10.0", "8.0")
-
     foreach ($basePath in $possiblePaths) {
-        foreach ($version in $versions) {
-            $kicadPath = Join-Path $basePath $version
-            $pythonExe = Join-Path $kicadPath "bin\python.exe"
-            $pythonLib = Join-Path $kicadPath "lib\python3\dist-packages"
-
-            if (Test-Path $pythonExe) {
-                Write-Success "Found KiCAD $version at: $kicadPath"
-                return @{
-                    Path = $kicadPath
-                    Version = $version
-                    PythonExe = $pythonExe
-                    PythonLib = $pythonLib
-                }
-            }
+        $info = Get-KiCadInfo -Root $basePath
+        if ($info) {
+            return $info
         }
     }
 
@@ -114,8 +195,8 @@ if ($kicad) {
     Write-Info "KiCAD Version: $($kicad.Version)"
     Write-Info "Python Path: $($kicad.PythonLib)"
 } else {
-    Write-Error-Custom "KiCAD not found in standard locations"
-    Write-Warning-Custom "Checked: C:\Program Files, C:\Program Files (x86), and $env:USERPROFILE\AppData\Local\Programs"
+    Write-Error-Custom "KiCAD not found (checked registry, environment variables, and standard locations)"
+    Write-Warning-Custom "Checked: registry uninstall keys, KICAD*_* env vars, C:\Program Files, C:\Program Files (x86), and $env:USERPROFILE\AppData\Local\Programs"
     Write-Warning-Custom "Please install KiCAD 9.0+ from https://www.kicad.org/download/windows/"
     $script:Results.Errors += "KiCAD not found"
 }
@@ -257,6 +338,7 @@ Write-Step "Step 8: Generating Configuration"
 if ($kicad -and $script:Results.ProjectBuilt) {
     $distPath = Join-Path $ProjectRoot "dist\index.js"
     $distPathEscaped = $distPath -replace '\\', '\\'
+    $pythonExeEscaped = $kicad.PythonExe -replace '\\', '\\'
     $pythonLibEscaped = $kicad.PythonLib -replace '\\', '\\'
 
     $config = @"
@@ -267,6 +349,7 @@ if ($kicad -and $script:Results.ProjectBuilt) {
       "args": ["$distPathEscaped"],
       "env": {
         "PYTHONPATH": "$pythonLibEscaped",
+        "KICAD_PYTHON": "$pythonExeEscaped",
         "NODE_ENV": "production",
         "LOG_LEVEL": "info"
       }
@@ -316,6 +399,7 @@ if ($kicad -and $script:Results.ProjectBuilt) {
     Write-Info "Testing server startup..."
 
     $env:PYTHONPATH = $kicad.PythonLib
+    $env:KICAD_PYTHON = $kicad.PythonExe
     $distPath = Join-Path $ProjectRoot "dist\index.js"
 
     # Start the server process


### PR DESCRIPTION
Fixes two issues with the Windows setup scripts for KiCAD 10:

1. **KiCAD detection no longer assumes C: drive.** All-users installs can land on any drive; detection now queries registry uninstall keys (InstallLocation/DisplayIcon) and KICAD*_* environment variables before falling back to the standard paths.

2. **KiCAD 10 must use the bundled python from its install directory.** Generated MCP configs now set KICAD_PYTHON to the detected bin\\python.exe, and site-packages falls back to bin\\Lib\\site-packages when lib\\python3\\dist-packages is absent (the KiCad 10 layout).

Verified on a machine with KiCAD 10.0 at D:\Program Files\KiCad (detected via registry, pcbnew import works).