### PR TITLE
fix(registry): give the symbol-library tools a search_tools home

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 **Key Capabilities:**
 
-- 146 tools across 13 categories with JSON Schema validation
+- 161 tools across 14 categories with JSON Schema validation
 - Keyword tool discovery via `search_tools` / `get_category_tools`
 - 8 dynamic resources exposing project state
 - Complete schematic workflow with 27 tools and dynamic symbol loading (~10,000 symbols)
@@ -486,7 +486,7 @@ Access project state without executing tools:
 
 ## Available Tools
 
-The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **146 tools** are additionally indexed into 13 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
+The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **161 tools** are additionally indexed into 14 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
 
 For the complete tool reference with access types (direct/routed/additional), see [Tool Inventory](docs/TOOL_INVENTORY.md).
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -146,17 +146,30 @@ export const toolCategories: ToolCategory[] = [
   },
   {
     name: "library",
+    description: "Footprint library access: search, browse, get footprint information",
+    tools: ["list_libraries", "search_footprints", "list_library_footprints", "get_footprint_info"],
+  },
+  {
+    name: "symbol_library",
     description:
-      "Footprint library access: search, browse, get footprint information; plus symbol-library repair",
+      "Symbol library access and maintenance: search/browse sym-lib-table libraries, create/edit/rename/import/export symbols in a .kicad_sym file, repair malformed vendor symbols, and sync placed schematic instances to their library definitions",
     tools: [
-      "list_libraries",
-      "search_footprints",
-      "list_library_footprints",
-      "get_footprint_info",
-      // Symbol-library maintenance. Sits here for now because there is no
-      // symbol-library category yet -- see #345, which tracks giving the
-      // ~13 unregistered symbol tools a proper home.
+      "list_symbol_libraries",
+      "search_symbols",
+      "list_library_symbols",
+      "get_symbol_info",
+      "create_symbol",
+      "delete_symbol",
+      "rename_symbol",
+      "import_symbol",
+      "export_symbol",
+      "list_symbols_in_library",
+      "register_symbol_library",
+      "add_symbol_property",
       "repair_flat_symbols",
+      "update_symbol_from_library",
+      "add_library_symbol_property",
+      "replace_instance_lib_ids",
     ],
   },
   {

--- a/tests-ts/registry-completeness.test.ts
+++ b/tests-ts/registry-completeness.test.ts
@@ -22,6 +22,9 @@ import {
 // gate: the known set is frozen below and any NEW omission fails. Shrinking
 // the list is tracked separately -- do not add to it to make CI pass.
 //
+// #345 gave the symbol-library tools their own "symbol_library" category,
+// shrinking this baseline from 75 to 60.
+//
 // Parsing source text is deliberate: the point is to compare what is wired
 // into the server against what the registry claims, so reading the registry
 // through both paths would defeat it.
@@ -34,25 +37,20 @@ const KNOWN_UNREGISTERED = new Set([
   "add_component_3d_model",
   "add_footprint_3d_model",
   "add_gnd_stitching_vias",
-  "add_library_symbol_property",
   "add_schematic_hierarchical_label",
   "add_sheet_pin",
-  "add_symbol_property",
   "align_components",
   "check_courtyard_overlaps",
   "copy_routing_pattern",
   "create_footprint",
   "create_netclass",
-  "create_symbol",
   "delete_schematic_component",
-  "delete_symbol",
   "delete_trace",
   "download_jlcpcb_database",
   "duplicate_component",
   "edit_footprint_pad",
   "edit_schematic_component",
   "enrich_datasheets",
-  "export_symbol",
   "find_orphaned_wires",
   "find_overlapping_elements",
   "find_wires_crossing_symbols",
@@ -69,16 +67,11 @@ const KNOWN_UNREGISTERED = new Set([
   "get_schematic_component",
   "get_schematic_pin_locations",
   "get_schematic_view_region",
-  "get_symbol_info",
   "import_3d_model",
   "import_eagle_project",
   "import_svg_logo",
-  "import_symbol",
   "list_floating_labels",
   "list_footprint_libraries",
-  "list_library_symbols",
-  "list_symbol_libraries",
-  "list_symbols_in_library",
   "list_tool_categories",
   "modify_trace",
   "move_schematic_net_label",
@@ -87,17 +80,13 @@ const KNOWN_UNREGISTERED = new Set([
   "query_zones",
   "refill_zones",
   "register_footprint_library",
-  "register_symbol_library",
   "remove_schematic_component_property",
-  "rename_symbol",
-  "replace_instance_lib_ids",
   "route_arc_trace",
   "route_differential_pair",
   "route_pad_to_pad",
   "run_erc",
   "save_as",
   "search_jlcpcb_parts",
-  "search_symbols",
   "search_tools",
   "set_footprint_type",
   "set_schematic_component_property",
@@ -105,7 +94,6 @@ const KNOWN_UNREGISTERED = new Set([
   "suggest_jlcpcb_alternatives",
   "suggest_placement",
   "suggest_schematic_declutter",
-  "update_symbol_from_library",
 ]);
 
 function registeredToolNames(): Set<string> {


### PR DESCRIPTION
## Root cause

`searchTools()`, `getAllCategories()`, and `getRegistryStats()` in `src/tools/registry.ts` only read `toolCategories` and `directToolNames`. Any tool wired up with `server.tool()` in `src/tools/*.ts` but never added to either structure is callable, but invisible to `search_tools`/`get_category_tools` and uncounted by `getRegistryStats()`. `tests-ts/registry-completeness.test.ts` freezes the current gap as a 75-entry `KNOWN_UNREGISTERED` ratchet (added after #340/#342 shipped unregistered tools the same day).

15 of those 75 are the symbol-library tools, spread across `library-symbol.ts`, `symbol-creator.ts`, and `schematic-batch.ts`: browse/search a `sym-lib-table` library, create/edit/rename/import/export a `.kicad_sym` file, and sync a placed schematic instance back to its library definition. The `library` category's own comment already named this exact fix as pending: it parks `repair_flat_symbols` there "for now because there is no symbol-library category yet -- see #345" (added when #343 merged).

## Fix

Adds a `symbol_library` category holding those 15 tools plus `repair_flat_symbols`, and removes the now-stale placeholder comment. Shrinks `KNOWN_UNREGISTERED` from 75 to 60. Updates the two README lines `readme-counts.test.ts` pins to `getRegistryStats()` (146 -> 161 tools, 13 -> 14 categories) to match.

**Scope: this covers only the 15 symbol-library entries, not all 75 named in #345.** The remaining 60 span board/component/schematic/routing/footprint-library categorization, each with its own judgment call on category placement; the ratchet is built to make these reviewable in separate batches, so leaving `Refs #345` open rather than closing it with this partial fix.

## Verification

- `npm run test:ts` (Vitest, clean `node:20-bookworm` container): 70/70 pass, including `registry-completeness.test.ts`'s five completeness checks and `readme-counts.test.ts`'s README/registry parity check.
- `npm run build` (tsc) and `npm run lint:ts` (eslint) both clean; `pre-commit run --files` on the three changed files (prettier, eslint, trailing-whitespace, etc., the repo's own Code Quality CI job) all pass.
- Competing-PR sweep (14/14 open PRs, full pagination): 2 candidates touch `registry.ts` (#355 adds a `routing` category tool, #357 adds three `schematic` category tools), read both patches directly and neither overlaps the `library`/`symbol_library` hunks this PR touches.
- Not verified: the other 60 `KNOWN_UNREGISTERED` entries, and no live MCP client was used to confirm `search_tools`/`get_category_tools` surface the newly registered names end-to-end (only the registry's own unit tests were run).

Refs #345
