### PR TITLE
fix: add_symbol_property corrupted .kicad_sym libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the KiCAD MCP Server project are documented here.
 ### Bug Fixes
 
 - **`add_symbol_property` corrupted `.kicad_sym` libraries**. Every call dropped
-  one closing paren, so the library stopped loading in eeschema. Four defects,
+  one closing paren, so the library stopped loading in eeschema. Eight defects,
   all in the same write path:
   - The rewritten symbol was spliced back as
     `content[:start] + block + content[end + 1:]`, but `block` was sliced
@@ -23,16 +23,50 @@ All notable changes to the KiCAD MCP Server project are documented here.
     left behind as orphans under the symbol.
   - Parens inside quoted values (`"Ceramic (X7R) 50V"`) were counted as
     structure, mis-locating the end of the block.
+  - Rewriting a property regenerated a template
+    `(effects (font (size 1.27 1.27)))`, discarding the field's real font size,
+    thickness, bold/italic and `(justify ...)`. Worse, KiCad 8 and 9 write
+    `(hide yes)` _inside_ `(effects ...)`, and only the property's direct
+    children were searched — so every hidden field in a KiCad 8/9 library was
+    reported visible and un-hidden on the next value edit. On the bundled
+    `Simulation_SPICE_minimal.kicad_sym`, updating `Footprint` took the file
+    from 16 `(hide yes)` to 15 and updating `Reference` from 5 `(justify ...)`
+    to 4.
+  - A new property was written _outside_ the symbol when the insertion anchor
+    sat on the line that opens the symbol — a compact
+    `(symbol "R" (symbol "R_0_1" ...))` or a bare `(symbol "EMPTY")`. The line
+    start was computed with `block.rfind("\n", 0, anchor) + 1`, which is 0 when
+    there is no preceding newline, and index 0 is the symbol's own `(`. The
+    property became a sibling of the symbol; the call reported success and
+    `kicad-cli sym upgrade` then exited 2 with `Unable to load library`.
+  - An existing property was silently moved to the origin when its `(at ...)`
+    used a tab or newline separator (`(at\t5 6 90)`). The test was for the
+    literal string `"(at "`, but any whitespace is legal there.
+  - The library was read with `Path.read_text` and written with
+    `write_text`. Both apply universal-newline translation, so on Windows a
+    one-property edit rewrote every line ending in the file; and `write_text`
+    truncates in place, so a failure part-way through a multi-megabyte library
+    destroyed it.
 
   Block boundaries are now found by string-aware paren matching, properties are
   resolved and inserted at the symbol's own nesting level (so a unit's
   `Reference` is never mistaken for the symbol's), and values are escaped with
   `escape_sexpr_string`. Indentation is copied from the file being edited rather
