### PR TITLE
Fix schematic corruption on quoted property values, and nets dropped during board sync

### DIFF
--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -14,7 +14,12 @@ import uuid
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from utils.sexpr_format import QUOTED_VALUE, QUOTED_VALUE_SKIP, unescape_sexpr_string
+from utils.sexpr_format import (
+    QUOTED_VALUE,
+    QUOTED_VALUE_SKIP,
+    escape_sexpr_string,
+    unescape_sexpr_string,
+)
 
 logger = logging.getLogger("kicad_interface")
 
@@ -1013,10 +1018,19 @@ class DynamicSymbolLoader:
             """Build a KiCad-10 (property ...) block.
 
             Field order: at, [hide yes], show_name no, do_not_autoplace no, effects.
+
+            ``value`` arrives unescaped -- _extract_lib_property_value() runs the
+            library text through unescape_sexpr_string(), and caller-supplied
+            values are plain Python strings. Re-escape it here, or a value
+            containing a quote terminates the token early and corrupts every
+            following s-expression in the file. The stock power:VCC / power:GND
+            Description fields ('...global label with name "VCC"') hit this, so
+            the damage lands on ordinary schematics, not just exotic input.
             """
             hide_line = "      (hide yes)\n" if hide else ""
+            safe_value = escape_sexpr_string("" if value is None else str(value))
             return (
-                f'    (property "{name}" "{value}"\n'
+                f'    (property "{name}" "{safe_value}"\n'
                 f"      (at {_fmt(px)} {_fmt(py)} {_fmt(pa)})\n"
                 f"{hide_line}"
                 f"      (show_name no)\n"

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -246,6 +246,11 @@ class SchematicHandlersMixin:
             x = component.get("x", 0)
             y = component.get("y", 0)
             unit = component.get("unit", 1)
+            # The TS tool layer always sends these two (defaulting to 0/False);
+            # not reading them here silently ignored the documented `angle` and
+            # `mirrorY` arguments, so every symbol was placed unrotated.
+            angle = component.get("angle", 0)
+            mirror_y = component.get("mirrorY", False)
 
             # Derive project path from schematic path for project-local library resolution.
             # Walk up from the schematic file to find the directory that owns the project
@@ -270,6 +275,8 @@ class SchematicHandlersMixin:
                 x=x,
                 y=y,
                 unit=unit,
+                angle=angle,
+                mirror_y=mirror_y,
                 project_path=derived_project_path,
             )
 
@@ -2809,11 +2816,18 @@ class SchematicHandlersMixin:
                     except Exception:
                         pass
 
-            # Power symbols (#PWR / #FLG): value property IS the net name; use pin 1 pos
+            # Power symbols (#PWR): value property IS the net name; use pin 1 pos.
+            #
+            # #FLG (PWR_FLAG) is deliberately excluded. Its Value is the literal
+            # string "PWR_FLAG" — a marker for ERC, not a net name. Treating it
+            # as one invents a bogus "PWR_FLAG" net and, worse, stamps that name
+            # onto the flag's pin, from where the BFS below can propagate it over
+            # a real net. A PWR_FLAG takes whatever net it is wired to; it never
+            # names one.
             for sym in getattr(sch, "symbol", None) or []:
                 try:
                     ref = sym.property.Reference.value
-                    if not (ref.startswith("#PWR") or ref.startswith("#FLG")):
+                    if not ref.startswith("#PWR"):
                         continue
                     net_name = sym.property.Value.value
                     if not net_name:
@@ -2865,20 +2879,89 @@ class SchematicHandlersMixin:
                         visited.add(neighbor)
                         queue.append(neighbor)
 
-            # ── 3. Match component pin positions to net names ────────────────
+            # ── 3. Collect real (non-power) symbol pins with their positions ──
+            sym_pins = []  # (ref, lib_id, pin_num, (px, py))
             for sym in getattr(sch, "symbol", None) or []:
                 try:
                     ref = sym.property.Reference.value
                     if ref.startswith("#"):
                         continue