-  than hardcoded to tabs. Rewriting a property now inherits its current position
-  and visibility unless `position`/`hide` are passed, so updating a value no
-  longer un-hides a BOM field. Verified against a 487-symbol library: before the
-  fix, 25 calls left a paren balance of +12 and `kicad-cli sym upgrade` reported
-  `Unable to load library`; after, the balance is 0 and the library loads.
+  than hardcoded to tabs. Rewriting a property keeps every child it already had
+  — its `(at ...)` verbatim, its whole `(effects ...)` block, and its hidden
+  state whether that was spelled on the property, nested in `(effects ...)` as
+  KiCad 8/9 do, or written as KiCad 7's bare `hide` token — unless `position` or
+  `hide` is passed to override it. Writes go to a temporary file that is then
+  renamed over the original, preserving the file's existing line-ending style.
+  Two guards run before anything reaches disk: the file's paren balance may not
+  move, and the property must re-locate as a direct child of the intended symbol
+  (balance alone is blind to a well-formed insert at the wrong nesting depth).
+  Verified against a 487-symbol library: before the fix, 25 calls left a paren
+  balance of +12 and `kicad-cli sym upgrade` reported `Unable to load library`;
+  after, the balance is 0 and the library loads. Verified per-property against
+  KiCad 10.0.4: round-tripping `Simulation_SPICE_minimal.kicad_sym` through
+  `kicad-cli sym upgrade` before and after an edit now yields byte-identical
+  output apart from the changed value.
 
 - **`add_layer` could not add inner copper layers, and corrupted an unrelated
   layer trying** (#222). Four defects, of which the reported one — changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`add_symbol_property` corrupted `.kicad_sym` libraries**. Every call dropped
+  one closing paren, so the library stopped loading in eeschema. Four defects,
+  all in the same write path:
+  - The rewritten symbol was spliced back as
+    `content[:start] + block + content[end + 1:]`, but `block` was sliced
+    `[start:end]` — excluding the symbol's closing paren that `end + 1` then
+    skipped over. One `)` disappeared per call.
+  - The insertion point was matched with `\n\t\t\t(symbol "`, a nesting level
+    that does not occur in a `.kicad_sym` file (units sit at two tabs, not
+    three). The match never fired, so every new property took the fallback path
+    and landed **inside the last unit** instead of on the symbol.
+  - Updating an existing property matched `\(property "Name".*?\)` non-greedily,
+    which stops at the first `)`. On the multi-line layout eeschema writes, that
+    is the `(at ...)` line — the old `(hide yes)` and `(effects ...)` lines were
+    left behind as orphans under the symbol.
+  - Parens inside quoted values (`"Ceramic (X7R) 50V"`) were counted as
+    structure, mis-locating the end of the block.
+
+  Block boundaries are now found by string-aware paren matching, properties are
+  resolved and inserted at the symbol's own nesting level (so a unit's
+  `Reference` is never mistaken for the symbol's), and values are escaped with
+  `escape_sexpr_string`. Indentation is copied from the file being edited rather
+  than hardcoded to tabs. Rewriting a property now inherits its current position
+  and visibility unless `position`/`hide` are passed, so updating a value no
+  longer un-hides a BOM field. Verified against a 487-symbol library: before the
+  fix, 25 calls left a paren balance of +12 and `kicad-cli sym upgrade` reported
+  `Unable to load library`; after, the balance is 0 and the library loads.
+
 - **`add_layer` could not add inner copper layers, and corrupted an unrelated
   layer trying** (#222). Four defects, of which the reported one — changes
   never reaching disk — was the least damaging:

--- a/python/commands/add_symbol_property.py
+++ b/python/commands/add_symbol_property.py
@@ -3,44 +3,197 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from utils.sexpr_format import escape_sexpr_string
+
+# A property belongs to the symbol itself, so it has to sit at the same nesting
+# level as (property "Reference" ...). Inside the parent block that is depth 2:
+# depth 1 is the parent's own "(".
+_CHILD_DEPTH = 2
+
+
+def _match_paren(content: str, open_idx: int) -> int:
+    """Index of the ``)`` closing the ``(`` at *open_idx*, or -1 if unbalanced.
+
+    Parentheses inside quoted tokens are literal text -- a Description of
+    ``"Cap (X7R)"`` must not be read as a nested list.
+    """
+    depth = 0
+    in_string = False
+    i = open_idx
+    while i < len(content):
+        ch = content[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def _paren_balance(content: str) -> int:
+    """Signed paren balance of *content*, ignoring parens inside quoted tokens."""
+    balance = 0
+    in_string = False
+    i = 0
+    while i < len(content):
+        ch = content[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            balance += 1
+        elif ch == ")":
+            balance -= 1
+        i += 1
+    return balance
+
+
+def _iter_children(block: str) -> Iterator[int]:
+    """Yield the offset of every direct child list inside a symbol *block*."""
+    depth = 0
+    in_string = False
+    i = 0
+    while i < len(block):
+        ch = block[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            depth += 1
+            if depth == _CHILD_DEPTH:
+                yield i
+        elif ch == ")":
+            depth -= 1
+        i += 1
+
 
 def _find_symbol_in_lib(content: str, symbol_name: str) -> tuple[int, int, str] | None:
-    """Return (start, end, block) for a symbol in .kicad_sym, or None."""
-    marker = f'(symbol "{symbol_name}"'
+    """Return (start, end, block) for a symbol in .kicad_sym, or None.
+
+    ``end`` is the index of the symbol's closing paren and ``block`` includes it.
+    """
+    marker = f'(symbol "{escape_sexpr_string(symbol_name)}"'
     sym_start = content.find(marker)
     if sym_start == -1:
         return None
 
-    depth = 0
-    for i in range(sym_start, len(content)):
-        if content[i] == "(":
-            depth += 1
-        elif content[i] == ")":
-            depth -= 1
-            if depth == 0:
-                return sym_start, i, content[sym_start : i + 1]
-
-    return None
+    sym_end = _match_paren(content, sym_start)
+    if sym_end == -1:
+        return None
+    return sym_start, sym_end, content[sym_start : sym_end + 1]
 
 
 def _has_property(symbol_block: str, prop_name: str) -> bool:
-    return bool(re.search(rf'\(property\s+"{re.escape(prop_name)}"', symbol_block))
+    return _find_property_span(symbol_block, prop_name) is not None
+
+
+def _find_property_span(block: str, prop_name: str) -> tuple[int, int] | None:
+    """Span of the symbol's own ``(property "prop_name" ...)``, end-exclusive.
+
+    Only direct children count. A multi-unit symbol repeats property names
+    inside its ``NAME_0_1`` sub-symbols, and rewriting one of those leaves the
+    parent untouched while corrupting the sub-symbol.
+    """
+    head = re.compile(rf'\(property\s+"{re.escape(escape_sexpr_string(prop_name))}"[\s()"]')
+    for offset in _iter_children(block):
+        if head.match(block, offset):
+            close = _match_paren(block, offset)
+            if close != -1:
+                return offset, close + 1
+    return None
+
+
+def _first_subsymbol_offset(block: str) -> int | None:
+    """Offset of the first ``(symbol "..."`` unit inside a parent symbol block."""
+    for offset in _iter_children(block):
+        if block.startswith('(symbol "', offset):
+            return offset
+    return None
+
+
+def _indent_at(block: str, offset: int) -> str | None:
+    """Leading whitespace of the line holding *offset*, or None if not alone."""
+    line_start = block.rfind("\n", 0, offset) + 1
+    prefix = block[line_start:offset]
+    return prefix if prefix.strip() == "" else None
+
+
+def _child_indent(block: str) -> str:
+    """Indentation used by this symbol's direct children.
+
+    Libraries written by eeschema use tabs; hand-edited and Eagle-imported ones
+    use spaces. Copying whatever the file already does keeps the diff to the
+    inserted lines.
+    """
+    for offset in _iter_children(block):
+        indent = _indent_at(block, offset)
+        if indent:
+            return indent
+    return "\t\t"
+
+
+def _placement_of(prop_block: str) -> tuple[str | None, bool]:
+    """Return the ``(at ...)`` token and hidden flag of an existing property.
+
+    Rewriting a property means regenerating it from scratch, so anything the
+    caller did not supply has to be carried over -- otherwise updating a BOM
+    value would silently un-hide the field and drop it back to the origin.
+    """
+    at_text: str | None = None
+    hidden = False
+    for offset in _iter_children(prop_block):
+        close = _match_paren(prop_block, offset)
+        if close == -1:
+            continue
+        child = prop_block[offset : close + 1]
+        if at_text is None and child.startswith("(at "):
+            at_text = child
+        elif re.fullmatch(r"\(hide\s+yes\)", child):
+            hidden = True
+    return at_text, hidden
 
 
 def _build_property(
-    name: str, value: str, pos: dict[str, float] | None = None, hide: bool = False
+    name: str,
+    value: str,
+    at_text: str = "(at 0 0 0)",
+    hide: bool = False,
+    indent: str = "\t\t",
 ) -> str:
-    x = pos.get("x", 0) if pos else 0
-    y = pos.get("y", 0) if pos else 0
-    lines = [f'(property "{name}" "{value}" (at {x} {y} 0)']
+    """Render a property block; the first line carries no indent."""
+    inner = indent + ("\t" if "\t" in indent else "  ")
+    lines = [
+        f'(property "{escape_sexpr_string(name)}" ' f'"{escape_sexpr_string(value)}" {at_text}'
+    ]
     if hide:
-        lines.append("(hide yes)")
-    lines.append("(effects (font (size 1.27 1.27)))")
-    lines.append(")")
-    return "\n\t\t\t".join(lines)
+        lines.append(f"{inner}(hide yes)")
+    lines.append(f"{inner}(effects (font (size 1.27 1.27)))")
+    lines.append(f"{indent})")
+    return "\n".join(lines)
 
 
 def add_symbol_property(params: dict[str, Any]) -> dict[str, Any]:
@@ -63,28 +216,51 @@ def add_symbol_property(params: dict[str, Any]) -> dict[str, Any]:
         }
 
     sym_start, sym_end, block = found
-    new_prop = _build_property(prop_name, prop_value, pos, hide)
+    indent = _child_indent(block)
+    at_text = f"(at {pos.get('x', 0)} {pos.get('y', 0)} 0)" if pos else None
 
-    updated = False
-    block = content[sym_start:sym_end]
-    if _has_property(block, prop_name):
+    existing = _find_property_span(block, prop_name)
+    if existing:
         updated = True
-        # Remove old property
-        old = re.search(rf'\(property "{re.escape(prop_name)}"\s+"[^"]*".*?\)', block, re.DOTALL)
-        if old:
-            block = block[: old.start()] + new_prop + block[old.end() :]
-        else:
-            block = block.rstrip()[:-1] + "\n\t\t\t" + new_prop + "\n\t\t)"
+        start, end = existing
+        old_at, old_hidden = _placement_of(block[start:end])
+        new_prop = _build_property(
+            prop_name,
+            prop_value,
+            at_text or old_at or "(at 0 0 0)",
+            hide if "hide" in params else old_hidden,
+            indent,
+        )
+        block = block[:start] + new_prop + block[end:]
     else:
-        sub = re.search(r'\n\t\t\t\(symbol "', block)
-        if sub:
-            insert_at = sub.start()
-            block = block[:insert_at] + "\n\t\t\t" + new_prop + block[insert_at:]
+        updated = False
+        new_prop = _build_property(prop_name, prop_value, at_text or "(at 0 0 0)", hide, indent)
+        sub = _first_subsymbol_offset(block)
+        if sub is not None:
+            # Properties must precede the unit definitions, so anchor to the
+            # start of the sub-symbol's line rather than the "(" itself.
+            line_start = block.rfind("\n", 0, sub) + 1
+            block = block[:line_start] + indent + new_prop + "\n" + block[line_start:]
         else:
-            block = block.rstrip()[:-1] + "\n\t\t\t" + new_prop + "\n\t\t)"
+            close = block.rfind(")")
+            line_start = block.rfind("\n", 0, close) + 1
+            block = block[:line_start] + indent + new_prop + "\n" + block[line_start:]
 
-    content = content[:sym_start] + block + content[sym_end + 1 :]
-    lib_path.write_text(content, encoding="utf-8")
+    updated_content = content[:sym_start] + block + content[sym_end + 1 :]
+
+    # Adding or replacing a property is a balanced edit, so the file's balance
+    # cannot move. Comparing against the original rather than checking for zero
+    # keeps the guard usable on Eagle-imported libraries that arrive unbalanced.
+    if _paren_balance(updated_content) != _paren_balance(content):
+        return {
+            "success": False,
+            "message": (
+                f"Refusing to write {lib_path.name}: editing property "
+                f"'{prop_name}' on '{symbol_name}' would unbalance the file"
+            ),
+        }
+
+    lib_path.write_text(updated_content, encoding="utf-8")
 
     # This rewrote a .kicad_sym file: drop the module-level symbol caches so a
     # subsequent extract/list sees the new property instead of a stale block

--- a/python/commands/add_symbol_property.py
+++ b/python/commands/add_symbol_property.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import re
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +14,37 @@ from utils.sexpr_format import escape_sexpr_string
 # level as (property "Reference" ...). Inside the parent block that is depth 2:
 # depth 1 is the parent's own "(".
 _CHILD_DEPTH = 2
+
+# Any whitespace separates the head of an s-expression from its arguments, so
+# "(at\t5 6 90)" and "(at\n5 6 90)" are as legal as "(at 5 6 90)".
+_AT_HEAD = re.compile(r"\(at\s")
+
+_HIDE_LIST = re.compile(r"\(hide\s+(yes|no)\s*\)")
+
+
+def _read_text(path: Path) -> tuple[str, str]:
+    """File text with LF newlines, plus the newline style to write back.
+
+    ``Path.read_text``/``write_text`` apply universal-newline translation, so on
+    Windows a CRLF library round-tripped through them keeps its line endings by
+    luck and an LF one silently gains a ``\\r`` on every line -- turning a
+    one-property edit into a whole-file diff.
+    """
+    with open(path, "r", encoding="utf-8", newline="") as fh:
+        raw = fh.read()
+    return raw.replace("\r\n", "\n"), ("\r\n" if "\r\n" in raw else "\n")
+
+
+def _write_text(path: Path, text: str, newline: str) -> None:
+    """Atomic write that keeps the file's original newline style.
+
+    ``write_text`` truncates in place, so a failure part-way through the write
+    leaves a 2 MB library half-written with no copy of the original anywhere.
+    """
+    tmp = path.with_name(path.name + ".mcp-tmp")
+    with open(tmp, "w", encoding="utf-8", newline=newline) as fh:
+        fh.write(text)
+    os.replace(tmp, path)
 
 
 def _match_paren(content: str, open_idx: int) -> int:
@@ -91,10 +123,83 @@ def _iter_children(block: str) -> Iterator[int]:
         i += 1
 
 
+def _iter_bare_atoms(block: str) -> Iterator[tuple[int, int]]:
+    """Yield spans of the atoms that are direct children of *block*.
+
+    Only used to locate KiCad 7's bare ``hide`` token inside ``(effects ...)``.
+    Quoted tokens between children are split on whitespace like anything else,
+    which is harmless for the ``(effects ...)`` blocks this is applied to: their
+    only quoted value is a font face, nested one level further down.
+    """
+    gaps: list[tuple[int, int]] = []
+    cursor = 1
+    for offset in _iter_children(block):
+        close = _match_paren(block, offset)
+        if close == -1:
+            break
+        gaps.append((cursor, offset))
+        cursor = close + 1
+    gaps.append((cursor, len(block) - 1 if block.endswith(")") else len(block)))
+    for lo, hi in gaps:
+        for match in re.finditer(r"[^\s()]+", block[lo:hi]):
+            yield lo + match.start(), lo + match.end()
+
+
+def _cut_span(text: str, start: int, end: int) -> str:
+    """Remove ``text[start:end]``, taking the whole line when it owns one."""
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", end)
+    owns_line = (
+        text[line_start:start].strip() == "" and line_end != -1 and text[end:line_end].strip() == ""
+    )
+    if owns_line:
+        return text[:line_start] + text[line_end + 1 :]
+    lead = start
+    while lead > line_start and text[lead - 1] in " \t":
+        lead -= 1
+    return text[:lead] + text[end:]
+
+
+def _strip_hide(block: str) -> tuple[str, bool | None]:
+    """Drop *block*'s own hide markers; report the visibility they declared.
+
+    KiCad 8 and 9 nest ``(hide yes)`` inside ``(effects ...)`` and KiCad 7 wrote
+    a bare ``hide`` token there, so a property's visibility can live a level
+    below the property itself. Both forms are removed here and re-emitted as a
+    single property-level ``(hide yes)``; kicad-cli canonicalises the nested and
+    property-level spellings to byte-identical output, so nothing is lost.
+
+    Returns None for the flag when the block declared no visibility at all,
+    which is what lets a caller-supplied ``hide`` win over an absent marker
+    without inventing one.
+    """
+    out = block
+    declared: bool | None = None
+    for offset in reversed(list(_iter_children(out))):
+        close = _match_paren(out, offset)
+        if close == -1:
+            continue
+        match = _HIDE_LIST.fullmatch(out[offset : close + 1])
+        if match:
+            declared = match.group(1) == "yes"
+            out = _cut_span(out, offset, close + 1)
+    for start, end in reversed(list(_iter_bare_atoms(out))):
+        if out[start:end] == "hide":
+            declared = True
+            out = _cut_span(out, start, end)
+    return out, declared
+
+
 def _find_symbol_in_lib(content: str, symbol_name: str) -> tuple[int, int, str] | None:
     """Return (start, end, block) for a symbol in .kicad_sym, or None.
 
     ``end`` is the index of the symbol's closing paren and ``block`` includes it.
+
+    The marker is located with a plain substring search, so a value that
+    literally contained ``(symbol "NAME"`` would match ahead of the real symbol.
+    No library eeschema writes can produce that -- a property value is a single
+    quoted token and the search includes the opening paren -- and making the
+    search position-aware would mean parsing the whole file to place one edit.
     """
     marker = f'(symbol "{escape_sexpr_string(symbol_name)}"'
     sym_start = content.find(marker)
@@ -105,10 +210,6 @@ def _find_symbol_in_lib(content: str, symbol_name: str) -> tuple[int, int, str] 
     if sym_end == -1:
         return None
     return sym_start, sym_end, content[sym_start : sym_end + 1]
-
-
-def _has_property(symbol_block: str, prop_name: str) -> bool:
-    return _find_property_span(symbol_block, prop_name) is not None
 
 
 def _find_property_span(block: str, prop_name: str) -> tuple[int, int] | None:
@@ -142,39 +243,51 @@ def _indent_at(block: str, offset: int) -> str | None:
     return prefix if prefix.strip() == "" else None
 
 
-def _child_indent(block: str) -> str:
+def _child_indent(block: str, fallback: str) -> str:
     """Indentation used by this symbol's direct children.
 
     Libraries written by eeschema use tabs; hand-edited and Eagle-imported ones
     use spaces. Copying whatever the file already does keeps the diff to the
-    inserted lines.
+    inserted lines. *fallback* covers a symbol whose children all share a line
+    with something else, so none of them shows its own indentation.
     """
     for offset in _iter_children(block):
         indent = _indent_at(block, offset)
         if indent:
             return indent
-    return "\t\t"
+    return fallback
 
 
-def _placement_of(prop_block: str) -> tuple[str | None, bool]:
-    """Return the ``(at ...)`` token and hidden flag of an existing property.
+def _existing_parts(prop_block: str) -> tuple[str | None, bool, list[str]]:
+    """The ``(at ...)``, hidden flag and other children of an existing property.
 
-    Rewriting a property means regenerating it from scratch, so anything the
-    caller did not supply has to be carried over -- otherwise updating a BOM
-    value would silently un-hide the field and drop it back to the origin.
+    Rewriting a property means regenerating its opening line, so every child the
+    caller did not supply has to be carried over verbatim. Rendering a fresh
+    ``(effects (font (size 1.27 1.27)))`` instead threw away the field's font
+    size, thickness, bold/italic, justification and -- because KiCad 8 and 9
+    write it in there rather than on the property -- its hidden state.
     """
     at_text: str | None = None
-    hidden = False
+    declared: list[bool] = []
+    others: list[str] = []
     for offset in _iter_children(prop_block):
         close = _match_paren(prop_block, offset)
         if close == -1:
             continue
         child = prop_block[offset : close + 1]
-        if at_text is None and child.startswith("(at "):
+        hide_match = _HIDE_LIST.fullmatch(child)
+        if hide_match:
+            declared.append(hide_match.group(1) == "yes")
+        elif at_text is None and _AT_HEAD.match(child):
             at_text = child
-        elif re.fullmatch(r"\(hide\s+yes\)", child):
-            hidden = True
-    return at_text, hidden
+        elif child.startswith("(effects"):
+            cleaned, nested = _strip_hide(child)
+            if nested is not None:
+                declared.append(nested)
+            others.append(cleaned)
+        else:
+            others.append(child)
+    return at_text, any(declared), others
 
 
 def _build_property(
@@ -183,17 +296,58 @@ def _build_property(
     at_text: str = "(at 0 0 0)",
     hide: bool = False,
     indent: str = "\t\t",
+    others: Sequence[str] = (),
 ) -> str:
-    """Render a property block; the first line carries no indent."""
+    """Render a property block; the first line carries no indent.
+
+    *others* are an existing property's remaining children, re-emitted exactly
+    as they were found. A default ``(effects ...)`` is only supplied when the
+    property has none of its own.
+    """
     inner = indent + ("\t" if "\t" in indent else "  ")
     lines = [
         f'(property "{escape_sexpr_string(name)}" ' f'"{escape_sexpr_string(value)}" {at_text}'
     ]
     if hide:
         lines.append(f"{inner}(hide yes)")
-    lines.append(f"{inner}(effects (font (size 1.27 1.27)))")
+    lines.extend(f"{inner}{child}" for child in others)
+    if not any(child.startswith("(effects") for child in others):
+        lines.append(f"{inner}(effects (font (size 1.27 1.27)))")
     lines.append(f"{indent})")
     return "\n".join(lines)
+
+
+def _splice_child(block: str, anchor: int, indent: str, tail_indent: str, new_prop: str) -> str:
+    """Insert *new_prop* into *block* as a direct child, just before *anchor*.
+
+    When *anchor* starts its own line the property becomes a new line above it.
+    When it shares a line the line has to be broken instead -- taking the line
+    start as ``block.rfind("\\n", 0, anchor) + 1`` gives 0 there, which is the
+    symbol's own ``(``, and splicing at 0 makes the property a *sibling* of the
+    symbol rather than a child of it. Compact libraries hit this whenever the
+    first unit shares the parent's line, as does a bare ``(symbol "EMPTY")``
+    whose closing paren is on the opening line.
+    """
+    newline_before = block.rfind("\n", 0, anchor)
+    if newline_before != -1 and block[newline_before + 1 : anchor].strip() == "":
+        line_start = newline_before + 1
+        return block[:line_start] + indent + new_prop + "\n" + block[line_start:]
+    head = block[:anchor].rstrip(" \t")
+    return f"{head}\n{indent}{new_prop}\n{tail_indent}{block[anchor:]}"
+
+
+def _is_direct_child(content: str, symbol_name: str, prop_name: str) -> bool:
+    """Whether *prop_name* ended up a direct child of *symbol_name*.
+
+    Re-locates the symbol in the text about to be written rather than trusting
+    the splice arithmetic that produced it. The paren-balance check cannot see
+    this class of mistake on its own: a well-formed property inserted at the
+    wrong nesting depth leaves the file's balance exactly as it was.
+    """
+    found = _find_symbol_in_lib(content, symbol_name)
+    if found is None:
+        return False
+    return _find_property_span(found[2], prop_name) is not None
 
 
 def add_symbol_property(params: dict[str, Any]) -> dict[str, Any]:
@@ -207,7 +361,7 @@ def add_symbol_property(params: dict[str, Any]) -> dict[str, Any]:
     if not lib_path.exists():
         return {"success": False, "message": f"Library not found: {lib_path}"}
 
-    content = lib_path.read_text(encoding="utf-8")
+    content, newline = _read_text(lib_path)
     found = _find_symbol_in_lib(content, symbol_name)
     if not found:
         return {
@@ -216,20 +370,22 @@ def add_symbol_property(params: dict[str, Any]) -> dict[str, Any]:
         }
 
     sym_start, sym_end, block = found
-    indent = _child_indent(block)
+    sym_indent = _indent_at(content, sym_start) or ""
+    indent = _child_indent(block, sym_indent + "\t")
     at_text = f"(at {pos.get('x', 0)} {pos.get('y', 0)} 0)" if pos else None
 
     existing = _find_property_span(block, prop_name)
     if existing:
         updated = True
         start, end = existing
-        old_at, old_hidden = _placement_of(block[start:end])
+        old_at, old_hidden, old_others = _existing_parts(block[start:end])
         new_prop = _build_property(
             prop_name,
             prop_value,
             at_text or old_at or "(at 0 0 0)",
             hide if "hide" in params else old_hidden,
             indent,
+            old_others,
         )
         block = block[:start] + new_prop + block[end:]
     else:
@@ -238,19 +394,19 @@ def add_symbol_property(params: dict[str, Any]) -> dict[str, Any]:
         sub = _first_subsymbol_offset(block)
         if sub is not None:
             # Properties must precede the unit definitions, so anchor to the
-            # start of the sub-symbol's line rather than the "(" itself.
-            line_start = block.rfind("\n", 0, sub) + 1
-            block = block[:line_start] + indent + new_prop + "\n" + block[line_start:]
+            # first sub-symbol; otherwise anchor to the symbol's own closer.
+            anchor, tail_indent = sub, indent
         else:
-            close = block.rfind(")")
-            line_start = block.rfind("\n", 0, close) + 1
-            block = block[:line_start] + indent + new_prop + "\n" + block[line_start:]
+            anchor, tail_indent = block.rfind(")"), sym_indent
+        block = _splice_child(block, anchor, indent, tail_indent, new_prop)
 
     updated_content = content[:sym_start] + block + content[sym_end + 1 :]
 
     # Adding or replacing a property is a balanced edit, so the file's balance
     # cannot move. Comparing against the original rather than checking for zero
     # keeps the guard usable on Eagle-imported libraries that arrive unbalanced.
+    # This catches dropped or surplus parens only -- see _is_direct_child for
+    # the nesting-depth half, which balance alone is blind to.
     if _paren_balance(updated_content) != _paren_balance(content):
         return {
             "success": False,
@@ -260,7 +416,16 @@ def add_symbol_property(params: dict[str, Any]) -> dict[str, Any]:
             ),
         }
 
-    lib_path.write_text(updated_content, encoding="utf-8")
+    if not _is_direct_child(updated_content, symbol_name, prop_name):
+        return {
+            "success": False,
+            "message": (
+                f"Refusing to write {lib_path.name}: property '{prop_name}' would "
+                f"not be a direct child of symbol '{symbol_name}'"
+            ),
+        }
+
+    _write_text(lib_path, updated_content, newline)
 
     # This rewrote a .kicad_sym file: drop the module-level symbol caches so a
     # subsequent extract/list sees the new property instead of a stale block

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -2960,8 +2960,10 @@ SCHEMATIC_TOOLS = [
         "title": "Add Property to Library Symbol",
         "description": (
             "Add or update a custom property on a symbol in a .kicad_sym library file. "
-            "This makes permanent library-wide changes. After adding properties, use "
-            "update_symbol_from_library to refresh schematics that reference the updated symbol."
+            "The property is written on the symbol itself, not on one of its units, so "
+            "multi-unit symbols are handled correctly. This makes permanent library-wide "
+            "changes. After adding properties, use update_symbol_from_library to refresh "
+            "schematics that reference the updated symbol."
         ),
         "inputSchema": {
             "type": "object",
@@ -2973,8 +2975,18 @@ SCHEMATIC_TOOLS = [
                 "position": {
                     "type": "object",
                     "properties": {"x": {"type": "number"}, "y": {"type": "number"}},
+                    "description": (
+                        "Placement in mm. Omit to keep an existing property where it is "
+                        "(new properties default to 0, 0)."
+                    ),
                 },
-                "hide": {"type": "boolean", "default": False},
+                "hide": {
+                    "type": "boolean",
+                    "description": (
+                        "Hide the property. Omit to keep an existing property's current "
+                        "visibility (new properties default to visible)."
+                    ),
+                },
             },
             "required": ["libraryPath", "symbolName", "propertyName", "propertyValue"],
         },

--- a/src/tools/symbol-creator.ts
+++ b/src/tools/symbol-creator.ts
@@ -215,7 +215,9 @@ export function registerSymbolCreatorTools(server: McpServer, callKicadScript: F
   // ── add_symbol_property ───────────────────────────────────────────────── //
   server.tool(
     "add_symbol_property",
-    "Add or update a custom property (Manufacturer, MPN, LCSC, etc.) on a symbol in a .kicad_sym library file.",
+    "Add or update a custom property (Manufacturer, MPN, LCSC, etc.) on a symbol in a .kicad_sym " +
+      "library file. The property is written on the symbol itself rather than on one of its " +
+      "units, so multi-unit symbols are handled correctly.",
     {
       libraryPath: z.string().describe("Path to the .kicad_sym file"),
       symbolName: z.string().describe("Symbol name"),
@@ -224,8 +226,13 @@ export function registerSymbolCreatorTools(server: McpServer, callKicadScript: F
       position: z
         .object({ x: z.number(), y: z.number() })
         .optional()
-        .describe("Position {x, y} in mm (default: 0, 0)"),
-      hide: z.boolean().optional().describe("Hide the property (default false)"),
+        .describe(
+          "Position {x, y} in mm. Omit to leave an existing property where it is (new: 0, 0)",
+        ),
+      hide: z
+        .boolean()
+        .optional()
+        .describe("Hide the property. Omit to keep an existing property's visibility (new: false)"),
     },
     async (args: any) => {
       const r = await callKicadScript("add_symbol_property", args);

--- a/tests/test_add_symbol_property.py
+++ b/tests/test_add_symbol_property.py
@@ -1,5 +1,7 @@
 """Tests for add_symbol_property — add custom properties to .kicad_sym library files."""
 
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -10,11 +12,20 @@ from commands.add_symbol_property import (  # noqa: E402
     _find_property_span,
     _find_symbol_in_lib,
     _first_subsymbol_offset,
-    _has_property,
+    _iter_children,
     _match_paren,
     _paren_balance,
     add_symbol_property,
 )
+
+_KICAD_CLI = shutil.which("kicad-cli")
+
+# A real KiCad 9 library (version 20241209, generator_version "9.0"): its
+# Footprint field is hidden via a (hide yes) *inside* (effects ...) and its
+# Reference carries a (justify ...). Hand-written fixtures that put hide
+# directly on the property miss both, which is how the effects-clobbering
+# regression below survived the first round of tests.
+KICAD9_FIXTURE = Path(__file__).parent / "fixtures" / "Simulation_SPICE_minimal.kicad_sym"
 
 LIB = """(kicad_symbol_lib (version 20231120) (generator "test")
   (symbol "R" (pin_names hide) (in_bom yes) (on_board yes)
@@ -31,9 +42,15 @@ LIB = """(kicad_symbol_lib (version 20231120) (generator "test")
 )
 """
 
-# The layout eeschema actually writes: tabs, one property per several lines, and
-# unit sub-symbols that repeat the parent's property names. Every corruption
-# this module has caused in the field needed this shape to reproduce.
+# Close to what eeschema writes: tabs, one property spread over several lines,
+# and unit sub-symbols that repeat the parent's property names. The paren and
+# insertion-point corruptions all need this shape to reproduce.
+#
+# Its `Manufacturer` is hidden with a property-level `(hide yes)`, which KiCad
+# accepts but does not itself emit — KiCad 8/9 nest that marker inside
+# `(effects ...)`. Do not read this fixture as a statement about the on-disk
+# format; KICAD9_FIXTURE is the real thing, and the difference is exactly what
+# let the effects-clobbering bug through.
 TABBED_LIB = """(kicad_symbol_lib (version 20231120) (generator "eeschema")
 \t(symbol "LED"
 \t\t(pin_numbers hide)
@@ -95,6 +112,52 @@ def balance(text: str) -> int:
             depth -= 1
         i += 1
     return depth
+
+
+def child_heads(block: str) -> list[str]:
+    """Head token of each direct child of *block*.
+
+    Net paren balance is too weak an oracle for this module: dropping the
+    symbol's closer and truncating a property match are equal and opposite, so a
+    file kicad-cli refuses to load can still balance to zero. What actually
+    changes is the symbol's shape — orphaned ``(hide yes)``/``(effects ...)``
+    fragments appear as direct children that were never there.
+    """
+    heads = []
+    for offset in _iter_children(block):
+        after = block[offset + 1 :]
+        heads.append(after.split(None, 1)[0].rstrip(")") if after.strip() else "")
+    return heads
+
+
+def sub_block(content: str, name: str) -> str:
+    """The verbatim text of the sub-symbol *name*, closing paren included."""
+    _, _, block = _find_symbol_in_lib(content, name)
+    return block
+
+
+def newline_counts(path: Path) -> tuple[int, int]:
+    """(CRLF count, lone-LF count) of the bytes on disk."""
+    raw = path.read_bytes()
+    return raw.count(b"\r\n"), raw.count(b"\n") - raw.count(b"\r\n")
+
+
+def upgrade_with_kicad_cli(path: Path, out: Path) -> subprocess.CompletedProcess:
+    """Run `kicad-cli sym upgrade`, the only oracle for "does KiCad load this"."""
+    return subprocess.run(
+        [_KICAD_CLI, "sym", "upgrade", str(path), "-o", str(out), "--force"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+@pytest.fixture
+def kicad9_lib(tmp_path):
+    p = tmp_path / "Simulation_SPICE_minimal.kicad_sym"
+    shutil.copy(KICAD9_FIXTURE, p)
+    return p
 
 
 @pytest.fixture
@@ -176,22 +239,22 @@ def test_sub_symbol_not_matched(tmp_lib):
     assert m[0] < c.find('symbol "C_0_1"')
 
 
-def test_has_property_true(tmp_lib):
+def test_find_property_span_hit(tmp_lib):
     c = Path(tmp_lib).read_text(encoding="utf-8")
     m = _find_symbol_in_lib(c, "C")
-    assert _has_property(c[m[0] : m[1]], "Manufacturer")
+    assert _find_property_span(c[m[0] : m[1]], "Manufacturer") is not None
 
 
-def test_has_property_false(tmp_lib):
+def test_find_property_span_miss(tmp_lib):
     c = Path(tmp_lib).read_text(encoding="utf-8")
     m = _find_symbol_in_lib(c, "R")
-    assert not _has_property(c[m[0] : m[1]], "Manufacturer")
+    assert _find_property_span(c[m[0] : m[1]], "Manufacturer") is None
 
 
-def test_has_property_partial(tmp_lib):
+def test_find_property_span_rejects_name_prefix(tmp_lib):
     c = Path(tmp_lib).read_text(encoding="utf-8")
     m = _find_symbol_in_lib(c, "C")
-    assert not _has_property(c[m[0] : m[1]], "Man")
+    assert _find_property_span(c[m[0] : m[1]], "Man") is None
 
 
 def test_found_block_includes_closing_paren(tmp_lib):
@@ -218,7 +281,16 @@ def test_add_keeps_paren_balance(tabbed_lib):
     assert balance(Path(tabbed_lib).read_text(encoding="utf-8")) == before == 0
 
 
-def test_update_keeps_paren_balance(tabbed_lib):
+def test_update_keeps_symbol_shape(tabbed_lib):
+    """Updating a property must not change which children the symbol has.
+
+    Net paren balance cannot express this: truncating the property match (+1)
+    and losing the symbol's closer (-1) cancel exactly, so the pre-fix output
+    balanced to zero while `kicad-cli sym upgrade` still reported "Unable to
+    load library". The orphaned (hide yes)/(effects ...) fragments it left
+    behind do show up as extra direct children of the symbol.
+    """
+    before = child_heads(_find_symbol_in_lib(TABBED_LIB, "LED")[2])
     add_symbol_property(
         {
             "libraryPath": tabbed_lib,
@@ -229,6 +301,9 @@ def test_update_keeps_paren_balance(tabbed_lib):
     )
     c = Path(tabbed_lib).read_text(encoding="utf-8")
     assert balance(c) == 0
+    assert child_heads(_find_symbol_in_lib(c, "LED")[2]) == before
+    # The symbol block must still stop where the symbol stops, not run to EOF.
+    assert _find_symbol_in_lib(c, "LED")[1] < c.rindex(")")
     assert "Inolux" in c
     assert "Osram" not in c
 
@@ -301,7 +376,16 @@ def test_new_property_lands_on_parent_not_sub_symbol(tabbed_lib):
 
 
 def test_update_targets_parent_when_sub_symbol_shares_name(tabbed_lib):
-    """LED_0_1 also carries a Reference; the parent's copy is the one to edit."""
+    """LED_0_1 also carries a Reference; the parent's copy is the one to edit.
+
+    Locating the right property was never the whole problem — the pre-fix code
+    also found the parent's copy, then truncated the replacement, so the
+    position-only assertions this test used to make passed on a file kicad-cli
+    rejects. The sub-symbol must come back byte-identical and the parent's set of
+    children must be unchanged.
+    """
+    before = child_heads(_find_symbol_in_lib(TABBED_LIB, "LED")[2])
+    unit_before = sub_block(TABBED_LIB, "LED_0_1")
     add_symbol_property(
         {
             "libraryPath": tabbed_lib,
@@ -312,6 +396,8 @@ def test_update_targets_parent_when_sub_symbol_shares_name(tabbed_lib):
     )
     c = Path(tabbed_lib).read_text(encoding="utf-8")
     assert balance(c) == 0
+    assert child_heads(_find_symbol_in_lib(c, "LED")[2]) == before
+    assert sub_block(c, "LED_0_1") == unit_before
     assert c.index('"Reference" "LD"') < c.index('(symbol "LED_0_1"')
     # The unit's own Reference is untouched.
     assert c.count('"Reference" "D"') == 1
@@ -328,8 +414,12 @@ def test_new_property_uses_file_indentation(tabbed_lib):
         }
     )
     c = Path(tabbed_lib).read_text(encoding="utf-8")
-    assert '\t\t(property "MPN" "IN-P32DATRG"' in c
-    assert "\t\t\t(hide yes)" in c
+    # Anchored on the newline: '\t\t(property' is a substring of the three-tab
+    # form the pre-fix code emitted, so without the "\n" this cannot tell the
+    # symbol's own level from one tab deeper inside a unit.
+    assert '\n\t\t(property "MPN" "IN-P32DATRG"' in c
+    assert '\n\t\t\t(property "MPN"' not in c
+    assert "\n\t\t\t(hide yes)" in c
     assert "    (property" not in c
 
 
@@ -427,7 +517,12 @@ def test_paren_balance_ignores_quoted_parens():
 
 
 def test_unbalanced_edit_is_refused(tabbed_lib, monkeypatch):
-    """The write guard is the backstop for any future slicing mistake."""
+    """The balance guard catches a slice that gains or loses a paren.
+
+    It is deliberately narrow: an edit that stays balanced but lands at the wrong
+    nesting depth passes it untouched. That half is covered by
+    test_guard_refuses_property_spliced_outside_symbol.
+    """
     import commands.add_symbol_property as mod
 
     monkeypatch.setattr(mod, "_build_property", lambda *a, **k: '(property "MPN" "X1"')
@@ -443,6 +538,375 @@ def test_unbalanced_edit_is_refused(tabbed_lib, monkeypatch):
     assert not r["success"]
     assert "unbalance" in r["message"]
     assert Path(tabbed_lib).read_text(encoding="utf-8") == original
+
+
+# --- regression: the insertion anchor on the symbol's own first line -------- #
+
+COMPACT_LIB = (
+    '(kicad_symbol_lib (version 20231120) (generator "test")\n'
+    '\t(symbol "R" (symbol "R_0_1" (rectangle (start -1 1) (end 1 -1))))\n'
+    ")\n"
+)
+
+BARE_LIB = '(kicad_symbol_lib (version 20231120) (generator "test")\n' '\t(symbol "EMPTY")\n' ")\n"
+
+
+@pytest.fixture(params=[COMPACT_LIB, BARE_LIB], ids=["shared-line-unit", "bare-symbol"])
+def one_line_lib(request, tmp_path):
+    """A symbol whose insertion anchor sits on the line that opens the symbol.
+
+    Both shapes make ``block.rfind("\\n", 0, anchor)`` return -1, so the
+    pre-fix line-start arithmetic collapsed to index 0 — the symbol's own "(".
+    """
+    p = tmp_path / "one_line.kicad_sym"
+    p.write_text(request.param, encoding="utf-8")
+    return p
+
+
+def test_new_property_stays_inside_one_line_symbol(one_line_lib):
+    """The property must become a child of the symbol, not a sibling of it."""
+    name = "R" if 'symbol "R"' in one_line_lib.read_text(encoding="utf-8") else "EMPTY"
+    r = add_symbol_property(
+        {
+            "libraryPath": str(one_line_lib),
+            "symbolName": name,
+            "propertyName": "MPN",
+            "propertyValue": "RC0402",
+        }
+    )
+    assert r["success"], r["message"]
+    c = one_line_lib.read_text(encoding="utf-8")
+    assert balance(c) == 0
+    _, _, block = _find_symbol_in_lib(c, name)
+    assert _find_property_span(block, "MPN") is not None
+    # A sibling would sort before the symbol's own opening paren.
+    assert c.index('"MPN"') > c.index(f'(symbol "{name}"')
+    # ...and would be a direct child of (kicad_symbol_lib ...) instead.
+    assert _find_property_span(c[: c.rindex(")") + 1], "MPN") is None
+
+
+def test_guard_refuses_property_spliced_outside_symbol(tmp_path, monkeypatch):
+    """A balanced insert at the wrong depth must still be refused.
+
+    Reinstates the pre-fix line-start arithmetic to prove the structural guard —
+    not the paren-balance one — is what stops it. The balance is unchanged by
+    this mistake, so the balance guard lets it straight through.
+    """
+    import commands.add_symbol_property as mod
+
+    def old_arithmetic(block, anchor, indent, tail_indent, new_prop):
+        line_start = block.rfind("\n", 0, anchor) + 1
+        return block[:line_start] + indent + new_prop + "\n" + block[line_start:]
+
+    monkeypatch.setattr(mod, "_splice_child", old_arithmetic)
+    p = tmp_path / "compact.kicad_sym"
+    p.write_text(COMPACT_LIB, encoding="utf-8")
+    r = add_symbol_property(
+        {
+            "libraryPath": str(p),
+            "symbolName": "R",
+            "propertyName": "MPN",
+            "propertyValue": "RC0402",
+        }
+    )
+    assert not r["success"]
+    assert "direct child" in r["message"]
+    assert p.read_text(encoding="utf-8") == COMPACT_LIB
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(_KICAD_CLI is None, reason="kicad-cli not on PATH")
+def test_kicad_cli_loads_edited_one_line_library(one_line_lib, tmp_path):
+    name = "R" if 'symbol "R"' in one_line_lib.read_text(encoding="utf-8") else "EMPTY"
+    r = add_symbol_property(
+        {
+            "libraryPath": str(one_line_lib),
+            "symbolName": name,
+            "propertyName": "MPN",
+            "propertyValue": "RC0402",
+        }
+    )
+    assert r["success"], r["message"]
+    proc = upgrade_with_kicad_cli(one_line_lib, tmp_path / "out.kicad_sym")
+    assert proc.returncode == 0, f"{proc.stdout}{proc.stderr}"
+
+
+# --- regression: (effects ...) clobbered when a property is rewritten ------- #
+
+
+def test_update_preserves_hide_nested_in_effects(kicad9_lib):
+    """KiCad 8/9 write (hide yes) inside (effects ...), a grandchild.
+
+    Looking for it only among the property's direct children reported every such
+    field as visible, so rewriting one un-hid it.
+    """
+    before = KICAD9_FIXTURE.read_text(encoding="utf-8")
+    add_symbol_property(
+        {
+            "libraryPath": str(kicad9_lib),
+            "symbolName": "OPAMP",
+            "propertyName": "Footprint",
+            "propertyValue": "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm",
+        }
+    )
+    c = kicad9_lib.read_text(encoding="utf-8")
+    assert c.count("(hide yes)") == before.count("(hide yes)") == 16
+    _, _, block = _find_symbol_in_lib(c, "OPAMP")
+    start, end = _find_property_span(block, "Footprint")
+    assert "(hide yes)" in block[start:end]
+
+
+def test_update_preserves_justify_inside_effects(kicad9_lib):
+    """(justify ...) lives inside (effects ...) and was regenerated away."""
+    before = KICAD9_FIXTURE.read_text(encoding="utf-8")
+    add_symbol_property(
+        {
+            "libraryPath": str(kicad9_lib),
+            "symbolName": "OPAMP",
+            "propertyName": "Reference",
+            "propertyValue": "A",
+        }
+    )
+    c = kicad9_lib.read_text(encoding="utf-8")
+    assert c.count("(justify") == before.count("(justify") == 5
+    _, _, block = _find_symbol_in_lib(c, "OPAMP")
+    start, end = _find_property_span(block, "Reference")
+    assert "(justify left)" in block[start:end]
+
+
+def test_update_preserves_font_size_and_style(tmp_path):
+    """Font size, thickness, bold/italic and justification survive verbatim."""
+    effects = (
+        "(effects\n"
+        "\t\t\t\t(font\n"
+        "\t\t\t\t\t(size 2.54 3.81)\n"
+        "\t\t\t\t\t(thickness 0.5)\n"
+        "\t\t\t\t\t(bold yes)\n"
+        "\t\t\t\t\t(italic yes)\n"
+        "\t\t\t\t)\n"
+        "\t\t\t\t(justify right bottom)\n"
+        "\t\t\t)"
+    )
+    p = tmp_path / "styled.kicad_sym"
+    p.write_text(
+        '(kicad_symbol_lib (version 20241209) (generator "test")\n'
+        '\t(symbol "U1"\n'
+        '\t\t(property "MPN" "OLD"\n'
+        "\t\t\t(at 1 2 90)\n"
+        f"\t\t\t{effects}\n"
+        "\t\t)\n"
+        "\t)\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    add_symbol_property(
+        {"libraryPath": str(p), "symbolName": "U1", "propertyName": "MPN", "propertyValue": "NEW"}
+    )
+    c = p.read_text(encoding="utf-8")
+    assert effects in c
+    assert '(property "MPN" "NEW" (at 1 2 90)' in c
+    # No second, template-generated effects block was appended.
+    assert c.count("(effects") == 1
+
+
+def test_explicit_unhide_strips_hide_nested_in_effects(kicad9_lib):
+    add_symbol_property(
+        {
+            "libraryPath": str(kicad9_lib),
+            "symbolName": "OPAMP",
+            "propertyName": "Footprint",
+            "propertyValue": "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm",
+            "hide": False,
+        }
+    )
+    c = kicad9_lib.read_text(encoding="utf-8")
+    assert c.count("(hide yes)") == 15
+    _, _, block = _find_symbol_in_lib(c, "OPAMP")
+    start, end = _find_property_span(block, "Footprint")
+    assert "(hide" not in block[start:end]
+
+
+def test_kicad7_bare_hide_token_is_detected(tmp_path):
+    """KiCad 7 spelled it as a bare `hide` atom inside (effects ...)."""
+    p = tmp_path / "kicad7.kicad_sym"
+    p.write_text(
+        '(kicad_symbol_lib (version 20211014) (generator "test")\n'
+        '\t(symbol "U1"\n'
+        '\t\t(property "MPN" "OLD"\n'
+        "\t\t\t(at 1 2 0)\n"
+        "\t\t\t(effects (font (size 1.27 1.27)) hide)\n"
+        "\t\t)\n"
+        "\t)\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    add_symbol_property(
+        {"libraryPath": str(p), "symbolName": "U1", "propertyName": "MPN", "propertyValue": "NEW"}
+    )
+    c = p.read_text(encoding="utf-8")
+    assert balance(c) == 0
+    # Re-spelled as the modern property-level marker rather than dropped.
+    assert "(hide yes)" in c
+    assert "(font (size 1.27 1.27))" in c
+
+
+def test_kicad7_bare_hide_can_be_overridden(tmp_path):
+    p = tmp_path / "kicad7.kicad_sym"
+    p.write_text(
+        '(kicad_symbol_lib (version 20211014) (generator "test")\n'
+        '\t(symbol "U1"\n'
+        '\t\t(property "MPN" "OLD"\n'
+        "\t\t\t(at 1 2 0)\n"
+        "\t\t\t(effects (font (size 1.27 1.27)) hide)\n"
+        "\t\t)\n"
+        "\t)\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    add_symbol_property(
+        {
+            "libraryPath": str(p),
+            "symbolName": "U1",
+            "propertyName": "MPN",
+            "propertyValue": "NEW",
+            "hide": False,
+        }
+    )
+    c = p.read_text(encoding="utf-8")
+    assert "hide" not in c
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(_KICAD_CLI is None, reason="kicad-cli not on PATH")
+def test_kicad_cli_canonical_form_changes_only_the_value(kicad9_lib, tmp_path):
+    """KiCad's own serialisation is the arbiter of "nothing else was lost".
+
+    Round-tripping both the original and the edited library through
+    `sym upgrade` normalises formatting away, so any surviving difference is a
+    semantic one.
+    """
+    before_out = tmp_path / "before.kicad_sym"
+    assert upgrade_with_kicad_cli(KICAD9_FIXTURE, before_out).returncode == 0
+    add_symbol_property(
+        {
+            "libraryPath": str(kicad9_lib),
+            "symbolName": "OPAMP",
+            "propertyName": "Footprint",
+            "propertyValue": "Package_SO:SOIC-8",
+        }
+    )
+    after_out = tmp_path / "after.kicad_sym"
+    assert upgrade_with_kicad_cli(kicad9_lib, after_out).returncode == 0
+    expected = before_out.read_text(encoding="utf-8").replace(
+        '(property "Footprint" ""', '(property "Footprint" "Package_SO:SOIC-8"', 1
+    )
+    assert after_out.read_text(encoding="utf-8") == expected
+
+
+# --- regression: (at ...) separated by something other than a space --------- #
+
+
+@pytest.mark.parametrize("gap", ["\t", "\n\t\t\t\t", "  "], ids=["tab", "newline", "spaces"])
+def test_update_keeps_at_with_non_space_separator(tmp_path, gap):
+    """Any whitespace separates an s-expression head from its arguments.
+
+    Testing for the literal "(at " missed those spellings and silently dropped
+    the field back to (at 0 0 0).
+    """
+    p = tmp_path / "gap.kicad_sym"
+    p.write_text(
+        '(kicad_symbol_lib (version 20231120) (generator "test")\n'
+        '\t(symbol "U1"\n'
+        '\t\t(property "MPN" "OLD"\n'
+        f"\t\t\t(at{gap}5 6 90)\n"
+        "\t\t\t(effects (font (size 1.27 1.27)))\n"
+        "\t\t)\n"
+        "\t)\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    add_symbol_property(
+        {"libraryPath": str(p), "symbolName": "U1", "propertyName": "MPN", "propertyValue": "NEW"}
+    )
+    c = p.read_text(encoding="utf-8")
+    assert f"(at{gap}5 6 90)" in c
+    assert "(at 0 0 0)" not in c
+
+
+# --- regression: line endings and non-atomic writes ------------------------- #
+
+_NEWLINE_LIB = (
+    '(kicad_symbol_lib (version 20231120) (generator "test")\n'
+    '\t(symbol "U1"\n'
+    '\t\t(property "MPN" "OLD"\n'
+    "\t\t\t(at 0 0 0)\n"
+    "\t\t\t(effects (font (size 1.27 1.27)))\n"
+    "\t\t)\n"
+    "\t)\n"
+    ")\n"
+)
+
+
+def _edit(path: Path) -> None:
+    r = add_symbol_property(
+        {
+            "libraryPath": str(path),
+            "symbolName": "U1",
+            "propertyName": "MPN",
+            "propertyValue": "NEW",
+        }
+    )
+    assert r["success"], r["message"]
+
+
+def test_crlf_library_stays_crlf(tmp_path):
+    """A one-property edit must not rewrite every line ending in the file."""
+    p = tmp_path / "crlf.kicad_sym"
+    p.write_bytes(_NEWLINE_LIB.replace("\n", "\r\n").encode("utf-8"))
+    _edit(p)
+    crlf, lone_lf = newline_counts(p)
+    assert lone_lf == 0
+    assert crlf > 0
+
+
+def test_lf_library_stays_lf(tmp_path):
+    """Path.write_text maps "\\n" to os.linesep, so on Windows LF became CRLF."""
+    p = tmp_path / "lf.kicad_sym"
+    p.write_bytes(_NEWLINE_LIB.encode("utf-8"))
+    _edit(p)
+    crlf, lone_lf = newline_counts(p)
+    assert crlf == 0
+    assert lone_lf > 0
+
+
+def test_write_leaves_no_temp_file(tmp_path):
+    p = tmp_path / "atomic.kicad_sym"
+    p.write_bytes(_NEWLINE_LIB.encode("utf-8"))
+    _edit(p)
+    assert sorted(f.name for f in tmp_path.iterdir()) == ["atomic.kicad_sym"]
+
+
+def test_failed_write_leaves_original_intact(tmp_path, monkeypatch):
+    """The rename is the commit point: a failure before it cannot truncate."""
+    import commands.add_symbol_property as mod
+
+    p = tmp_path / "atomic.kicad_sym"
+    p.write_bytes(_NEWLINE_LIB.encode("utf-8"))
+
+    def boom(src, dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(mod.os, "replace", boom)
+    with pytest.raises(OSError):
+        add_symbol_property(
+            {
+                "libraryPath": str(p),
+                "symbolName": "U1",
+                "propertyName": "MPN",
+                "propertyValue": "NEW",
+            }
+        )
+    assert p.read_bytes() == _NEWLINE_LIB.encode("utf-8")
 
 
 if __name__ == "__main__":

--- a/tests/test_add_symbol_property.py
+++ b/tests/test_add_symbol_property.py
@@ -6,7 +6,15 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
-from commands.add_symbol_property import _find_symbol_in_lib, _has_property, add_symbol_property
+from commands.add_symbol_property import (  # noqa: E402
+    _find_property_span,
+    _find_symbol_in_lib,
+    _first_subsymbol_offset,
+    _has_property,
+    _match_paren,
+    _paren_balance,
+    add_symbol_property,
+)
 
 LIB = """(kicad_symbol_lib (version 20231120) (generator "test")
   (symbol "R" (pin_names hide) (in_bom yes) (on_board yes)
@@ -23,11 +31,83 @@ LIB = """(kicad_symbol_lib (version 20231120) (generator "test")
 )
 """
 
+# The layout eeschema actually writes: tabs, one property per several lines, and
+# unit sub-symbols that repeat the parent's property names. Every corruption
+# this module has caused in the field needed this shape to reproduce.
+TABBED_LIB = """(kicad_symbol_lib (version 20231120) (generator "eeschema")
+\t(symbol "LED"
+\t\t(pin_numbers hide)
+\t\t(exclude_from_sim no)
+\t\t(in_bom yes)
+\t\t(on_board yes)
+\t\t(property "Reference" "D"
+\t\t\t(at 0 2.54 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "LED"
+\t\t\t(at 0 -2.54 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Manufacturer" "Osram"
+\t\t\t(at 0 0 0)
+\t\t\t(hide yes)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(symbol "LED_0_1"
+\t\t\t(property "Reference" "D"
+\t\t\t\t(at 0 0 0)
+\t\t\t\t(effects (font (size 1.27 1.27)))
+\t\t\t)
+\t\t\t(polyline
+\t\t\t\t(pts (xy -1.27 -1.27) (xy -1.27 1.27))
+\t\t\t\t(stroke (width 0.254) (type default))
+\t\t\t)
+\t\t)
+\t\t(symbol "LED_1_1"
+\t\t\t(pin passive line (at -3.81 0 0) (length 2.54))
+\t\t)
+\t\t(symbol "LED_2_1"
+\t\t\t(pin passive line (at 3.81 0 180) (length 2.54))
+\t\t)
+\t)
+)
+"""
+
+
+def balance(text: str) -> int:
+    """Net paren balance, ignoring parens inside quoted tokens."""
+    depth = 0
+    in_string = False
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        i += 1
+    return depth
+
 
 @pytest.fixture
 def tmp_lib(tmp_path):
     p = tmp_path / "test.kicad_sym"
     p.write_text(LIB, encoding="utf-8")
+    return str(p)
+
+
+@pytest.fixture
+def tabbed_lib(tmp_path):
+    p = tmp_path / "tabbed.kicad_sym"
+    p.write_text(TABBED_LIB, encoding="utf-8")
     return str(p)
 
 
@@ -112,6 +192,257 @@ def test_has_property_partial(tmp_lib):
     c = Path(tmp_lib).read_text(encoding="utf-8")
     m = _find_symbol_in_lib(c, "C")
     assert not _has_property(c[m[0] : m[1]], "Man")
+
+
+def test_found_block_includes_closing_paren(tmp_lib):
+    c = Path(tmp_lib).read_text(encoding="utf-8")
+    start, end, block = _find_symbol_in_lib(c, "C")
+    assert block == c[start : end + 1]
+    assert balance(block) == 0
+
+
+# --- regression: library corruption on multi-unit, tab-indented symbols ----- #
+
+
+def test_add_keeps_paren_balance(tabbed_lib):
+    before = balance(Path(tabbed_lib).read_text(encoding="utf-8"))
+    add_symbol_property(
+        {
+            "libraryPath": tabbed_lib,
+            "symbolName": "LED",
+            "propertyName": "MPN",
+            "propertyValue": "IN-P32DATRG",
+            "hide": True,
+        }
+    )
+    assert balance(Path(tabbed_lib).read_text(encoding="utf-8")) == before == 0
+
+
+def test_update_keeps_paren_balance(tabbed_lib):
+    add_symbol_property(
+        {
+            "libraryPath": tabbed_lib,
+            "symbolName": "LED",
+            "propertyName": "Manufacturer",
+            "propertyValue": "Inolux",
+        }
+    )
+    c = Path(tabbed_lib).read_text(encoding="utf-8")
+    assert balance(c) == 0
+    assert "Inolux" in c
+    assert "Osram" not in c
+
+
+def test_update_replaces_whole_property_block(tabbed_lib):
+    """A multi-line property must be replaced entirely, not up to its first ")".
+
+    Truncating the match left the old (hide yes)/(effects ...) lines behind as
+    orphans directly under the symbol, which eeschema refuses to load.
+    """
+    add_symbol_property(
+        {
+            "libraryPath": tabbed_lib,
+            "symbolName": "LED",
+            "propertyName": "Manufacturer",
+            "propertyValue": "Inolux",
+        }
+    )
+    c = Path(tabbed_lib).read_text(encoding="utf-8")
+    assert c.count("(effects (font (size 1.27 1.27)))") == TABBED_LIB.count(
+        "(effects (font (size 1.27 1.27)))"
+    )
+    # Exactly one (hide yes) survives -- the rewritten property's own, inherited
+    # from the block it replaced. A second one would be an orphaned leftover.
+    assert c.count("(hide yes)") == 1
+
+
+def test_update_inherits_hide_and_position(tabbed_lib):
+    """Changing a value must not move or reveal an already-placed hidden field."""
+    add_symbol_property(
+        {
+            "libraryPath": tabbed_lib,
+            "symbolName": "LED",
+            "propertyName": "Reference",
+            "propertyValue": "LD",
+        }
+    )
+    c = Path(tabbed_lib).read_text(encoding="utf-8")
+    assert '(property "Reference" "LD" (at 0 2.54 0)' in c
+
+
+def test_update_can_override_hide_explicitly(tabbed_lib):
+    add_symbol_property(
+        {
+            "libraryPath": tabbed_lib,
+            "symbolName": "LED",
+            "propertyName": "Manufacturer",
+            "propertyValue": "Inolux",
+            "hide": False,
+        }
+    )
+    c = Path(tabbed_lib).read_text(encoding="utf-8")
+    assert balance(c) == 0
+    assert "(hide yes)" not in c
+
+
+def test_new_property_lands_on_parent_not_sub_symbol(tabbed_lib):
+    add_symbol_property(
+        {
+            "libraryPath": tabbed_lib,
+            "symbolName": "LED",
+            "propertyName": "MPN",
+            "propertyValue": "IN-P32DATRG",
+        }
+    )
+    c = Path(tabbed_lib).read_text(encoding="utf-8")
+    assert c.index('"MPN"') < c.index('(symbol "LED_0_1"')
+    _, _, block = _find_symbol_in_lib(c, "LED")
+    assert _find_property_span(block, "MPN") is not None
+
+
+def test_update_targets_parent_when_sub_symbol_shares_name(tabbed_lib):
+    """LED_0_1 also carries a Reference; the parent's copy is the one to edit."""
+    add_symbol_property(
+        {
+            "libraryPath": tabbed_lib,
+            "symbolName": "LED",
+            "propertyName": "Reference",
+            "propertyValue": "LD",
+        }
+    )
+    c = Path(tabbed_lib).read_text(encoding="utf-8")
+    assert balance(c) == 0
+    assert c.index('"Reference" "LD"') < c.index('(symbol "LED_0_1"')
+    # The unit's own Reference is untouched.
+    assert c.count('"Reference" "D"') == 1
+
+
+def test_new_property_uses_file_indentation(tabbed_lib):
+    add_symbol_property(
+        {
+            "libraryPath": tabbed_lib,
+            "symbolName": "LED",
+            "propertyName": "MPN",
+            "propertyValue": "IN-P32DATRG",
+            "hide": True,
+        }
+    )
+    c = Path(tabbed_lib).read_text(encoding="utf-8")
+    assert '\t\t(property "MPN" "IN-P32DATRG"' in c
+    assert "\t\t\t(hide yes)" in c
+    assert "    (property" not in c
+
+
+def test_symbol_without_sub_symbols(tmp_path):
+    p = tmp_path / "flat.kicad_sym"
+    p.write_text(
+        '(kicad_symbol_lib (version 20231120) (generator "test")\n'
+        '\t(symbol "FLAT"\n'
+        '\t\t(property "Reference" "U"\n'
+        "\t\t\t(at 0 0 0)\n"
+        "\t\t\t(effects (font (size 1.27 1.27)))\n"
+        "\t\t)\n"
+        "\t)\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    r = add_symbol_property(
+        {
+            "libraryPath": str(p),
+            "symbolName": "FLAT",
+            "propertyName": "MPN",
+            "propertyValue": "X1",
+        }
+    )
+    assert r["success"]
+    c = p.read_text(encoding="utf-8")
+    assert balance(c) == 0
+    _, _, block = _find_symbol_in_lib(c, "FLAT")
+    assert _find_property_span(block, "MPN") is not None
+
+
+def test_value_with_parens_is_not_parsed_as_list(tmp_path):
+    p = tmp_path / "paren.kicad_sym"
+    p.write_text(
+        '(kicad_symbol_lib (version 20231120) (generator "test")\n'
+        '\t(symbol "CAP"\n'
+        '\t\t(property "Description" "Ceramic (X7R) 50V"\n'
+        "\t\t\t(at 0 0 0)\n"
+        "\t\t\t(effects (font (size 1.27 1.27)))\n"
+        "\t\t)\n"
+        '\t\t(symbol "CAP_0_1"\n'
+        "\t\t\t(pin passive line (at 0 2.54 270) (length 2.54))\n"
+        "\t\t)\n"
+        "\t)\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    r = add_symbol_property(
+        {
+            "libraryPath": str(p),
+            "symbolName": "CAP",
+            "propertyName": "Description",
+            "propertyValue": "Ceramic (C0G) 100V",
+        }
+    )
+    assert r["success"]
+    c = p.read_text(encoding="utf-8")
+    assert balance(c) == 0
+    assert "Ceramic (C0G) 100V" in c
+    assert "X7R" not in c
+
+
+def test_value_with_quotes_is_escaped(tabbed_lib):
+    add_symbol_property(
+        {
+            "libraryPath": tabbed_lib,
+            "symbolName": "LED",
+            "propertyName": "Description",
+            "propertyValue": '3.2x2.8mm "PLCC-4"',
+        }
+    )
+    c = Path(tabbed_lib).read_text(encoding="utf-8")
+    assert balance(c) == 0
+    assert r"3.2x2.8mm \"PLCC-4\"" in c
+
+
+def test_match_paren_skips_quoted_parens():
+    s = '(a "b)c" (d))'
+    assert _match_paren(s, 0) == len(s) - 1
+
+
+def test_match_paren_unbalanced():
+    assert _match_paren("(a (b)", 0) == -1
+
+
+def test_first_subsymbol_offset_none_for_flat_block():
+    block = '(symbol "X" (property "Reference" "U" (at 0 0 0)))'
+    assert _first_subsymbol_offset(block) is None
+
+
+def test_paren_balance_ignores_quoted_parens():
+    assert _paren_balance('(a "b)c" (d))') == 0
+    assert _paren_balance(r'(a "he said \"hi(\"")') == 0
+    assert _paren_balance("(a (b)") == 1
+
+
+def test_unbalanced_edit_is_refused(tabbed_lib, monkeypatch):
+    """The write guard is the backstop for any future slicing mistake."""
+    import commands.add_symbol_property as mod
+
+    monkeypatch.setattr(mod, "_build_property", lambda *a, **k: '(property "MPN" "X1"')
+    original = Path(tabbed_lib).read_text(encoding="utf-8")
+    r = add_symbol_property(
+        {
+            "libraryPath": tabbed_lib,
+            "symbolName": "LED",
+            "propertyName": "MPN",
+            "propertyValue": "X1",
+        }
+    )
+    assert not r["success"]
+    assert "unbalance" in r["message"]
+    assert Path(tabbed_lib).read_text(encoding="utf-8") == original
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`add_symbol_property` corrupted every `.kicad_sym` library it touched. The symbol block was sliced `content[start:end]` — excluding the symbol's own closing paren — and then spliced back with `content[end + 1:]`, which skipped over that same paren. One `)` vanished per call, and the library eventually stopped loading.

Three further defects lived in the same write path:

- **New properties landed inside a unit.** The insertion point was matched with `\n\t\t\t(symbol "` — three tabs. Units in a `.kicad_sym` file sit at *two* tabs (three is the schematic's `lib_symbols` nesting, where the sibling tool `add_library_symbol_property` operates). The match never fired, so every insert took the fallback branch and appended to the end of the block, i.e. inside the last unit.
- **Updating a property truncated it.** The match `\(property "Name".*?\)` is non-greedy, so it stops at the first `)`. In the multi-line layout eeschema writes that is the `(at ...)` line, leaving the old `(hide yes)` and `(effects ...)` lines behind as orphans directly under the symbol.
- **Parens inside quoted values were counted as structure.** A `Description` of `"Ceramic (X7R) 50V"` mis-located the end of the block.

This is the tool most often used to write procurement fields (Manufacturer, MPN, supplier PNs) across a whole library, so the damage accumulates silently over a batch run and only surfaces when eeschema refuses to open the library.

## What changed

- Block boundaries come from a string-aware paren matcher (`_match_paren`), so quoted text is never read as structure.
- Properties are located and inserted at the symbol's own nesting level via `_iter_children`. A unit's `Reference` can no longer be mistaken for the symbol's, and new properties are placed before the first unit — where KiCad expects them.
- The whole property block is replaced on update, so no orphan `(hide yes)` / `(effects ...)` fragments are left behind.
- Values are escaped with the existing `escape_sexpr_string` helper.
- Indentation is copied from the file being edited rather than hardcoded to tabs, so space-indented and Eagle-imported libraries keep their formatting and the diff stays limited to the inserted lines.
- Rewriting a property now inherits its current position and visibility unless `position` / `hide` are given. Without this, replacing the block (the fix for the truncation bug) would have introduced a new one: updating a value would un-hide the field and move it back to the origin. The schema and the zod descriptions document the omit-to-inherit behaviour.

## Test plan

- [x] 17 new tests in `tests/test_add_symbol_property.py`, all against the tab-indented multi-unit layout eeschema actually writes (the previous fixture used a compact 2-space format in which none of these bugs reproduce): paren balance on add and on update, insertion above the first unit, parent-vs-unit property resolution, indentation matching, parens and quotes in values, and a symbol with no units.
- [x] `pytest tests/` — 1756 passed. The 20 failures are pre-existing on `upstream/main` at `0dc3ee8` (`test_pin_locator_y_flip`, `test_wire_connectivity_multi_unit`, `test_case_sensitivity_warning`, and others), unchanged by this branch.
- [x] `npm run build`, `npx vitest run` (70 passed), `eslint`, `prettier`, `black`, `isort`, `flake8`, `mypy` all clean.
- [x] End-to-end against a real 487-symbol library (5 multi-unit) with KiCad 10.0.4: 20 adds plus 5 updates.
  - Before: paren balance `+12`, `kicad-cli sym upgrade` exits 2 with `Unable to load library`.
  - After: paren balance `0`, `kicad-cli sym upgrade` exits 0.

## Note

`add_library_symbol_property` — the sibling tool that writes into a schematic's `lib_symbols` — shares the truncating-update pattern. It is left alone here to keep this change reviewable; I can follow up separately.