+                    lib_id = sym.lib_id.value if hasattr(sym, "lib_id") else ""
                 except Exception:
                     continue
 
                 pin_positions = pin_locator.get_all_symbol_pins(sch_path, ref)
                 for pin_num, (px, py) in pin_positions.items():
-                    net = nearby_net((px, py), point_net)
-                    if net:
-                        pad_net_map[(ref, pin_num)] = net
+                    sym_pins.append((ref, lib_id, pin_num, (px, py)))
+
+            # ── 3b. Auto-name wire clusters that carry no label ──────────────
+            # A net formed only by a wire between two component pins — no net
+            # label, no power symbol — was named by nothing above. KiCad
+            # synthesises a name for it during F8 ("Net-(D1-A)"); without that
+            # these pads reach the board with no net at all and the connection
+            # is silently dropped from the layout, leaving pads that look placed
+            # but are unroutable.
+            #
+            # Step 2's BFS floods a name across every point of a connected wire
+            # cluster, so a cluster is either wholly named or wholly unnamed —
+            # which is why testing the seed point alone is sufficient here.
+            def _pin_label(lib_id: str, pin_num: str) -> str:
+                """KiCad-style pin token for an auto net name: pin name if the
+                symbol gives it a meaningful one, else PadN."""
+                try:
+                    pins = pin_locator.get_symbol_pins(sch_path, lib_id) or {}
+                    name = (pins.get(pin_num) or {}).get("name", "") or ""
+                    if name and name != "~":
+                        return name
+                except Exception:
+                    pass
+                return f"Pad{pin_num}"
+
+            def _pin_sort_key(item):
+                ref, pin_num, _lib = item
+                try:
+                    return (ref, 0, int(pin_num), "")
+                except (TypeError, ValueError):
+                    return (ref, 1, 0, str(pin_num))
+
+            clustered = set()
+            for seed in sorted(all_wire_pts):
+                if seed in point_net or seed in clustered:
+                    continue
+                cluster = set()
+                stack = [seed]
+                clustered.add(seed)
+                while stack:
+                    cur = stack.pop()
+                    cluster.add(cur)
+                    for neighbor in point_adj[cur]:
+                        if neighbor not in clustered:
+                            clustered.add(neighbor)
+                            stack.append(neighbor)
+
+                members = sorted(
+                    (
+                        (ref, pin_num, lib_id)
+                        for ref, lib_id, pin_num, (px, py) in sym_pins
+                        if snap(px, py) in cluster
+                    ),
+                    key=_pin_sort_key,
+                )
+                # A single pin on a wire stub is not a connection worth naming.
+                if len(members) < 2:
+                    continue
+
+                ref0, pin0, lib0 = members[0]
+                auto_name = f"Net-({ref0}-{_pin_label(lib0, pin0)})"
+                for pt in cluster:
+                    point_net[pt] = auto_name
+                all_net_names.add(auto_name)
+
+            # ── 3c. Match component pin positions to net names ───────────────
+            for ref, _lib_id, pin_num, (px, py) in sym_pins:
+                net = nearby_net((px, py), point_net)
+                if net:
+                    pad_net_map[(ref, pin_num)] = net
 
         logger.info(
             f"_build_hierarchical_pad_net_map: {len(pad_net_map)} pin→net assignments, "

--- a/tests/test_add_schematic_component.py
+++ b/tests/test_add_schematic_component.py
@@ -40,6 +40,18 @@ def _unit_values_in_file(path: Path) -> list[int]:
     ]
 
 
+def _instance_angles_in_file(path: Path) -> list[float]:
+    """Return the rotation from each symbol instance's (at x y angle)."""
+    content = path.read_text(encoding="utf-8")
+    return [
+        float(a)
+        for a in re.findall(
+            r"\(symbol \(lib_id [^)]+\) \(at [\d.-]+ [\d.-]+ ([\d.-]+)\)",
+            content,
+        )
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Unit tests – create_component_instance
 # ---------------------------------------------------------------------------
@@ -194,6 +206,49 @@ class TestHandlerAddSchematicComponent:
         assert result["success"] is True
         units = _unit_values_in_file(sch)
         assert 2 in units
+
+    # -- angle / mirrorY plumbing ------------------------------------------
+    #
+    # create_component_instance has always accepted angle and mirror_y, and the
+    # TS tool layer has always sent them, but the handler in between read
+    # neither — so both documented arguments were silently discarded and every
+    # symbol landed unrotated.
+
+    def _place_with(self, sch: Path, **extra: Any) -> dict:
+        component = {
+            "library": "Device",
+            "type": "R",
+            "reference": "R1",
+            "value": "1k",
+            "x": 100,
+            "y": 100,
+        }
+        component.update(extra)
+        return self._call_handler({"schematicPath": str(sch), "component": component})
+
+    def test_angle_defaults_to_zero_in_handler(self, tmp_path: Any) -> None:
+        sch = tmp_path / "test.kicad_sch"
+        shutil.copy(EMPTY_SCH, sch)
+        assert self._place_with(sch)["success"] is True
+        assert _instance_angles_in_file(sch) == [0]
+
+    def test_angle_passed_through_handler(self, tmp_path: Any) -> None:
+        sch = tmp_path / "test.kicad_sch"
+        shutil.copy(EMPTY_SCH, sch)
+        assert self._place_with(sch, angle=90)["success"] is True
+        assert _instance_angles_in_file(sch) == [90]
+
+    def test_mirror_y_passed_through_handler(self, tmp_path: Any) -> None:
+        sch = tmp_path / "test.kicad_sch"
+        shutil.copy(EMPTY_SCH, sch)
+        assert self._place_with(sch, mirrorY=True)["success"] is True
+        assert "(mirror y)" in sch.read_text(encoding="utf-8")
+
+    def test_mirror_y_absent_by_default(self, tmp_path: Any) -> None:
+        sch = tmp_path / "test.kicad_sch"
+        shutil.copy(EMPTY_SCH, sch)
+        assert self._place_with(sch)["success"] is True
+        assert "(mirror y)" not in sch.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hierarchical_pad_net_map.py
+++ b/tests/test_hierarchical_pad_net_map.py
@@ -50,6 +50,26 @@ _LIB_SYMBOLS_BLOCK = textwrap.dedent("""\
             )
           )
         )
+        (symbol "TestLib:PWR"
+          (symbol "TestLib:PWR_1_1"
+            (pin power_in line (at 0 0 90) (length 0)
+              (name "~" (effects (font (size 1.27 1.27))))
+              (number "1" (effects (font (size 1.27 1.27))))
+            )
+          )
+        )
+        (symbol "TestLib:D"
+          (symbol "TestLib:D_1_1"
+            (pin passive line (at -1.27 0 0) (length 0)
+              (name "K" (effects (font (size 1.27 1.27))))
+              (number "1" (effects (font (size 1.27 1.27))))
+            )
+            (pin passive line (at 1.27 0 180) (length 0)
+              (name "A" (effects (font (size 1.27 1.27))))
+              (number "2" (effects (font (size 1.27 1.27))))
+            )
+          )
+        )
       )
 """)
 
@@ -97,6 +117,19 @@ def _sym_mock(ref: str, lib_id: str, x: float, y: float, rotation: float = 0) ->
     m.property.Value.value = "~"
     m.lib_id.value = lib_id
     m.at.value = [x, y, rotation]
+    return m
+
+
+def _pwr_mock(ref: str, value: str, lib_id: str, x: float, y: float) -> MagicMock:
+    """Mock of a power-ish symbol (#PWR / #FLG) whose Value carries the net name.
+
+    Distinct from _sym_mock only in that Value is meaningful rather than "~".
+    """
+    m = MagicMock()
+    m.property.Reference.value = ref
+    m.property.Value.value = value
+    m.lib_id.value = lib_id
+    m.at.value = [x, y, 0]
     return m
 
 
@@ -442,3 +475,172 @@ class TestRotatedSymbol:
         pad_net_map, _ = _call(iface, sch, mock_sch)
         assert pad_net_map.get(("R1", "1")) == "UP_NET"
         assert pad_net_map.get(("R1", "2")) == "DN_NET"
+
+
+# ===========================================================================
+# TestPowerFlagIsNotANet
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestPowerFlagIsNotANet:
+    """A PWR_FLAG (#FLG) must never contribute a net name.
+
+    Its Value property is the literal string "PWR_FLAG" — an ERC marker, not a
+    net. Treating it as one invented a bogus "PWR_FLAG" net and could propagate
+    that name over the real net the flag is wired to.
+    """
+
+    def test_pwr_flag_value_does_not_become_a_net(self, iface, tmp_path):
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(
+            _build_sch_with_instances(
+                [
+                    ("R1", "TestLib:R", 10.0, 10.0, 0),
+                    ("#PWR01", "TestLib:PWR", 8.73, 10.0, 0),
+                    ("#FLG01", "TestLib:PWR", 5.0, 10.0, 0),
+                ]
+            )
+        )
+        # #PWR01 pin sits exactly on R1 pin 1; the flag hangs off a wire to it.
+        mock_sch = _sch_mock(
+            symbols=[
+                _sym_mock("R1", "TestLib:R", 10.0, 10.0),
+                _pwr_mock("#PWR01", "VCC", "TestLib:PWR", 8.73, 10.0),
+                _pwr_mock("#FLG01", "PWR_FLAG", "TestLib:PWR", 5.0, 10.0),
+            ],
+            wires=[_wire_mock(5.0, 10.0, 8.73, 10.0)],
+        )
+        pad_net_map, net_names = _call(iface, sch, mock_sch)
+
+        assert "PWR_FLAG" not in net_names
+        # The real rail still resolves, and the flag did not overwrite it.
+        assert pad_net_map.get(("R1", "1")) == "VCC"
+
+    def test_pwr_flag_does_not_overwrite_net_across_wire(self, iface, tmp_path):
+        """The flag's name must not win the BFS over the rail it is attached to."""
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(
+            _build_sch_with_instances(
+                [
+                    ("R1", "TestLib:R", 10.0, 10.0, 0),
+                    ("#FLG01", "TestLib:PWR", 5.0, 10.0, 0),
+                ]
+            )
+        )
+        mock_sch = _sch_mock(
+            symbols=[
+                _sym_mock("R1", "TestLib:R", 10.0, 10.0),
+                _pwr_mock("#FLG01", "PWR_FLAG", "TestLib:PWR", 5.0, 10.0),
+            ],
+            global_labels=[_lbl_mock("VBUS", 8.73, 10.0)],
+            wires=[_wire_mock(5.0, 10.0, 8.73, 10.0)],
+        )
+        pad_net_map, net_names = _call(iface, sch, mock_sch)
+
+        assert "PWR_FLAG" not in net_names
+        assert pad_net_map.get(("R1", "1")) == "VBUS"
+
+
+# ===========================================================================
+# TestUnlabelledNetGetsAutoName
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestUnlabelledNetGetsAutoName:
+    """A wire joining two component pins with no label is still a net.
+
+    KiCad synthesises a name for it during F8 ("Net-(D1-A)"). Without that these
+    pads reached the board with no net at all, so the connection was silently
+    dropped from the layout and the pads were left unroutable.
+    """
+
+    def test_bare_wire_between_two_pins_is_named_and_shared(self, iface, tmp_path):
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(
+            _build_sch_with_instances(
+                [
+                    ("R1", "TestLib:R", 10.0, 10.0, 0),
+                    ("R2", "TestLib:R", 20.0, 10.0, 0),
+                ]
+            )
+        )
+        # R1 pin2 (11.27, 10) --- wire --- R2 pin1 (18.73, 10). No labels at all.
+        mock_sch = _sch_mock(
+            symbols=[
+                _sym_mock("R1", "TestLib:R", 10.0, 10.0),
+                _sym_mock("R2", "TestLib:R", 20.0, 10.0),
+            ],
+            wires=[_wire_mock(11.27, 10.0, 18.73, 10.0)],
+        )
+        pad_net_map, net_names = _call(iface, sch, mock_sch)
+
+        r1_2 = pad_net_map.get(("R1", "2"))
+        r2_1 = pad_net_map.get(("R2", "1"))
+        assert r1_2 is not None, "unlabelled net was dropped entirely"
+        assert r1_2 == r2_1, "the two pads must land on the SAME net"
+        assert r1_2.startswith("Net-("), f"expected a KiCad-style auto name, got {r1_2!r}"
+        assert r1_2 in net_names
+
+    def test_auto_name_uses_pin_name_when_the_symbol_has_one(self, iface, tmp_path):
+        """KiCad names these after a pin: Net-(D1-A), not Net-(D1-Pad2)."""
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(
+            _build_sch_with_instances(
+                [
+                    ("D1", "TestLib:D", 10.0, 10.0, 0),
+                    ("R1", "TestLib:R", 20.0, 10.0, 0),
+                ]
+            )
+        )
+        mock_sch = _sch_mock(
+            symbols=[
+                _sym_mock("D1", "TestLib:D", 10.0, 10.0),
+                _sym_mock("R1", "TestLib:R", 20.0, 10.0),
+            ],
+            wires=[_wire_mock(11.27, 10.0, 18.73, 10.0)],
+        )
+        pad_net_map, _ = _call(iface, sch, mock_sch)
+
+        # D1 sorts before R1, and its pin 2 is named "A".
+        assert pad_net_map.get(("D1", "2")) == "Net-(D1-A)"
+        assert pad_net_map.get(("R1", "1")) == "Net-(D1-A)"
+
+    def test_explicit_label_still_wins_over_auto_name(self, iface, tmp_path):
+        """Auto-naming must only fill genuine gaps, never override a real label."""
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(
+            _build_sch_with_instances(
+                [
+                    ("R1", "TestLib:R", 10.0, 10.0, 0),
+                    ("R2", "TestLib:R", 20.0, 10.0, 0),
+                ]
+            )
+        )
+        mock_sch = _sch_mock(
+            symbols=[
+                _sym_mock("R1", "TestLib:R", 10.0, 10.0),
+                _sym_mock("R2", "TestLib:R", 20.0, 10.0),
+            ],
+            global_labels=[_lbl_mock("SIGNAL", 11.27, 10.0)],
+            wires=[_wire_mock(11.27, 10.0, 18.73, 10.0)],
+        )
+        pad_net_map, net_names = _call(iface, sch, mock_sch)
+
+        assert pad_net_map.get(("R1", "2")) == "SIGNAL"
+        assert pad_net_map.get(("R2", "1")) == "SIGNAL"
+        assert not any(n.startswith("Net-(") for n in net_names)
+
+    def test_single_pin_stub_is_not_named(self, iface, tmp_path):
+        """A wire reaching only one pin is not a connection worth inventing a net for."""
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(_build_sch_with_instances([("R1", "TestLib:R", 10.0, 10.0, 0)]))
+        mock_sch = _sch_mock(
+            symbols=[_sym_mock("R1", "TestLib:R", 10.0, 10.0)],
+            wires=[_wire_mock(11.27, 10.0, 15.0, 10.0)],
+        )
+        pad_net_map, net_names = _call(iface, sch, mock_sch)
+
+        assert pad_net_map == {}
+        assert net_names == set()

--- a/tests/test_sexpr_escaping.py
+++ b/tests/test_sexpr_escaping.py
@@ -151,3 +151,83 @@ class TestCallSitesAreConverted:
         assert (
             """replace('"', '\\\\"')""" not in source
         ), f"{filename} escapes quotes without escaping backslashes first (#336)"
+
+
+# ---------------------------------------------------------------------------
+# The #336 sweep converted the READERS. create_component_instance is a WRITER
+# that was missed: it unescapes a library property value and then interpolates
+# it straight back into a quoted token. The stock power:VCC / power:GND
+# Description carries an escaped quote, so placing either of those symbols —
+# i.e. almost any real schematic — emitted a file KiCad could not load at all,
+# and ERC failed with "Failed to load schematic".
+# ---------------------------------------------------------------------------
+
+DESC_WITH_QUOTES = 'Power symbol creates a global label with name "VCC"'
+
+
+def _sch_with_lib_symbol(description: str) -> str:
+    """A minimal schematic whose lib_symbols entry carries `description`."""
+    return (
+        '(kicad_sch (version 20231120) (generator "eeschema")\n'
+        "  (uuid 11111111-2222-3333-4444-555555555555)\n"
+        "  (lib_symbols\n"
+        '    (symbol "power:VCC"\n'
+        '      (property "Reference" "#PWR" (at 0 -3.81 0) (effects (font (size 1.27 1.27))))\n'
+        '      (property "Value" "VCC" (at 0 3.556 0) (effects (font (size 1.27 1.27))))\n'
+        '      (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27))))\n'
+        '      (property "Datasheet" "" (at 0 0 0) (effects (font (size 1.27 1.27))))\n'
+        f'      (property "Description" "{escape_sexpr_string(description)}"'
+        " (at 0 0 0) (effects (font (size 1.27 1.27))))\n"
+        '      (symbol "VCC_1_1"\n'
+        "        (pin power_in line (at 0 0 90) (length 0)\n"
+        '          (name "" (effects (font (size 1.27 1.27))))\n'
+        '          (number "1" (effects (font (size 1.27 1.27))))\n'
+        "        )\n"
+        "      )\n"
+        "    )\n"
+        "  )\n"
+        '  (sheet_instances (path "/" (page "1")))\n'
+        ")\n"
+    )
+
+
+class TestPlacedInstanceEscapesCopiedValues:
+    def _place(self, tmp_path, description):
+        from commands.dynamic_symbol_loader import DynamicSymbolLoader
+
+        sch = tmp_path / "t.kicad_sch"
+        sch.write_text(_sch_with_lib_symbol(description), encoding="utf-8")
+        (tmp_path / "t.kicad_pro").write_text("{}", encoding="utf-8")
+
+        DynamicSymbolLoader(project_path=tmp_path).create_component_instance(
+            sch, "power", "VCC", reference="#PWR01", value="VCC", x=100, y=65
+        )
+        return sch.read_text(encoding="utf-8")
+
+    def test_output_is_still_parseable(self, tmp_path):
+        """The whole point: a quote in a copied value must not break the file."""
+        content = self._place(tmp_path, DESC_WITH_QUOTES)
+        sexpdata.loads(content)  # raises if the token ran on
+
+    def test_copied_description_round_trips(self, tmp_path):
+        content = self._place(tmp_path, DESC_WITH_QUOTES)
+        found = [
+            unescape_sexpr_string(m)
+            for m in re.findall(r'\(property\s+"Description"\s+' + QUOTED_VALUE, content)
+        ]
+        # One in lib_symbols, one on the placed instance; both must survive intact.
+        assert found == [DESC_WITH_QUOTES, DESC_WITH_QUOTES], found
+
+    def test_no_bare_quote_leaks_into_the_instance(self, tmp_path):
+        content = self._place(tmp_path, DESC_WITH_QUOTES)
+        assert 'name "VCC""' not in content, "unescaped quote written into the instance"
+
+    @pytest.mark.parametrize("value", NASTY_VALUES)
+    def test_any_nasty_description_survives(self, tmp_path, value):
+        content = self._place(tmp_path, value)
+        sexpdata.loads(content)
+        found = [
+            unescape_sexpr_string(m)
+            for m in re.findall(r'\(property\s+"Description"\s+' + QUOTED_VALUE, content)
+        ]
+        assert found == [value, value], found


### PR DESCRIPTION
I ran a trivial two-part board (LED + current-limiting resistor) through the whole
create → add component → sync → place → route → export Gerbers flow, and hit three
separate bugs on the schematic side. Fixes and tests for all three here.

## 1. Placing any stock power symbol writes a schematic KiCad can't open

`create_component_instance` copies `Datasheet` and `Description` from the library symbol
into the placed instance. It unescapes the value on the way in
(`_extract_lib_property_value` → `unescape_sexpr_string`) but interpolated it straight
back into a quoted token on the way out, without re-escaping.

Both `power:VCC` and `power:GND` ship with a quote inside their Description:

```
Power symbol creates a global label with name "VCC"
```

so the emitted instance came out as:

```
(property "Description" "Power symbol creates a global label with name "
    VCC ""
```

The token terminates at that inner quote and the rest of the form gets swallowed.
Eeschema then won't load the file at all, and `run_erc` reports a bare
"Failed to load schematic" with nothing pointing at the cause. Since most schematics
have a GND symbol on them somewhere, this is easy to walk into.

This looks like a straggler from the #336 work in #348 — that pass made the property
*readers* escape-aware, but this writer was missed. `escape_sexpr_string` already
existed, it just wasn't being called here.

## 2. `sync_schematic_to_board` silently drops nets that have no label

Two things going on in `_build_hierarchical_pad_net_map`:

**`PWR_FLAG` was being treated as a net name.** A `#FLG` symbol's Value is the literal
string `PWR_FLAG` — it's a marker for ERC, not a net. That put a bogus `PWR_FLAG` net on
the board, and since the name gets stamped at the flag's pin position it can also
propagate out over the real net through the BFS below it. A PWR_FLAG takes whatever net
it's wired to; it never names one.

**Unlabelled nets vanished entirely.** A net made only of a wire between two component
pins has no label and no power symbol, so nothing named it, and `nearby_net()` returned
None for both pads. Those pads reach the board with no net assigned at all — the
connection disappears from the layout and the pads can't be routed. Nothing errors;
`pads_assigned` just quietly comes back short (2 of 4, in my case) and you only notice
when the ratsnest is missing a connection.

KiCad synthesises a name for these during F8, so this now does the same: cluster the
unnamed wire points and name them after the first connected pin. On the LED case that
produces `Net-(D1-A)`, which is exactly what `kicad-cli`'s own netlist calls it, so a
later real F8 in the GUI won't churn the name.

## 3. `angle` and `mirrorY` were being thrown away

`create_component_instance` has always accepted both, and the TS tool layer has always
sent both, but `_handle_add_schematic_component` in between only read `unit`. So the
documented `angle` argument did nothing and every symbol got placed unrotated. Two lines.

## Tests

22 new tests across the three areas. 10 of them fail if you revert the matching fix — I
checked that individually for each rather than assuming, since a regression test that
passes either way isn't worth much. The rest are guards against over-correcting: an
explicit net label still wins over an auto-generated name, and a single-pin wire stub is
deliberately left unnamed.

Full suite passes otherwise. For transparency, there are 14 pre-existing failures on my
machine (Windows) in the autoroute/freerouting tests plus a few that shell out to
subprocesses, but they fail identically on a clean checkout of `main`, so they're
unrelated to these changes.
