### PR TITLE
feat: validate_schematic and validate_symbol_library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,21 +18,36 @@ All notable changes to the KiCAD MCP Server project are documented here.
   `"Ceramic (X7R) 50V"` are text, so the naive `count("(") - count(")")` check
   that gives false positives on real libraries is not used. On top of that:
   - **Orphaned fragments.** A `(property ...)`, `(effects ...)` or `(at ...)`
-    sitting directly under `(kicad_sch ...)` is what a truncated property
-    rewrite leaves behind. It is balanced, so nothing else notices, and
-    eeschema refuses to open the file.
+    sitting directly under `(kicad_sch ...)` — or, in a `.kicad_sym`, an
+    `(effects ...)`, `(at ...)`, `(hide ...)`, `(font ...)` or `(justify ...)`
+    directly inside a `(symbol ...)` — is what a truncated property rewrite
+    leaves behind. It is balanced, so nothing that counts parens notices, and
+    KiCad refuses to open the file — kicad-cli 10.0.4 answers
+    `Unable to load library` for a perfectly balanced library with either
+    fragment misplaced. The `.kicad_sym` rule is deliberately not applied to
+    `.kicad_sch`, where `(at ...)` is a legal child of a placed `(symbol ...)`.
   - **Stale unit names.** Renaming a symbol without renaming its `NAME_0_1`
     sub-symbols makes the _whole library_ unloadable — confirmed against
     kicad-cli 10.0, which is why this is graded an error rather than a warning.
+  - **Escaped units.** A dropped paren promotes a unit to the top level, where
+    its name still says which symbol it came from. Graded a _warning_, because
+    the library does still load (kicad-cli returns 0) — it just loads wrong:
+    KiCad reads the unit as a symbol of its own, so the parent keeps none of
+    those graphics or pins and `symbolCount` comes out too high.
   - **Duplicate symbol names**, where KiCad silently keeps one.
 
-  When the paren structure is broken, every node past the break nests one level
-  too deep, so the name checks are skipped rather than reporting hundreds of
-  consequences of the one real problem: on a real 487-symbol library a single
-  deleted `)` went from 489 reported errors to 2. Since `unclosed_form` can
-  only ever blame the outermost form (line 1), an indentation heuristic — KiCad
-  writes one tab per level — points at the first line where nesting stops
-  matching indentation, which is where the paren actually went missing.
+  When the paren structure is _unbalanced_, every node past the break nests one
+  level too deep, so the name checks are skipped rather than reporting hundreds
+  of consequences of the one real problem: on a real 487-symbol library a single
+  deleted `)` went from 489 reported errors to 2. Since `unclosed_form` can only
+  ever blame the outermost form (line 1), an indentation heuristic — KiCad writes
+  one tab per level — points at the first line where nesting stops matching
+  indentation, which is where the paren actually went missing. That heuristic
+  runs on every tab-indented file, not only when something else already failed,
+  because the case it is needed for most is a paren fault that _nets to zero_ —
+  one dropped and a later one spare, which is what a bad slice-and-splice edit
+  produces. Nothing counts its way to that fault and kicad-cli reports no
+  position for it, so the indentation is the only evidence there is.
 
   `kicad-cli` then runs on a throwaway copy as the authoritative answer, so a
   file that passes the scan but not KiCad is still reported. The copy is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,12 @@ All notable changes to the KiCAD MCP Server project are documented here.
   and trailing content — parens inside quoted values such as
   `"Ceramic (X7R) 50V"` are text, so the naive `count("(") - count(")")` check
   that gives false positives on real libraries is not used. On top of that:
-
   - **Orphaned fragments.** A `(property ...)`, `(effects ...)` or `(at ...)`
     sitting directly under `(kicad_sch ...)` is what a truncated property
     rewrite leaves behind. It is balanced, so nothing else notices, and
     eeschema refuses to open the file.
   - **Stale unit names.** Renaming a symbol without renaming its `NAME_0_1`
-    sub-symbols makes the *whole library* unloadable — confirmed against
+    sub-symbols makes the _whole library_ unloadable — confirmed against
     kicad-cli 10.0, which is why this is graded an error rather than a warning.
   - **Duplicate symbol names**, where KiCad silently keeps one.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### New Features
+
+- **`validate_schematic` and `validate_symbol_library`** — locate structural
+  damage in `.kicad_sch` / `.kicad_sym` files. `kicad-cli` answers whether a
+  file loads, but not why: one misplaced paren in a 40 000-line library
+  produces `Unable to load library` and nothing else, leaving a manual bisect
+  as the only way forward. These tools report the line and column of each
+  fault.
+
+  A single string-aware pass catches unbalanced parens, unterminated strings
+  and trailing content — parens inside quoted values such as
+  `"Ceramic (X7R) 50V"` are text, so the naive `count("(") - count(")")` check
+  that gives false positives on real libraries is not used. On top of that:
+
+  - **Orphaned fragments.** A `(property ...)`, `(effects ...)` or `(at ...)`
+    sitting directly under `(kicad_sch ...)` is what a truncated property
+    rewrite leaves behind. It is balanced, so nothing else notices, and
+    eeschema refuses to open the file.
+  - **Stale unit names.** Renaming a symbol without renaming its `NAME_0_1`
+    sub-symbols makes the *whole library* unloadable — confirmed against
+    kicad-cli 10.0, which is why this is graded an error rather than a warning.
+  - **Duplicate symbol names**, where KiCad silently keeps one.
+
+  When the paren structure is broken, every node past the break nests one level
+  too deep, so the name checks are skipped rather than reporting hundreds of
+  consequences of the one real problem: on a real 487-symbol library a single
+  deleted `)` went from 489 reported errors to 2. Since `unclosed_form` can
+  only ever blame the outermost form (line 1), an indentation heuristic — KiCad
+  writes one tab per level — points at the first line where nesting stops
+  matching indentation, which is where the paren actually went missing.
+
+  `kicad-cli` then runs on a throwaway copy as the authoritative answer, so a
+  file that passes the scan but not KiCad is still reported. The copy is not
+  optional: `upgrade` rewrites in place, and a validator must not modify the
+  file it is validating. Pass `runKicadCli: false` for a structure-only check
+  or when KiCad is not installed.
+
 ### Bug Fixes
 
 - **`add_layer` could not add inner copper layers, and corrupted an unrelated

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 **Key Capabilities:**
 
-- 146 tools across 13 categories with JSON Schema validation
+- 148 tools across 14 categories with JSON Schema validation
 - Keyword tool discovery via `search_tools` / `get_category_tools`
 - 8 dynamic resources exposing project state
 - Complete schematic workflow with 27 tools and dynamic symbol loading (~10,000 symbols)

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ configuration command and backend options.
 We've implemented an intelligent tool router to keep AI context efficient while maintaining full functionality:
 
 - **22 direct tools** always visible for high-frequency operations
-- **111 routed tools** organized into 13 categories (board, component, export, drc, schematic, library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, parts-registry)
+- **113 routed tools** organized into 14 categories (board, component, export, drc, schematic, library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, validation, parts-registry)
 - **4 router tools** for discovery and execution:
   - `list_tool_categories` - Browse all available categories
   - `get_category_tools` - View tools in a specific category
@@ -486,7 +486,7 @@ Access project state without executing tools:
 
 ## Available Tools
 
-The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **146 tools** are additionally indexed into 13 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
+The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **148 tools** are additionally indexed into 14 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
 
 For the complete tool reference with access types (direct/routed/additional), see [Tool Inventory](docs/TOOL_INVENTORY.md).
 
@@ -1363,7 +1363,7 @@ How many Basic parts are available?
 - **JSON-RPC 2.0 Transport:** Bi-directional communication via STDIO
 - **Protocol Version:** MCP 2025-06-18
 - **Capabilities:** Tools (122), Resources (8)
-- **Tool Router:** Intelligent discovery system with 13 categories
+- **Tool Router:** Intelligent discovery system with 14 categories
 - **Error Handling:** Standard JSON-RPC error codes
 
 ### TypeScript Server (`src/`)
@@ -1513,7 +1513,7 @@ npm run format
 
 See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix and [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
 
-**Working Features (146 tools):**
+**Working Features (148 tools):**
 
 - Project management with snapshot checkpointing
 - Complete board design (outline, layers, zones, mounting holes, text, SVG logos)
@@ -1524,6 +1524,7 @@ See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix a
 - FFC/ribbon cable passthrough workflow
 - Schematic-to-board synchronization
 - Design rule checking (DRC and ERC)
+- Structural validation of schematics and symbol libraries
 - Export to Gerber, PDF, SVG, 3D, BOM, netlist, position file
 - Custom footprint and symbol creation
 - JLCPCB parts integration (2.5M+ parts catalog)

--- a/python/commands/validate_kicad_files.py
+++ b/python/commands/validate_kicad_files.py
@@ -8,7 +8,15 @@ These tools do the locating. A single string-aware pass over the text reports
 the line and column of every structural fault, then a set of KiCad-specific
 checks catches the damage that is syntactically legal but still wrong -- a
 property sitting directly under ``(kicad_sch ...)`` instead of inside a symbol,
-or a unit still named after the symbol it was renamed away from.
+an ``(effects ...)`` tail left inside a ``(symbol ...)`` by a truncated rewrite,
+a unit that escaped its parent, or one still named after the symbol it was
+renamed away from.
+
+Paren faults that net to zero are the hard case, because nothing counts them and
+``kicad-cli`` reports no position for them. Since KiCad writes one tab per
+nesting level, the first line whose indentation stops agreeing with its depth is
+where the structure broke, and that check runs on every tab-indented file rather
+than only when something else already failed.
 
 ``kicad-cli`` is then run on a throwaway copy as the authoritative answer, so a
 file that passes here but not there is reported rather than hidden. The copy
@@ -42,7 +50,31 @@ _ATOM = re.compile(r"[^\s()\"]+")
 # left the tail behind (see the add_symbol_property truncation bug).
 _ORPHAN_FRAGMENTS = frozenset({"property", "effects", "hide", "at", "font", "justify"})
 
-# Cap on how much a hierarchical validation may copy to the temp dir.
+# The same fragments minus "property", which is a perfectly legal direct child
+# of (symbol ...) in a .kicad_sym -- these five never are. Checked against all
+# 222 libraries KiCad 10 ships (22 776 symbols): the only direct children of a
+# (symbol ...) there are property, symbol, embedded_fonts, extends,
+# exclude_from_sim, in_bom, on_board, in_pos_files,
+# duplicate_pin_numbers_are_jumpers, pin_names, pin_numbers, power and
+# body_styles, and of a unit pin, rectangle, polyline, arc, circle, text,
+# text_box, bezier and unit_name. kicad-cli 10.0.4 answers "Unable to load
+# library" for a perfectly balanced library with (effects ...) or (at ...)
+# placed there, which is why these are errors.
+#
+# .kicad_sch is a different format and this set does NOT apply to it: (at ...)
+# is a legal direct child of a placed (symbol ...) in a schematic.
+_SYMBOL_ORPHAN_FRAGMENTS = frozenset({"effects", "hide", "at", "font", "justify"})
+
+# A unit that escaped its parent symbol lands at the top level still carrying
+# the "<symbol>_<unit>_<style>" name it was given inside it.
+_UNIT_NAME = re.compile(r"(?P<stem>.+)_\d+_\d+$")
+
+# Spellings of false a shell or a hand-written script actually produces. JSON
+# has a real boolean, but a caller reaching this dispatch directly can pass the
+# string "false", which is truthy and would run the kicad-cli it asked to skip.
+_FALSE_STRINGS = frozenset({"", "0", "false", "no", "off", "none", "null"})
+
+# Cap on the size of the single file this will duplicate to run kicad-cli on.
 _MAX_CLI_COPY_BYTES = 64 * 1024 * 1024
 
 _CLI_TIMEOUT_SEC = 180
@@ -102,11 +134,34 @@ def _scan(content: str) -> Tuple[List[_Node], List[Dict[str, Any]]]:
             i += 1
             continue
 
+        # Before dispatching on the character: anything but whitespace out here
+        # is content the top-level form does not contain. Checking it after the
+        # '"' branch would let a quoted token through, because that branch
+        # consumes the whole string and continues. An extra ')' is excluded --
+        # unbalanced_close below names that far better.
+        if closed_root and not ch.isspace() and ch != ")":
+            issues.append(
+                _issue(
+                    "error",
+                    "trailing_content",
+                    "Content after the top-level form closed",
+                    line,
+                    i - line_start + 1,
+                )
+            )
+            closed_root = False
+
         if ch == '"':
             j = i + 1
             str_line, str_line_start = line, line_start
             while j < n:
                 if content[j] == "\\":
+                    # The escaped character may itself be the newline: skipping
+                    # it blind loses a line and shifts every position reported
+                    # after this string by one.
+                    if j + 1 < n and content[j + 1] == "\n":
+                        line += 1
+                        line_start = j + 2
                     j += 2
                     continue
                 if content[j] == '"':
@@ -131,17 +186,6 @@ def _scan(content: str) -> Tuple[List[_Node], List[Dict[str, Any]]]:
 
         if ch == "(":
             column = i - line_start + 1
-            if closed_root:
-                issues.append(
-                    _issue(
-                        "error",
-                        "trailing_content",
-                        "Content after the top-level form closed",
-                        line,
-                        column,
-                    )
-                )
-                closed_root = False
             atom = _ATOM.match(content, i + 1)
             node = _Node(
                 atom.group(0) if atom else "",
@@ -173,18 +217,6 @@ def _scan(content: str) -> Tuple[List[_Node], List[Dict[str, Any]]]:
                 )
             i += 1
             continue
-
-        if closed_root and not ch.isspace():
-            issues.append(
-                _issue(
-                    "error",
-                    "trailing_content",
-                    "Content after the top-level form closed",
-                    line,
-                    i - line_start + 1,
-                )
-            )
-            closed_root = False
 
         i += 1
 
@@ -220,8 +252,14 @@ def _indent_divergence(content: str, nodes: List[_Node]) -> Optional[Dict[str, A
         prefix = line_text[: node.column - 1]
         if prefix.strip():
             continue  # not the first token on its line
-        if prefix and set(prefix) != {"\t"}:
+        if set(prefix) - {"\t"}:
             continue  # space-indented line: the one-tab-per-level rule says nothing
+        if not prefix and node.depth:
+            # Un-indented but nested: a hand-edited or generated line sitting at
+            # column 1 is legal and says nothing about the paren structure. The
+            # depth-0 root also has no prefix, and that one must still be
+            # checked, so this cannot just test the prefix.
+            continue
         if len(prefix) != node.depth:
             return _issue(
                 "error",
@@ -255,6 +293,65 @@ def _check_orphan_fragments(nodes: List[_Node], root: str) -> List[Dict[str, Any
                     node.column,
                 )
             )
+    return issues
+
+
+def _check_symbol_child_fragments(nodes: List[_Node]) -> List[Dict[str, Any]]:
+    """Property-block tails that ended up as direct children of a (symbol ...).
+
+    .kicad_sym only -- see _SYMBOL_ORPHAN_FRAGMENTS for why this must not be
+    applied to a schematic. The truncating property rewrite leaves its tail
+    *inside* the symbol it was editing rather than under the root, so the
+    root-only check above cannot see the damage this module exists to find.
+    """
+    issues = []
+    for node in nodes:
+        if node.parent == "symbol" and node.name in _SYMBOL_ORPHAN_FRAGMENTS:
+            issues.append(
+                _issue(
+                    "error",
+                    "orphan_fragment",
+                    f"({node.name} ...) sits directly inside a (symbol ...); it belongs in "
+                    f"the (property ...) or graphic it was cut out of. KiCad refuses to "
+                    f"open the file (kicad-cli 10.0: 'Unable to load library').",
+                    node.line,
+                    node.column,
+                )
+            )
+    return issues
+
+
+def _check_escaped_units(symbols: Dict[str, _Node]) -> List[Dict[str, Any]]:
+    """Top-level symbols that are really units which escaped their parent.
+
+    A dropped paren above a unit promotes it to the top level, where its name
+    still says which symbol it came from. Unlike the fragments above this is a
+    warning: the library still loads (kicad-cli 10.0.4 returns 0), which is
+    exactly what makes it easy to miss. KiCad reads the unit as a symbol in its
+    own right, so the parent is left with none of those graphics or pins and the
+    library gains bogus extra entries -- which is also why symbolCount is higher
+    than the number of symbols the author meant to write.
+    """
+    issues = []
+    for name, node in symbols.items():
+        match = _UNIT_NAME.match(name)
+        if not match:
+            continue
+        stem = match.group("stem")
+        parent = symbols.get(stem)
+        if parent is None:
+            continue
+        issues.append(
+            _issue(
+                "warning",
+                "escaped_unit",
+                f"Top-level symbol '{name}' is a unit of '{stem}' (line {parent.line}) that "
+                f"escaped its parent; KiCad loads it as a separate symbol, leaving '{stem}' "
+                f"without those graphics and pins",
+                node.line,
+                node.column,
+            )
+        )
     return issues
 
 
@@ -301,51 +398,51 @@ def _cli_check(subcommand: str, work_dir: Path, target: Path) -> Dict[str, Any]:
     }
 
 
-def _copy_for_cli(root: Path, patterns: Tuple[str, ...], tmp: Path) -> Optional[Path]:
-    """Copy the file plus its siblings matching *patterns* into *tmp*.
+def _copy_for_cli(root: Path, tmp: Path) -> Optional[Path]:
+    """Copy the file under validation into *tmp*, on its own.
 
-    A hierarchical schematic only loads if its sub-sheets are reachable, so the
-    sheet cannot be validated alone. Returns the copied root, or None if the
-    tree is too large to duplicate.
+    Only that one file is needed. ``kicad-cli sch upgrade`` upgrades exactly the
+    file it is given and does not follow (sheet ...) references, so a sheet from
+    a hierarchical design validates alone -- verified against kicad-cli 10.0.4,
+    which returns 0 for a root sheet whose sub-sheet is absent from the
+    directory entirely, and again when the sub-sheet is present but corrupt.
+    Copying the siblings in would only make the size cap below depend on
+    unrelated projects that happen to share a parent directory, and tripping
+    that cap skips the authoritative check altogether.
+
+    Returns the copied file, or None if it alone is too large to duplicate.
     """
-    base = root.parent
-    sources = [root]
-    for pattern in patterns:
-        sources.extend(p for p in base.rglob(pattern) if p != root and p.is_file())
-
-    total = 0
-    for src in sources:
-        try:
-            total += src.stat().st_size
-        except OSError:
-            continue
-    if total > _MAX_CLI_COPY_BYTES:
+    try:
+        if root.stat().st_size > _MAX_CLI_COPY_BYTES:
+            return None
+    except OSError:
         return None
 
-    for src in sources:
-        try:
-            dest = tmp / src.relative_to(base)
-        except ValueError:
-            continue
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            shutil.copy2(src, dest)
-        except OSError:
-            continue
-    return tmp / root.name
+    dest = tmp / root.name
+    try:
+        shutil.copy2(root, dest)
+    except OSError:
+        return None
+    return dest
 
 
-def _run_cli_if(
-    path: Path, run_cli: bool, subcommand: str, patterns: Tuple[str, ...]
-) -> Dict[str, Any]:
+def _run_cli_if(path: Path, run_cli: bool, subcommand: str) -> Dict[str, Any]:
     """Confirm with kicad-cli, on a copy, unless the caller opted out."""
     if not run_cli:
         return {"ran": False, "reason": "not requested"}
     with tempfile.TemporaryDirectory(prefix="kicad-validate-") as tmp:
-        copy = _copy_for_cli(path, patterns, Path(tmp))
+        copy = _copy_for_cli(path, Path(tmp))
         if copy is None:
-            return {"ran": False, "reason": "file tree too large to copy for validation"}
+            return {"ran": False, "reason": "file too large to copy for validation"}
         return _cli_check(subcommand, Path(tmp), copy)
+
+
+def _wants_cli(params: Dict[str, Any]) -> bool:
+    """Whether to run kicad-cli, tolerating a string where a bool was meant."""
+    value = params.get("runKicadCli", True)
+    if isinstance(value, str):
+        return value.strip().lower() not in _FALSE_STRINGS
+    return bool(value)
 
 
 def _read(path: Path) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
@@ -411,7 +508,7 @@ def _finish(
 def validate_symbol_library(params: Dict[str, Any]) -> Dict[str, Any]:
     """Check that a .kicad_sym file is structurally sound and will load."""
     path = Path(params["libraryPath"])
-    run_cli = params.get("runKicadCli", True)
+    run_cli = _wants_cli(params)
 
     content, error = _read(path)
     if error:
@@ -420,19 +517,28 @@ def validate_symbol_library(params: Dict[str, Any]) -> Dict[str, Any]:
 
     nodes, issues = _scan(content)
     issues.extend(_check_root(nodes, "kicad_symbol_lib"))
+    unbalanced = bool(issues)
 
-    # Past a paren fault every node's depth is wrong, so the checks below would
-    # report hundreds of consequences of the one real problem. Locate the break
-    # and stop.
-    if issues:
-        hint = _indent_divergence(content, nodes)
-        if hint:
-            issues.append(hint)
+    # A paren fault that nets to zero -- one dropped and a later one spare,
+    # which is what a bad slice-and-splice rewrite produces -- leaves the scan
+    # above with nothing to report, and kicad-cli gives no line number either.
+    # The indentation hint is then the only thing that can say where the file
+    # broke, so it runs whatever the scan found rather than only as a footnote
+    # to a fault already caught.
+    hint = _indent_divergence(content, nodes)
+    if hint:
+        issues.append(hint)
+
+    # Past an *unbalanced* paren every later node's depth is wrong, so the
+    # checks below would report hundreds of consequences of the one real
+    # problem. Locate the break and stop.
+    if unbalanced:
         return _finish(
-            path, issues, {"semanticChecksRan": False}, _run_cli_if(path, run_cli, "sym", ())
+            path, issues, {"semanticChecksRan": False}, _run_cli_if(path, run_cli, "sym")
         )
 
     issues.extend(_check_orphan_fragments(nodes, "kicad_symbol_lib"))
+    issues.extend(_check_symbol_child_fragments(nodes))
 
     symbols: Dict[str, _Node] = {}
     symbol_nodes = [n for n in nodes if n.name == "symbol" and n.depth == 1]
@@ -459,9 +565,13 @@ def validate_symbol_library(params: Dict[str, Any]) -> Dict[str, Any]:
         else:
             symbols[name] = node
 
+    issues.extend(_check_escaped_units(symbols))
+
     # A unit is bound to its symbol by name, not by nesting. Renaming a symbol
-    # without renaming "OLD_0_1" leaves units that KiCad silently drops, so the
-    # symbol loads with no graphics and no pins.
+    # without renaming its "OLD_0_1" units leaves names that no longer match,
+    # and KiCad rejects the whole library rather than quietly dropping them:
+    # kicad-cli 10.0.4 answers "Unable to load library" for both `sym upgrade`
+    # and `sym export svg`.
     open_symbol: Optional[str] = None
     for node in nodes:
         if node.depth == 1 and node.name == "symbol":
@@ -482,14 +592,14 @@ def validate_symbol_library(params: Dict[str, Any]) -> Dict[str, Any]:
                     )
                 )
 
-    cli = _run_cli_if(path, run_cli, "sym", ())
+    cli = _run_cli_if(path, run_cli, "sym")
     return _finish(path, issues, {"symbolCount": len(symbols), "semanticChecksRan": True}, cli)
 
 
 def validate_schematic(params: Dict[str, Any]) -> Dict[str, Any]:
     """Check that a .kicad_sch file is structurally sound and will load."""
     path = Path(params["schematicPath"])
-    run_cli = params.get("runKicadCli", True)
+    run_cli = _wants_cli(params)
 
     content, error = _read(path)
     if error:
@@ -498,19 +608,24 @@ def validate_schematic(params: Dict[str, Any]) -> Dict[str, Any]:
 
     nodes, issues = _scan(content)
     issues.extend(_check_root(nodes, "kicad_sch"))
+    unbalanced = bool(issues)
 
-    # Past a paren fault every node's depth is wrong, so the checks below would
-    # report hundreds of consequences of the one real problem. Locate the break
-    # and stop.
-    if issues:
-        hint = _indent_divergence(content, nodes)
-        if hint:
-            issues.append(hint)
+    # See validate_symbol_library: a paren fault that nets to zero leaves the
+    # scan with nothing to report, and this hint is the only thing that can
+    # localise it, so it does not depend on the scan having found something.
+    hint = _indent_divergence(content, nodes)
+    if hint:
+        issues.append(hint)
+
+    # Past an *unbalanced* paren every later node's depth is wrong, so the
+    # checks below would report hundreds of consequences of the one real
+    # problem. Locate the break and stop.
+    if unbalanced:
         return _finish(
             path,
             issues,
             {"semanticChecksRan": False},
-            _run_cli_if(path, run_cli, "sch", ("*.kicad_sch",)),
+            _run_cli_if(path, run_cli, "sch"),
         )
 
     issues.extend(_check_orphan_fragments(nodes, "kicad_sch"))
@@ -529,5 +644,5 @@ def validate_schematic(params: Dict[str, Any]) -> Dict[str, Any]:
             )
         )
 
-    cli = _run_cli_if(path, run_cli, "sch", ("*.kicad_sch",))
+    cli = _run_cli_if(path, run_cli, "sch")
     return _finish(path, issues, {"componentCount": len(instances), "semanticChecksRan": True}, cli)

--- a/python/commands/validate_kicad_files.py
+++ b/python/commands/validate_kicad_files.py
@@ -1,0 +1,533 @@
+"""Structural validation for .kicad_sch and .kicad_sym files.
+
+``kicad-cli`` answers whether a file loads, but not why: a single misplaced
+paren anywhere in a 40 000-line library produces ``Unable to load library`` and
+nothing else. Recovering from that means bisecting the file by hand.
+
+These tools do the locating. A single string-aware pass over the text reports
+the line and column of every structural fault, then a set of KiCad-specific
+checks catches the damage that is syntactically legal but still wrong -- a
+property sitting directly under ``(kicad_sch ...)`` instead of inside a symbol,
+or a unit still named after the symbol it was renamed away from.
+
+``kicad-cli`` is then run on a throwaway copy as the authoritative answer, so a
+file that passes here but not there is reported rather than hidden. The copy
+matters: ``upgrade`` rewrites in place, and a validator must not touch the file
+it is validating.
+
+Tools:
+  - validate_schematic:      .kicad_sch structure and orphaned fragments
+  - validate_symbol_library: .kicad_sym structure, duplicates, unit naming
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from utils.kicad_cli import resolve_kicad_cli
+
+logger = logging.getLogger("kicad_interface")
+
+# Atom directly after "(" -- the node name. KiCad never puts space there.
+_ATOM = re.compile(r"[^\s()\"]+")
+
+# Tokens that only ever appear inside a property or graphic. Finding one as a
+# direct child of the root means a property rewrite truncated its block and
+# left the tail behind (see the add_symbol_property truncation bug).
+_ORPHAN_FRAGMENTS = frozenset({"property", "effects", "hide", "at", "font", "justify"})
+
+# Cap on how much a hierarchical validation may copy to the temp dir.
+_MAX_CLI_COPY_BYTES = 64 * 1024 * 1024
+
+_CLI_TIMEOUT_SEC = 180
+
+
+class _Node:
+    """One list in the file, recorded when its "(" is seen."""
+
+    __slots__ = ("name", "line", "column", "parent", "depth", "start")
+
+    def __init__(
+        self, name: str, line: int, column: int, parent: Optional[str], depth: int, start: int
+    ):
+        self.name = name
+        self.line = line
+        self.column = column
+        self.parent = parent
+        self.depth = depth
+        self.start = start
+
+
+def _issue(
+    severity: str, code: str, message: str, line: int = 0, column: int = 0
+) -> Dict[str, Any]:
+    return {
+        "severity": severity,
+        "code": code,
+        "message": message,
+        "line": line,
+        "column": column,
+    }
+
+
+def _scan(content: str) -> Tuple[List[_Node], List[Dict[str, Any]]]:
+    """Walk the s-expression text once, returning its nodes and structural faults.
+
+    Quoted tokens are skipped wholesale, so a ``"Cap (X7R)"`` description is
+    text rather than an unbalanced paren -- the false positive that makes a
+    naive ``count("(") - count(")")`` check useless on real libraries.
+    """
+    nodes: List[_Node] = []
+    issues: List[Dict[str, Any]] = []
+    stack: List[_Node] = []
+
+    line = 1
+    line_start = 0
+    closed_root = False
+    i = 0
+    n = len(content)
+
+    while i < n:
+        ch = content[i]
+
+        if ch == "\n":
+            line += 1
+            line_start = i + 1
+            i += 1
+            continue
+
+        if ch == '"':
+            j = i + 1
+            str_line, str_line_start = line, line_start
+            while j < n:
+                if content[j] == "\\":
+                    j += 2
+                    continue
+                if content[j] == '"':
+                    break
+                if content[j] == "\n":
+                    line += 1
+                    line_start = j + 1
+                j += 1
+            if j >= n:
+                issues.append(
+                    _issue(
+                        "error",
+                        "unterminated_string",
+                        "String opened here is never closed",
+                        str_line,
+                        i - str_line_start + 1,
+                    )
+                )
+                return nodes, issues
+            i = j + 1
+            continue
+
+        if ch == "(":
+            column = i - line_start + 1
+            if closed_root:
+                issues.append(
+                    _issue(
+                        "error",
+                        "trailing_content",
+                        "Content after the top-level form closed",
+                        line,
+                        column,
+                    )
+                )
+                closed_root = False
+            atom = _ATOM.match(content, i + 1)
+            node = _Node(
+                atom.group(0) if atom else "",
+                line,
+                column,
+                stack[-1].name if stack else None,
+                len(stack),
+                i,
+            )
+            nodes.append(node)
+            stack.append(node)
+            i += 1
+            continue
+
+        if ch == ")":
+            if stack:
+                stack.pop()
+                if not stack:
+                    closed_root = True
+            else:
+                issues.append(
+                    _issue(
+                        "error",
+                        "unbalanced_close",
+                        "Closing paren with nothing open -- the file has one ')' too many",
+                        line,
+                        i - line_start + 1,
+                    )
+                )
+            i += 1
+            continue
+
+        if closed_root and not ch.isspace():
+            issues.append(
+                _issue(
+                    "error",
+                    "trailing_content",
+                    "Content after the top-level form closed",
+                    line,
+                    i - line_start + 1,
+                )
+            )
+            closed_root = False
+
+        i += 1
+
+    for node in stack:
+        issues.append(
+            _issue(
+                "error",
+                "unclosed_form",
+                f"({node.name} ...) opened here is never closed",
+                node.line,
+                node.column,
+            )
+        )
+
+    return nodes, issues
+
+
+def _indent_divergence(content: str, nodes: List[_Node]) -> Optional[Dict[str, Any]]:
+    """Locate a missing/extra paren by where nesting stops matching indentation.
+
+    ``unclosed_form`` can only name the outermost form that stayed open, which
+    for a paren dropped in the middle of a file is always line 1 -- true and
+    useless. KiCad writes one tab per level, so the first line whose tab count
+    disagrees with its actual nesting depth is where the structure broke.
+    Returns None for files that are not tab-indented, where this says nothing.
+    """
+    lines = content.split("\n")
+    if not any(line.startswith("\t") for line in lines):
+        return None
+
+    for node in nodes:
+        line_text = lines[node.line - 1] if node.line - 1 < len(lines) else ""
+        prefix = line_text[: node.column - 1]
+        if prefix.strip():
+            continue  # not the first token on its line
+        if prefix and set(prefix) != {"\t"}:
+            continue  # space-indented line: the one-tab-per-level rule says nothing
+        if len(prefix) != node.depth:
+            return _issue(
+                "error",
+                "indent_depth_mismatch",
+                f"({node.name} ...) is indented {len(prefix)} level(s) but nests "
+                f"{node.depth} deep -- a paren is missing or extra above this line",
+                node.line,
+                node.column,
+            )
+    return None
+
+
+def _quoted_after(content: str, node: _Node) -> Optional[str]:
+    """First quoted token following a node's name, e.g. the name in (symbol "X")."""
+    m = re.compile(r'\s*"((?:[^"\\]|\\.)*)"').match(content, node.start + 1 + len(node.name))
+    return m.group(1) if m else None
+
+
+def _check_orphan_fragments(nodes: List[_Node], root: str) -> List[Dict[str, Any]]:
+    """Property/effects/at fragments that ended up as direct children of the root."""
+    issues = []
+    for node in nodes:
+        if node.depth == 1 and node.parent == root and node.name in _ORPHAN_FRAGMENTS:
+            issues.append(
+                _issue(
+                    "error",
+                    "orphan_fragment",
+                    f"({node.name} ...) sits directly under ({root} ...); it belongs "
+                    f"inside a symbol. KiCad refuses to open the file.",
+                    node.line,
+                    node.column,
+                )
+            )
+    return issues
+
+
+def _check_root(nodes: List[_Node], expected: str) -> List[Dict[str, Any]]:
+    if not nodes:
+        return [_issue("error", "empty_file", "File contains no s-expression", 1, 1)]
+    if nodes[0].name != expected:
+        return [
+            _issue(
+                "error",
+                "wrong_root",
+                f"Top-level form is ({nodes[0].name} ...), expected ({expected} ...)",
+                nodes[0].line,
+                nodes[0].column,
+            )
+        ]
+    return []
+
+
+def _cli_check(subcommand: str, work_dir: Path, target: Path) -> Dict[str, Any]:
+    """Run ``kicad-cli <subcommand> upgrade`` on a copy and report the outcome."""
+    cli = resolve_kicad_cli()
+    if not cli:
+        return {"ran": False, "reason": "kicad-cli not found"}
+    try:
+        proc = subprocess.run(
+            [cli, subcommand, "upgrade", str(target)],
+            cwd=str(work_dir),
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        return {"ran": False, "reason": f"kicad-cli timed out after {_CLI_TIMEOUT_SEC}s"}
+    except OSError as exc:
+        return {"ran": False, "reason": f"kicad-cli could not be executed: {exc}"}
+
+    output = (proc.stdout + proc.stderr).strip()
+    return {
+        "ran": True,
+        "ok": proc.returncode == 0,
+        "exitCode": proc.returncode,
+        "output": output[:2000],
+    }
+
+
+def _copy_for_cli(root: Path, patterns: Tuple[str, ...], tmp: Path) -> Optional[Path]:
+    """Copy the file plus its siblings matching *patterns* into *tmp*.
+
+    A hierarchical schematic only loads if its sub-sheets are reachable, so the
+    sheet cannot be validated alone. Returns the copied root, or None if the
+    tree is too large to duplicate.
+    """
+    base = root.parent
+    sources = [root]
+    for pattern in patterns:
+        sources.extend(p for p in base.rglob(pattern) if p != root and p.is_file())
+
+    total = 0
+    for src in sources:
+        try:
+            total += src.stat().st_size
+        except OSError:
+            continue
+    if total > _MAX_CLI_COPY_BYTES:
+        return None
+
+    for src in sources:
+        try:
+            dest = tmp / src.relative_to(base)
+        except ValueError:
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            shutil.copy2(src, dest)
+        except OSError:
+            continue
+    return tmp / root.name
+
+
+def _run_cli_if(
+    path: Path, run_cli: bool, subcommand: str, patterns: Tuple[str, ...]
+) -> Dict[str, Any]:
+    """Confirm with kicad-cli, on a copy, unless the caller opted out."""
+    if not run_cli:
+        return {"ran": False, "reason": "not requested"}
+    with tempfile.TemporaryDirectory(prefix="kicad-validate-") as tmp:
+        copy = _copy_for_cli(path, patterns, Path(tmp))
+        if copy is None:
+            return {"ran": False, "reason": "file tree too large to copy for validation"}
+        return _cli_check(subcommand, Path(tmp), copy)
+
+
+def _read(path: Path) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    if not path.exists():
+        return None, {"success": False, "message": f"File not found: {path}"}
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except UnicodeDecodeError as exc:
+        return None, {"success": False, "message": f"File is not valid UTF-8: {exc}"}
+    except OSError as exc:
+        return None, {"success": False, "message": f"Could not read {path}: {exc}"}
+
+
+def _finish(
+    path: Path,
+    issues: List[Dict[str, Any]],
+    extra: Dict[str, Any],
+    cli: Dict[str, Any],
+) -> Dict[str, Any]:
+    # kicad-cli is authoritative: a clean structural scan that it still rejects
+    # means a fault this module does not know how to name yet, and reporting
+    # "valid" there would be worse than saying nothing.
+    if cli.get("ran") and not cli.get("ok") and not any(i["severity"] == "error" for i in issues):
+        issues.append(
+            _issue(
+                "error",
+                "kicad_cli_rejected",
+                "Structure scan found nothing, but kicad-cli refused the file: "
+                + (cli.get("output") or "no output"),
+            )
+        )
+
+    issues.sort(key=lambda i: (i["line"], i["column"]))
+    errors = [i for i in issues if i["severity"] == "error"]
+    warnings = [i for i in issues if i["severity"] == "warning"]
+    valid = not errors
+
+    if valid:
+        message = f"{path.name} is valid"
+        if warnings:
+            message += f" ({len(warnings)} warning(s))"
+    else:
+        first = errors[0]
+        where = f" at line {first['line']}" if first["line"] else ""
+        message = (
+            f"{path.name} is invalid: {len(errors)} error(s), first{where}: {first['message']}"
+        )
+
+    result = {
+        "success": True,
+        "valid": valid,
+        "path": str(path),
+        "message": message,
+        "errorCount": len(errors),
+        "warningCount": len(warnings),
+        "issues": issues,
+        "kicadCli": cli,
+    }
+    result.update(extra)
+    return result
+
+
+def validate_symbol_library(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Check that a .kicad_sym file is structurally sound and will load."""
+    path = Path(params["libraryPath"])
+    run_cli = params.get("runKicadCli", True)
+
+    content, error = _read(path)
+    if error:
+        return error
+    assert content is not None
+
+    nodes, issues = _scan(content)
+    issues.extend(_check_root(nodes, "kicad_symbol_lib"))
+
+    # Past a paren fault every node's depth is wrong, so the checks below would
+    # report hundreds of consequences of the one real problem. Locate the break
+    # and stop.
+    if issues:
+        hint = _indent_divergence(content, nodes)
+        if hint:
+            issues.append(hint)
+        return _finish(
+            path, issues, {"semanticChecksRan": False}, _run_cli_if(path, run_cli, "sym", ())
+        )
+
+    issues.extend(_check_orphan_fragments(nodes, "kicad_symbol_lib"))
+
+    symbols: Dict[str, _Node] = {}
+    symbol_nodes = [n for n in nodes if n.name == "symbol" and n.depth == 1]
+    for node in symbol_nodes:
+        name = _quoted_after(content, node)
+        if name is None:
+            issues.append(
+                _issue(
+                    "error", "unnamed_symbol", "(symbol ...) has no name", node.line, node.column
+                )
+            )
+            continue
+        if name in symbols:
+            issues.append(
+                _issue(
+                    "warning",
+                    "duplicate_symbol",
+                    f"Symbol '{name}' is defined again (first at line "
+                    f"{symbols[name].line}); KiCad keeps only one",
+                    node.line,
+                    node.column,
+                )
+            )
+        else:
+            symbols[name] = node
+
+    # A unit is bound to its symbol by name, not by nesting. Renaming a symbol
+    # without renaming "OLD_0_1" leaves units that KiCad silently drops, so the
+    # symbol loads with no graphics and no pins.
+    open_symbol: Optional[str] = None
+    for node in nodes:
+        if node.depth == 1 and node.name == "symbol":
+            open_symbol = _quoted_after(content, node)
+        elif node.depth == 2 and node.name == "symbol" and open_symbol:
+            unit_name = _quoted_after(content, node)
+            parent_name = open_symbol
+            if unit_name is not None and not unit_name.startswith(f"{parent_name}_"):
+                issues.append(
+                    _issue(
+                        "error",
+                        "unit_name_mismatch",
+                        f"Unit '{unit_name}' does not start with '{parent_name}_'; "
+                        f"KiCad rejects the whole library (verified against "
+                        f"kicad-cli 10.0: 'Unable to load library')",
+                        node.line,
+                        node.column,
+                    )
+                )
+
+    cli = _run_cli_if(path, run_cli, "sym", ())
+    return _finish(path, issues, {"symbolCount": len(symbols), "semanticChecksRan": True}, cli)
+
+
+def validate_schematic(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Check that a .kicad_sch file is structurally sound and will load."""
+    path = Path(params["schematicPath"])
+    run_cli = params.get("runKicadCli", True)
+
+    content, error = _read(path)
+    if error:
+        return error
+    assert content is not None
+
+    nodes, issues = _scan(content)
+    issues.extend(_check_root(nodes, "kicad_sch"))
+
+    # Past a paren fault every node's depth is wrong, so the checks below would
+    # report hundreds of consequences of the one real problem. Locate the break
+    # and stop.
+    if issues:
+        hint = _indent_divergence(content, nodes)
+        if hint:
+            issues.append(hint)
+        return _finish(
+            path,
+            issues,
+            {"semanticChecksRan": False},
+            _run_cli_if(path, run_cli, "sch", ("*.kicad_sch",)),
+        )
+
+    issues.extend(_check_orphan_fragments(nodes, "kicad_sch"))
+
+    instances = [
+        n for n in nodes if n.name == "symbol" and n.depth == 1 and n.parent == "kicad_sch"
+    ]
+    has_lib_symbols = any(n.name == "lib_symbols" and n.depth == 1 for n in nodes)
+    if instances and not has_lib_symbols:
+        issues.append(
+            _issue(
+                "warning",
+                "missing_lib_symbols",
+                "Schematic places symbols but has no (lib_symbols ...) section; "
+                "run update_symbol_from_library to restore the cached definitions",
+            )
+        )
+
+    cli = _run_cli_if(path, run_cli, "sch", ("*.kicad_sch",))
+    return _finish(path, issues, {"componentCount": len(instances), "semanticChecksRan": True}, cli)

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -357,6 +357,7 @@ try:
     from commands.symbol_repair import SymbolRepairCommands
     from commands.symbol_schematic import SymbolSchematicCommands
     from commands.update_symbol_from_library import update_symbol_from_library
+    from commands.validate_kicad_files import validate_schematic, validate_symbol_library
 
     logger.info("Successfully imported all command handlers")
 except ImportError as e:
@@ -687,6 +688,9 @@ class KiCADInterface(SchematicHandlersMixin):
             "list_symbols_in_library": self._handle_list_symbols_in_library,
             "register_symbol_library": self._handle_register_symbol_library,
             "add_symbol_property": add_symbol_property,
+            # File validation (structure scan + kicad-cli confirmation)
+            "validate_schematic": validate_schematic,
+            "validate_symbol_library": validate_symbol_library,
             # Freerouting autoroute commands
             "autoroute": self.freerouting_commands.autoroute,
             "export_dsn": self.freerouting_commands.export_dsn,

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -3056,6 +3056,69 @@ UI_TOOLS = [
 ]
 
 # =============================================================================
+# VALIDATION TOOLS
+# =============================================================================
+
+VALIDATION_TOOLS = [
+    {
+        "name": "validate_schematic",
+        "title": "Validate Schematic File",
+        "description": (
+            "Check that a .kicad_sch file is structurally sound, reporting the line and "
+            "column of every fault. kicad-cli only says whether a file loads; this says "
+            "where it broke. Catches unbalanced parens, unterminated strings, trailing "
+            "content, and property/effects fragments orphaned directly under (kicad_sch), "
+            "which is what a truncated property rewrite leaves behind. kicad-cli is then "
+            "run on a throwaway copy as the authoritative answer, so the file being "
+            "validated is never modified. Run this after any tool that edits a schematic."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "schematicPath": {"type": "string", "description": "Path to the .kicad_sch file"},
+                "runKicadCli": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": (
+                        "Confirm with kicad-cli on a copy. Set false for a fast "
+                        "structure-only check, or when KiCad is not installed."
+                    ),
+                },
+            },
+            "required": ["schematicPath"],
+        },
+    },
+    {
+        "name": "validate_symbol_library",
+        "title": "Validate Symbol Library File",
+        "description": (
+            "Check that a .kicad_sym file is structurally sound and will load, reporting "
+            "the line and column of every fault instead of a bare 'Unable to load "
+            "library'. Beyond paren/string structure it reports units whose names no "
+            "longer match their symbol (a rename that missed the NAME_0_1 sub-symbols "
+            "makes the whole library unloadable) and duplicate symbol names. kicad-cli is "
+            "run on a throwaway copy, so the library is never modified. Run this after "
+            "any tool that edits a library."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "libraryPath": {"type": "string", "description": "Path to the .kicad_sym file"},
+                "runKicadCli": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": (
+                        "Confirm with kicad-cli on a copy. Set false for a fast "
+                        "structure-only check, or when KiCad is not installed."
+                    ),
+                },
+            },
+            "required": ["libraryPath"],
+        },
+    },
+]
+
+# =============================================================================
 # COMBINED TOOL SCHEMAS
 # =============================================================================
 
@@ -3072,6 +3135,7 @@ for tool in (
     + EXPORT_TOOLS
     + SCHEMATIC_TOOLS
     + UI_TOOLS
+    + VALIDATION_TOOLS
 ):
     TOOL_SCHEMAS[tool["name"]] = tool
 

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -3068,9 +3068,13 @@ VALIDATION_TOOLS = [
             "column of every fault. kicad-cli only says whether a file loads; this says "
             "where it broke. Catches unbalanced parens, unterminated strings, trailing "
             "content, and property/effects fragments orphaned directly under (kicad_sch), "
-            "which is what a truncated property rewrite leaves behind. kicad-cli is then "
-            "run on a throwaway copy as the authoritative answer, so the file being "
-            "validated is never modified. Run this after any tool that edits a schematic."
+            "which is what a truncated property rewrite leaves behind. A paren fault that "
+            "nets to zero is caught too, by the first line whose indentation stops "
+            "agreeing with its nesting depth. kicad-cli is then run on a throwaway copy "
+            "as the authoritative answer, so the file being validated is never modified. "
+            "'column' counts characters, so a tab counts once and the number will be "
+            "lower than an editor's ruler shows on indented lines. Run this after any "
+            "tool that edits a schematic."
         ),
         "inputSchema": {
             "type": "object",
@@ -3096,9 +3100,13 @@ VALIDATION_TOOLS = [
             "the line and column of every fault instead of a bare 'Unable to load "
             "library'. Beyond paren/string structure it reports units whose names no "
             "longer match their symbol (a rename that missed the NAME_0_1 sub-symbols "
-            "makes the whole library unloadable) and duplicate symbol names. kicad-cli is "
-            "run on a throwaway copy, so the library is never modified. Run this after "
-            "any tool that edits a library."
+            "makes the whole library unloadable), (effects ...)/(at ...) fragments a "
+            "truncated property rewrite left inside a (symbol ...), units that escaped "
+            "their parent to the top level, and duplicate symbol names. kicad-cli is "
+            "run on a throwaway copy, so the library is never modified. 'column' counts "
+            "characters, so a tab counts once and the number will be lower than an "
+            "editor's ruler shows on indented lines. Run this after any tool that edits "
+            "a library."
         ),
         "inputSchema": {
             "type": "object",

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ import { registerUITools } from "./tools/ui.js";
 import { registerFreeroutingTools } from "./tools/freerouting.js";
 import { registerEagleTools } from "./tools/eagle.js";
 import { registerPcbImportTools } from "./tools/pcb-import.js";
+import { registerValidationTools } from "./tools/validation.js";
 import { registerRouterTools } from "./tools/router.js";
 
 // Import resource registration functions
@@ -315,6 +316,7 @@ export class KiCADMcpServer {
     registerFreeroutingTools(this.server, this.callKicadScript.bind(this));
     registerEagleTools(this.server, this.callKicadScript.bind(this));
     registerPcbImportTools(this.server, this.callKicadScript.bind(this));
+    registerValidationTools(this.server, this.callKicadScript.bind(this));
 
     // Register all resources
     registerProjectResources(this.server, this.callKicadScript.bind(this));

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,3 +18,4 @@ export { registerFootprintTools } from "./footprint.js";
 export { registerSymbolCreatorTools } from "./symbol-creator.js";
 export { registerFreeroutingTools } from "./freerouting.js";
 export { registerPartsRegistryTools } from "./parts-registry.js";
+export { registerValidationTools } from "./validation.js";

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -212,6 +212,12 @@ export const toolCategories: ToolCategory[] = [
     tools: ["autoroute", "export_dsn", "import_ses", "check_freerouting"],
   },
   {
+    name: "validation",
+    description:
+      "File integrity checks: locate structural damage in schematics and symbol libraries before KiCad refuses to open them",
+    tools: ["validate_schematic", "validate_symbol_library"],
+  },
+  {
     name: "parts-registry",
     description:
       "Open gate-verified parts registry (PartReel by default, no auth): search existing KiCAD parts and download footprint/symbol/3D files before generating custom ones",

--- a/src/tools/validation.ts
+++ b/src/tools/validation.ts
@@ -17,7 +17,10 @@ export function registerValidationTools(server: McpServer, callKicadScript: Func
       "every fault. kicad-cli only says whether a file loads; this says where it broke. " +
       "Catches unbalanced parens, unterminated strings, trailing content, and property or " +
       "effects fragments orphaned directly under (kicad_sch ...), which is what a truncated " +
-      "property rewrite leaves behind. Run it after any tool that edits a schematic.",
+      "property rewrite leaves behind. A paren fault that nets to zero is caught too, by " +
+      "the first line whose indentation stops agreeing with its nesting depth. Note that " +
+      "column counts characters, so a tab counts once and the number reads lower than an " +
+      "editor's ruler on indented lines. Run it after any tool that edits a schematic.",
     {
       schematicPath: z.string().describe("Absolute path to the .kicad_sch file"),
       runKicadCli,
@@ -35,8 +38,12 @@ export function registerValidationTools(server: McpServer, callKicadScript: Func
     "Check that a .kicad_sym file is structurally sound and will load, reporting the line " +
       "and column of every fault instead of a bare 'Unable to load library'. Beyond paren " +
       "and string structure it reports units whose names no longer match their symbol (a " +
-      "rename that missed the NAME_0_1 sub-symbols makes the whole library unloadable) and " +
-      "duplicate symbol names. Run it after any tool that edits a library.",
+      "rename that missed the NAME_0_1 sub-symbols makes the whole library unloadable), " +
+      "(effects ...) or (at ...) fragments a truncated property rewrite left inside a " +
+      "(symbol ...), units that escaped their parent to the top level, and duplicate " +
+      "symbol names. Note that column counts characters, so a tab counts once and the " +
+      "number reads lower than an editor's ruler on indented lines. Run it after any tool " +
+      "that edits a library.",
     {
       libraryPath: z.string().describe("Absolute path to the .kicad_sym file"),
       runKicadCli,

--- a/src/tools/validation.ts
+++ b/src/tools/validation.ts
@@ -1,0 +1,51 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+export function registerValidationTools(server: McpServer, callKicadScript: Function) {
+  const runKicadCli = z
+    .boolean()
+    .optional()
+    .describe(
+      "Confirm the result with kicad-cli, run on a throwaway copy so the file is never " +
+        "modified (default true). Set false for a fast structure-only check, or when " +
+        "KiCad is not installed.",
+    );
+
+  server.tool(
+    "validate_schematic",
+    "Check that a .kicad_sch file is structurally sound, reporting the line and column of " +
+      "every fault. kicad-cli only says whether a file loads; this says where it broke. " +
+      "Catches unbalanced parens, unterminated strings, trailing content, and property or " +
+      "effects fragments orphaned directly under (kicad_sch ...), which is what a truncated " +
+      "property rewrite leaves behind. Run it after any tool that edits a schematic.",
+    {
+      schematicPath: z.string().describe("Absolute path to the .kicad_sch file"),
+      runKicadCli,
+    },
+    async (args: { schematicPath: string; runKicadCli?: boolean }) => {
+      const result = await callKicadScript("validate_schematic", args);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    "validate_symbol_library",
+    "Check that a .kicad_sym file is structurally sound and will load, reporting the line " +
+      "and column of every fault instead of a bare 'Unable to load library'. Beyond paren " +
+      "and string structure it reports units whose names no longer match their symbol (a " +
+      "rename that missed the NAME_0_1 sub-symbols makes the whole library unloadable) and " +
+      "duplicate symbol names. Run it after any tool that edits a library.",
+    {
+      libraryPath: z.string().describe("Absolute path to the .kicad_sym file"),
+      runKicadCli,
+    },
+    async (args: { libraryPath: string; runKicadCli?: boolean }) => {
+      const result = await callKicadScript("validate_symbol_library", args);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+}

--- a/tests/test_validate_kicad_files.py
+++ b/tests/test_validate_kicad_files.py
@@ -534,9 +534,11 @@ def test_run_kicad_cli_honours_a_string_false(tmp_path):
     for value in ("false", "False", "FALSE", "no", "0", "off", ""):
         r = validate_symbol_library({"libraryPath": path, "runKicadCli": value})
         assert r["kicadCli"] == {"ran": False, "reason": "not requested"}, value
+    # "was the CLI attempted", not "did it run": this suite must pass on a
+    # machine with no KiCad, where the attempt reports "kicad-cli not found".
     for value in ("true", "yes", "1"):
         r = validate_symbol_library({"libraryPath": path, "runKicadCli": value})
-        assert r["kicadCli"]["ran"] is True, value
+        assert r["kicadCli"].get("reason") != "not requested", value
 
 
 # --- no false positives on real files ---------------------------------------- #

--- a/tests/test_validate_kicad_files.py
+++ b/tests/test_validate_kicad_files.py
@@ -1,0 +1,329 @@
+"""Tests for validate_schematic / validate_symbol_library."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+from commands.validate_kicad_files import (  # noqa: E402
+    _scan,
+    validate_schematic,
+    validate_symbol_library,
+)
+from utils.kicad_cli import resolve_kicad_cli  # noqa: E402
+
+needs_cli = pytest.mark.skipif(
+    resolve_kicad_cli() is None, reason="kicad-cli not installed on this machine"
+)
+
+GOOD_LIB = """(kicad_symbol_lib
+\t(version 20231120)
+\t(generator "eeschema")
+\t(symbol "R"
+\t\t(property "Reference" "R"
+\t\t\t(at 0 0 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Description" "Resistor (thick film) 1%"
+\t\t\t(at 0 0 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(symbol "R_0_1"
+\t\t\t(rectangle (start -1 -2.5) (end 1 2.5))
+\t\t)
+\t\t(symbol "R_1_1"
+\t\t\t(pin passive line (at 0 3.81 270) (length 1.27))
+\t\t)
+\t)
+)
+"""
+
+GOOD_SCH = """(kicad_sch
+\t(version 20231120)
+\t(generator "eeschema")
+\t(paper "A4")
+\t(lib_symbols
+\t\t(symbol "Device:R"
+\t\t\t(property "Reference" "R"
+\t\t\t\t(at 0 0 0)
+\t\t\t\t(effects (font (size 1.27 1.27)))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 100 0)
+\t\t(uuid "11111111-2222-3333-4444-555555555555")
+\t)
+)
+"""
+
+
+def write(tmp_path, name, text):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+def check_lib(path, **kw):
+    """Structure-only by default so the suite does not need a KiCad install."""
+    kw.setdefault("runKicadCli", False)
+    return validate_symbol_library({"libraryPath": path, **kw})
+
+
+def check_sch(path, **kw):
+    kw.setdefault("runKicadCli", False)
+    return validate_schematic({"schematicPath": path, **kw})
+
+
+def codes(result):
+    return [i["code"] for i in result["issues"]]
+
+
+# --- structural scanner ---------------------------------------------------- #
+
+
+def test_scan_accepts_parens_inside_strings():
+    nodes, issues = _scan('(lib (property "Cap (X7R) 50V") )')
+    assert issues == []
+    assert [n.name for n in nodes] == ["lib", "property"]
+
+
+def test_scan_reports_unclosed_form_with_position():
+    _, issues = _scan('(kicad_symbol_lib\n\t(symbol "R"\n\t\t(pin)\n)\n')
+    assert [i["code"] for i in issues] == ["unclosed_form"]
+    assert issues[0]["line"] == 1
+
+
+def test_scan_reports_extra_close():
+    _, issues = _scan("(a (b))\n)")
+    assert [i["code"] for i in issues] == ["unbalanced_close"]
+    assert issues[0]["line"] == 2
+
+
+def test_scan_reports_unterminated_string():
+    _, issues = _scan('(a "never closed\n')
+    assert [i["code"] for i in issues] == ["unterminated_string"]
+
+
+def test_scan_reports_trailing_content():
+    _, issues = _scan("(a)\n(b)\n")
+    assert [i["code"] for i in issues] == ["trailing_content"]
+    assert issues[0]["line"] == 2
+
+
+def test_scan_records_depth_and_parent():
+    nodes, _ = _scan('(kicad_sch (symbol (lib_id "X")))')
+    by_name = {n.name: n for n in nodes}
+    assert by_name["symbol"].depth == 1
+    assert by_name["lib_id"].parent == "symbol"
+
+
+def test_scan_column_is_one_based():
+    _, issues = _scan("(a)\n  )")
+    assert issues[0]["line"] == 2
+    assert issues[0]["column"] == 3
+
+
+# --- symbol library -------------------------------------------------------- #
+
+
+def test_valid_library(tmp_path):
+    r = check_lib(write(tmp_path, "ok.kicad_sym", GOOD_LIB))
+    assert r["success"]
+    assert r["valid"], r["issues"]
+    assert r["symbolCount"] == 1
+    assert r["errorCount"] == 0
+
+
+def test_missing_paren_is_located(tmp_path):
+    """The exact damage add_symbol_property used to cause: one ')' short."""
+    broken = GOOD_LIB.replace("\t\t\t(effects (font (size 1.27 1.27)))\n\t\t)\n", "", 1)
+    r = check_lib(write(tmp_path, "bad.kicad_sym", broken))
+    assert not r["valid"]
+    assert "unclosed_form" in codes(r)
+    assert all(i["line"] > 0 for i in r["issues"])
+
+
+def test_missing_paren_points_at_the_break_not_just_line_one(tmp_path):
+    """unclosed_form can only ever blame the root; the indent hint locates it."""
+    broken = GOOD_LIB.replace("\t\t\t(effects (font (size 1.27 1.27)))\n\t\t)\n", "", 1)
+    r = check_lib(write(tmp_path, "bad.kicad_sym", broken))
+    hint = next(i for i in r["issues"] if i["code"] == "indent_depth_mismatch")
+    # First line whose nesting outran its indentation: the one after the break.
+    assert hint["line"] == 7
+
+
+def test_a_single_missing_paren_does_not_cascade(tmp_path):
+    """Every node past the break nests one level too deep; reporting each is noise."""
+    broken = GOOD_LIB.replace("\t\t\t(effects (font (size 1.27 1.27)))\n\t\t)\n", "", 1)
+    r = check_lib(write(tmp_path, "bad.kicad_sym", broken))
+    assert r["semanticChecksRan"] is False
+    assert r["errorCount"] == 2
+    assert "unit_name_mismatch" not in codes(r)
+
+
+def test_extra_paren_is_located(tmp_path):
+    r = check_lib(write(tmp_path, "x.kicad_sym", GOOD_LIB + ")\n"))
+    assert not r["valid"]
+    assert "unbalanced_close" in codes(r)
+
+
+def test_orphan_property_under_library_root(tmp_path):
+    broken = GOOD_LIB.replace(
+        '\t(symbol "R"', '\t(property "MPN" "X1"\n\t\t(at 0 0 0)\n\t)\n\t(symbol "R"', 1
+    )
+    r = check_lib(write(tmp_path, "o.kicad_sym", broken))
+    assert not r["valid"]
+    assert "orphan_fragment" in codes(r)
+
+
+def test_duplicate_symbol_is_a_warning(tmp_path):
+    dup = GOOD_LIB.replace("\n)\n", '\n\t(symbol "R"\n\t)\n)\n', 1)
+    r = check_lib(write(tmp_path, "d.kicad_sym", dup))
+    assert r["valid"]
+    assert "duplicate_symbol" in codes(r)
+    assert r["warningCount"] == 1
+
+
+def test_unit_left_behind_by_a_rename_is_an_error(tmp_path):
+    """Renaming "R" without renaming "R_0_1" makes the library unloadable."""
+    renamed = GOOD_LIB.replace('(symbol "R"', '(symbol "R_SMALL"', 1)
+    r = check_lib(write(tmp_path, "r.kicad_sym", renamed))
+    assert not r["valid"]
+    assert codes(r).count("unit_name_mismatch") == 2
+
+
+def test_units_of_correctly_renamed_symbol_pass(tmp_path):
+    renamed = GOOD_LIB.replace('"R', '"R_SMALL')
+    r = check_lib(write(tmp_path, "r2.kicad_sym", renamed))
+    assert r["valid"], r["issues"]
+
+
+def test_wrong_root_form(tmp_path):
+    r = check_lib(write(tmp_path, "w.kicad_sym", GOOD_SCH))
+    assert not r["valid"]
+    assert "wrong_root" in codes(r)
+
+
+def test_library_not_found():
+    r = validate_symbol_library({"libraryPath": "/no/such/lib.kicad_sym"})
+    assert not r["success"]
+
+
+def test_cli_is_skipped_when_not_requested(tmp_path):
+    r = check_lib(write(tmp_path, "ok.kicad_sym", GOOD_LIB))
+    assert r["kicadCli"]["ran"] is False
+    assert r["valid"]
+
+
+def test_message_names_the_first_error(tmp_path):
+    r = check_lib(write(tmp_path, "b.kicad_sym", GOOD_LIB + ")\n"))
+    assert "invalid" in r["message"]
+    assert "line" in r["message"]
+
+
+# --- schematic ------------------------------------------------------------- #
+
+
+def test_valid_schematic(tmp_path):
+    r = check_sch(write(tmp_path, "ok.kicad_sch", GOOD_SCH))
+    assert r["valid"], r["issues"]
+    assert r["componentCount"] == 1
+
+
+def test_orphan_property_under_schematic_root(tmp_path):
+    """What a truncated property rewrite leaves behind; eeschema will not open it."""
+    broken = GOOD_SCH.replace(
+        '\t(paper "A4")',
+        '\t(paper "A4")\n\t(property "MANUFACTURER" "TDK"\n\t\t(at 0 0 0)\n\t)',
+        1,
+    )
+    r = check_sch(write(tmp_path, "o.kicad_sch", broken))
+    assert not r["valid"]
+    assert "orphan_fragment" in codes(r)
+    assert r["issues"][0]["line"] == 5
+
+
+def test_orphan_effects_fragment(tmp_path):
+    broken = GOOD_SCH.replace(
+        '\t(paper "A4")', '\t(paper "A4")\n\t(effects (font (size 1.27 1.27)))', 1
+    )
+    r = check_sch(write(tmp_path, "e.kicad_sch", broken))
+    assert not r["valid"]
+    assert "orphan_fragment" in codes(r)
+
+
+def test_nested_property_is_not_flagged(tmp_path):
+    r = check_sch(write(tmp_path, "n.kicad_sch", GOOD_SCH))
+    assert "orphan_fragment" not in codes(r)
+
+
+def test_missing_lib_symbols_is_a_warning(tmp_path):
+    stripped = GOOD_SCH.replace(
+        '\t(lib_symbols\n\t\t(symbol "Device:R"\n'
+        '\t\t\t(property "Reference" "R"\n'
+        "\t\t\t\t(at 0 0 0)\n"
+        "\t\t\t\t(effects (font (size 1.27 1.27)))\n"
+        "\t\t\t)\n\t\t)\n\t)\n",
+        "",
+        1,
+    )
+    r = check_sch(write(tmp_path, "m.kicad_sch", stripped))
+    assert r["valid"]
+    assert "missing_lib_symbols" in codes(r)
+
+
+def test_schematic_not_found():
+    r = validate_schematic({"schematicPath": "/no/such/sheet.kicad_sch"})
+    assert not r["success"]
+
+
+def test_issues_are_ordered_by_position(tmp_path):
+    broken = GOOD_SCH.replace(
+        '\t(paper "A4")',
+        '\t(paper "A4")\n\t(at 0 0 0)\n\t(property "A" "b"\n\t\t(at 0 0 0)\n\t)\n\t(hide yes)',
+        1,
+    )
+    r = check_sch(write(tmp_path, "s.kicad_sch", broken))
+    lines = [i["line"] for i in r["issues"]]
+    assert lines == sorted(lines)
+    assert len(lines) == 3
+
+
+# --- kicad-cli integration ------------------------------------------------- #
+
+
+@needs_cli
+def test_cli_confirms_a_good_library(tmp_path):
+    r = validate_symbol_library({"libraryPath": write(tmp_path, "ok.kicad_sym", GOOD_LIB)})
+    assert r["kicadCli"]["ran"] is True
+    assert r["kicadCli"]["ok"] is True
+    assert r["valid"]
+
+
+@needs_cli
+def test_cli_does_not_modify_the_validated_file(tmp_path):
+    """upgrade rewrites in place, so it has to run on a copy."""
+    path = write(tmp_path, "ok.kicad_sym", GOOD_LIB)
+    validate_symbol_library({"libraryPath": path})
+    assert Path(path).read_text(encoding="utf-8") == GOOD_LIB
+
+
+@needs_cli
+def test_cli_agrees_a_stale_unit_name_is_fatal(tmp_path):
+    """Evidence for grading unit_name_mismatch as an error rather than a warning.
+
+    The file is perfectly balanced, so only KiCad itself can say whether it
+    loads -- and it does not.
+    """
+    renamed = GOOD_LIB.replace('(symbol "R"', '(symbol "R_SMALL"', 1)
+    r = validate_symbol_library({"libraryPath": write(tmp_path, "r.kicad_sym", renamed)})
+    assert r["kicadCli"]["ran"] is True
+    assert r["kicadCli"]["ok"] is False
+    assert not r["valid"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_validate_kicad_files.py
+++ b/tests/test_validate_kicad_files.py
@@ -6,12 +6,16 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+import commands.validate_kicad_files as vkf  # noqa: E402
 from commands.validate_kicad_files import (  # noqa: E402
+    _indent_divergence,
     _scan,
     validate_schematic,
     validate_symbol_library,
 )
 from utils.kicad_cli import resolve_kicad_cli  # noqa: E402
+
+FIXTURES = Path(__file__).parent / "fixtures"
 
 needs_cli = pytest.mark.skipif(
     resolve_kicad_cli() is None, reason="kicad-cli not installed on this machine"
@@ -56,6 +60,41 @@ GOOD_SCH = """(kicad_sch
 \t\t(at 100 100 0)
 \t\t(uuid "11111111-2222-3333-4444-555555555555")
 \t)
+)
+"""
+
+
+# Byte-for-byte what main's add_symbol_property produced when asked to update an
+# existing "Description" property on GOOD_LIB above (hide=True). Its removal
+# regex, `\(property "X"\s+"[^"]*".*?\)` non-greedy, stops at the ')' closing
+# (at 0 0 0) rather than the one closing the property, so the tail of the old
+# block survives; and it splices with content[:start] + block + content[end+1:]
+# where block excludes the symbol's own ')', dropping one. The two cancel: the
+# file stays balanced (27 '(' and 27 ')'), which is why nothing that counts
+# parens can see it. Lines 13-14 are the damage: the leftover (effects ...) now
+# sits directly inside (symbol "R"), whose ')' arrives a level early, promoting
+# both units to the top level.
+TRUNCATED_REWRITE = """(kicad_symbol_lib
+\t(version 20231120)
+\t(generator "eeschema")
+\t(symbol "R"
+\t\t(property "Reference" "R"
+\t\t\t(at 0 0 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Description" "Resistor (thick film) 1%" (at 0 0 0)
+\t\t\t(hide yes)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t\t)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(symbol "R_0_1"
+\t\t\t(rectangle (start -1 -2.5) (end 1 2.5))
+\t\t)
+\t\t(symbol "R_1_1"
+\t\t\t(pin passive line (at 0 3.81 270) (length 1.27))
+\t\t)
+\t
 )
 """
 
@@ -196,7 +235,12 @@ def test_unit_left_behind_by_a_rename_is_an_error(tmp_path):
 
 
 def test_units_of_correctly_renamed_symbol_pass(tmp_path):
-    renamed = GOOD_LIB.replace('"R', '"R_SMALL')
+    # Anchored on '(symbol "R': an unanchored '"R' -> '"R_SMALL' also rewrites
+    # "Reference" to "R_SMALLeference" and mangles the description, so the test
+    # would pass on an input it does not claim to be using.
+    renamed = GOOD_LIB.replace('(symbol "R', '(symbol "R_SMALL')
+    assert '"Reference"' in renamed
+    assert '"Resistor (thick film) 1%"' in renamed
     r = check_lib(write(tmp_path, "r2.kicad_sym", renamed))
     assert r["valid"], r["issues"]
 
@@ -293,6 +337,287 @@ def test_issues_are_ordered_by_position(tmp_path):
 
 
 # --- kicad-cli integration ------------------------------------------------- #
+
+
+# --- the truncated property rewrite, which is what all of this is for -------- #
+
+
+def test_truncated_rewrite_is_not_reported_as_valid(tmp_path):
+    """The corruption this module exists to catch used to pass the structure scan.
+
+    Balanced parens, so nothing counts its way to the fault; the orphan check
+    only looked at direct children of the root, and the tail lands inside the
+    symbol instead.
+    """
+    r = check_lib(write(tmp_path, "t.kicad_sym", TRUNCATED_REWRITE))
+    assert not r["valid"], r
+    assert r["errorCount"] == 2
+
+
+def test_truncated_rewrite_names_the_line_that_broke(tmp_path):
+    """Saying WHERE is the whole point: kicad-cli only says 'Unable to load'."""
+    r = check_lib(write(tmp_path, "t.kicad_sym", TRUNCATED_REWRITE))
+    assert "line 13" in r["message"]
+    assert [i["line"] for i in r["issues"] if i["severity"] == "error"] == [13, 13]
+
+
+def test_orphan_fragment_left_inside_a_symbol_is_an_error(tmp_path):
+    r = check_lib(write(tmp_path, "t.kicad_sym", TRUNCATED_REWRITE))
+    orphan = next(i for i in r["issues"] if i["code"] == "orphan_fragment")
+    assert orphan["line"] == 13
+    assert "(symbol ...)" in orphan["message"]
+
+
+def test_indent_hint_runs_when_the_scan_found_nothing(tmp_path):
+    """A dropped paren offset by a spare one leaves _scan with zero issues."""
+    _, issues = _scan(TRUNCATED_REWRITE)
+    assert issues == [], "premise: the paren scan itself sees nothing here"
+    r = check_lib(write(tmp_path, "t.kicad_sym", TRUNCATED_REWRITE))
+    hint = next(i for i in r["issues"] if i["code"] == "indent_depth_mismatch")
+    assert hint["line"] == 13
+
+
+def test_units_promoted_to_the_top_level_are_reported(tmp_path):
+    """Balanced, and kicad-cli 10.0.4 loads it (exit 0), so this is a warning.
+
+    KiCad reads each escaped unit as a symbol of its own, which is where the
+    inflated symbolCount comes from.
+    """
+    r = check_lib(write(tmp_path, "t.kicad_sym", TRUNCATED_REWRITE))
+    escaped = [i for i in r["issues"] if i["code"] == "escaped_unit"]
+    assert [i["line"] for i in escaped] == [15, 18]
+    assert all(i["severity"] == "warning" for i in escaped)
+    assert r["symbolCount"] == 3, "R plus the two units KiCad now sees as symbols"
+
+
+def test_at_directly_inside_a_symbol_is_an_error(tmp_path):
+    """Balanced, and kicad-cli 10.0.4 answers 'Unable to load library'."""
+    broken = GOOD_LIB.replace('\t\t(symbol "R_0_1"', '\t\t(at 0 0 0)\n\t\t(symbol "R_0_1"', 1)
+    r = check_lib(write(tmp_path, "at.kicad_sym", broken))
+    assert not r["valid"]
+    assert "orphan_fragment" in codes(r)
+
+
+def test_at_inside_a_placed_schematic_symbol_stays_legal(tmp_path):
+    """.kicad_sch is a different format: (at ...) IS a child of (symbol ...) there.
+
+    GOOD_SCH already relies on it, so widening the .kicad_sym rule must not leak
+    across.
+    """
+    assert "\t\t(at 100 100 0)" in GOOD_SCH
+    r = check_sch(write(tmp_path, "ok.kicad_sch", GOOD_SCH))
+    assert r["valid"], r["issues"]
+    assert "orphan_fragment" not in codes(r)
+
+
+# --- localisation must not blame an innocent line ---------------------------- #
+
+
+def test_unindented_line_is_not_blamed(tmp_path):
+    """A valid line at column 1 in a tab-indented file is not a paren fault.
+
+    The guard skipped space-indented lines but not zero-indented ones, because
+    "" is falsy, so this file was reported broken at line 2.
+    """
+    text = '(kicad_symbol_lib\n(version 20231120)\n\t(symbol "R"\n\t\t(pin)\n\t)\n)\n'
+    nodes, issues = _scan(text)
+    assert issues == [], "premise: the file is structurally perfect"
+    assert _indent_divergence(text, nodes) is None
+    r = check_lib(write(tmp_path, "flat.kicad_sym", text))
+    assert r["valid"], r["issues"]
+
+
+def test_unindented_line_does_not_outrank_the_real_break(tmp_path):
+    """_finish sorts by line, so a bogus line-2 hint would headline the report."""
+    text = '(kicad_symbol_lib\n(version 20231120)\n\t(symbol "R"\n\t\t\t(pin)\n\t)\n)\n'
+    nodes, _ = _scan(text)
+    hint = _indent_divergence(text, nodes)
+    assert hint is not None
+    assert hint["line"] == 4, "the over-indented (pin), not the un-indented (version)"
+
+
+def test_indent_hint_still_ignores_space_indented_files():
+    spaced = '(kicad_symbol_lib\n    (symbol "R"\n        (pin)\n    )\n)\n'
+    nodes, _ = _scan(spaced)
+    assert _indent_divergence(spaced, nodes) is None
+
+
+def test_root_at_column_one_is_still_checked():
+    """The depth-0 root has no prefix either; skipping on "" would exempt it."""
+    nested = '(kicad_symbol_lib\n\t(symbol "R"\n\t\t(pin)\n\t)\n)\n'
+    nodes, _ = _scan(nested)
+    assert _indent_divergence(nested, nodes) is None
+
+
+# --- scanner details -------------------------------------------------------- #
+
+
+def test_scan_reports_quoted_trailing_content():
+    """The '"' branch consumed the string and continued past the check."""
+    _, issues = _scan('(kicad_symbol_lib)\n"junk"\n')
+    assert [i["code"] for i in issues] == ["trailing_content"]
+    assert issues[0]["line"] == 2
+
+
+def test_escaped_newline_does_not_shift_later_line_numbers():
+    """`\\` before a newline was skipped without counting the line it ate."""
+    text = '(kicad_symbol_lib\n\t(symbol "A\\\nB")\n)\n)\n'
+    assert text.split("\n")[4] == ")", "premise: the spare ')' is on line 5"
+    _, issues = _scan(text)
+    assert [i["code"] for i in issues] == ["unbalanced_close"]
+    assert issues[0]["line"] == 5
+
+
+# --- kicad-cli is run on the file itself, not on its neighbours -------------- #
+
+
+def test_cli_copy_leaves_unrelated_siblings_behind(tmp_path, monkeypatch):
+    """`sch upgrade` upgrades only the file named, so siblings buy nothing.
+
+    Verified against kicad-cli 10.0.4: a root sheet whose sub-sheet is missing
+    from the directory entirely still returns 0.
+    """
+    target = tmp_path / "sheet.kicad_sch"
+    target.write_text(GOOD_SCH, encoding="utf-8")
+    (tmp_path / "unrelated.kicad_sch").write_text(GOOD_SCH, encoding="utf-8")
+    (tmp_path / "other_project").mkdir()
+    (tmp_path / "other_project" / "deep.kicad_sch").write_text(GOOD_SCH, encoding="utf-8")
+
+    copied = {}
+
+    def spy(subcommand, work_dir, cli_target):
+        copied["names"] = sorted(p.name for p in Path(work_dir).rglob("*"))
+        return {"ran": True, "ok": True, "exitCode": 0, "output": ""}
+
+    monkeypatch.setattr(vkf, "_cli_check", spy)
+    validate_schematic({"schematicPath": str(target), "runKicadCli": True})
+    assert copied["names"] == ["sheet.kicad_sch"]
+
+
+def test_unrelated_sibling_cannot_disable_the_cli_check(tmp_path, monkeypatch):
+    """Tripping the size cap skips the authoritative check and reports "valid".
+
+    Letting an unrelated file in the same directory decide that is the worst
+    version of this bug, so the cap must only ever see the file being validated.
+    """
+    monkeypatch.setattr(vkf, "_MAX_CLI_COPY_BYTES", 4096)
+    target = tmp_path / "sheet.kicad_sch"
+    target.write_text(GOOD_SCH, encoding="utf-8")
+    assert target.stat().st_size < 4096
+    (tmp_path / "huge.kicad_sch").write_text("x" * 8192, encoding="utf-8")
+
+    monkeypatch.setattr(
+        vkf,
+        "_cli_check",
+        lambda *a, **k: {"ran": True, "ok": True, "exitCode": 0, "output": ""},
+    )
+    r = validate_schematic({"schematicPath": str(target), "runKicadCli": True})
+    assert r["kicadCli"]["ran"] is True, r["kicadCli"]
+
+
+def test_oversized_target_still_skips_the_cli(tmp_path, monkeypatch):
+    monkeypatch.setattr(vkf, "_MAX_CLI_COPY_BYTES", 64)
+    target = tmp_path / "sheet.kicad_sch"
+    target.write_text(GOOD_SCH, encoding="utf-8")
+    r = validate_schematic({"schematicPath": str(target), "runKicadCli": True})
+    assert r["kicadCli"]["ran"] is False
+    assert "too large" in r["kicadCli"]["reason"]
+
+
+def test_run_kicad_cli_honours_a_string_false(tmp_path):
+    """JSON has a real boolean; a script calling this dispatch directly may not.
+
+    "false" is a non-empty string, so plain truthiness ran the CLI the caller
+    asked it to skip.
+    """
+    path = write(tmp_path, "ok.kicad_sym", GOOD_LIB)
+    for value in ("false", "False", "FALSE", "no", "0", "off", ""):
+        r = validate_symbol_library({"libraryPath": path, "runKicadCli": value})
+        assert r["kicadCli"] == {"ran": False, "reason": "not requested"}, value
+    for value in ("true", "yes", "1"):
+        r = validate_symbol_library({"libraryPath": path, "runKicadCli": value})
+        assert r["kicadCli"]["ran"] is True, value
+
+
+# --- no false positives on real files ---------------------------------------- #
+
+
+def test_repo_symbol_fixture_is_clean():
+    r = check_lib(str(FIXTURES / "Simulation_SPICE_minimal.kicad_sym"))
+    assert r["valid"], r["issues"]
+    assert r["issues"] == []
+
+
+def test_repo_schematic_fixture_is_clean():
+    r = check_sch(str(FIXTURES / "canonical_schematic.kicad_sch"))
+    assert r["valid"], r["issues"]
+    assert r["issues"] == []
+
+
+def test_minified_single_line_library_is_clean(tmp_path):
+    """No newlines and no indentation at all: every check must stay quiet."""
+    minified = " ".join(GOOD_LIB.split()) + "\n"
+    assert "\n" not in minified.strip()
+    r = check_lib(write(tmp_path, "min.kicad_sym", minified))
+    assert r["valid"], r["issues"]
+    assert r["issues"] == []
+    assert r["symbolCount"] == 1
+
+
+def test_space_indented_library_is_clean(tmp_path):
+    """The one-tab-per-level rule says nothing here, so it must not guess."""
+    spaced = "\n".join(
+        "    " * (len(ln) - len(ln.lstrip("\t"))) + ln.lstrip("\t") for ln in GOOD_LIB.split("\n")
+    )
+    assert "\t" not in spaced
+    r = check_lib(write(tmp_path, "sp.kicad_sym", spaced))
+    assert r["valid"], r["issues"]
+    assert r["issues"] == []
+
+
+def test_repo_symbol_fixture_survives_reindentation(tmp_path):
+    real = (FIXTURES / "Simulation_SPICE_minimal.kicad_sym").read_text(encoding="utf-8")
+    spaced = "\n".join(
+        "  " * (len(ln) - len(ln.lstrip("\t"))) + ln.lstrip("\t") for ln in real.split("\n")
+    )
+    assert "\t" not in spaced
+    r = check_lib(write(tmp_path, "sp.kicad_sym", spaced))
+    assert r["valid"], r["issues"]
+    r2 = check_lib(write(tmp_path, "min.kicad_sym", " ".join(real.split()) + "\n"))
+    assert r2["valid"], r2["issues"]
+
+
+# --- kicad-cli integration ------------------------------------------------- #
+
+
+@needs_cli
+def test_cli_agrees_the_truncated_rewrite_is_broken(tmp_path):
+    """Evidence that the file the structure scan used to pass really is broken."""
+    r = validate_symbol_library({"libraryPath": write(tmp_path, "t.kicad_sym", TRUNCATED_REWRITE)})
+    assert r["kicadCli"]["ran"] is True
+    assert r["kicadCli"]["ok"] is False
+    assert not r["valid"]
+    # The point of the module: a line number, not just "Unable to load library".
+    assert "line 13" in r["message"]
+
+
+@needs_cli
+def test_cli_agrees_promoted_units_still_load(tmp_path):
+    """Why escaped_unit is a warning: the library loads, it just loads wrong."""
+    hoisted = GOOD_LIB.replace(
+        '\t\t(symbol "R_0_1"\n\t\t\t(rectangle (start -1 -2.5) (end 1 2.5))\n\t\t)\n',
+        "",
+        1,
+    ).replace(
+        "\n)\n",
+        '\n\t(symbol "R_0_1"\n\t\t(rectangle (start -1 -2.5) (end 1 2.5))\n\t)\n)\n',
+        1,
+    )
+    r = validate_symbol_library({"libraryPath": write(tmp_path, "h.kicad_sym", hoisted)})
+    assert r["kicadCli"]["ran"] is True
+    assert r["kicadCli"]["ok"] is True, r["kicadCli"]
+    assert "escaped_unit" in codes(r)
+    assert r["valid"], r["issues"]
 
 
 @needs_cli


### PR DESCRIPTION
## Summary

Two new tools, `validate_schematic` and `validate_symbol_library`, that locate structural damage in `.kicad_sch` and `.kicad_sym` files.

`kicad-cli` already answers whether a file loads. It does not answer *where* it broke: one misplaced paren in a 40 000-line library produces `Unable to load library` and nothing else, which leaves bisecting the file by hand as the only way forward. Since the server has a growing set of tools that edit these files as text, "did my last edit damage the file, and if so where" is a question worth being able to ask directly. `kicad-cli` is invoked internally in 14 places but never exposed as a tool.

## What the scan finds

A single string-aware pass reports unbalanced parens, unterminated strings and trailing content, each with a line and column. Parens inside quoted values (`"Ceramic (X7R) 50V"`) are treated as text, so the naive `count("(") - count(")")` check — which gives false positives on any real library — is not used.

Three checks then cover damage that is syntactically legal but still fatal:

| Check | Why it matters |
|---|---|
| `orphan_fragment` | A `(property ...)`, `(effects ...)` or `(at ...)` directly under `(kicad_sch ...)` is what a truncated property rewrite leaves behind. It is balanced, so nothing else notices, and eeschema refuses to open the file. |
| `unit_name_mismatch` | Renaming a symbol without renaming its `NAME_0_1` sub-symbols makes the whole library unloadable. |
| `duplicate_symbol` | KiCad silently keeps one of them. |

`unit_name_mismatch` is graded an **error** rather than a warning on evidence: the file is perfectly balanced, so only KiCad can say whether it loads, and kicad-cli 10.0 answers `Unable to load library`. There is a test pinning that (`test_cli_agrees_a_stale_unit_name_is_fatal`).

## Two decisions worth calling out

**Semantic checks stop when the structure is broken.** Past a paren fault every subsequent node nests one level too deep, so the name checks turn into hundreds of reports of the same root cause. On a real 487-symbol library, deleting a single `)` produced 489 errors before this guard and 2 after. The response carries `semanticChecksRan: false` so the omission is visible rather than implied.

**An indentation heuristic locates the break.** `unclosed_form` can only ever name the outermost form that stayed open, which for a paren dropped mid-file is always line 1 — true and useless. KiCad writes one tab per nesting level, so the first line whose tab count disagrees with its actual depth is where the structure broke. On the corrupted 487-symbol library that points at line 75, the line right after the deleted paren. The heuristic is skipped for files that are not tab-indented, where it would say nothing.

**kicad-cli runs on a copy.** It is the authoritative answer, so a file that passes the scan but not KiCad is still reported (`kicad_cli_rejected`). The copy is not optional — `upgrade` rewrites in place, and a validator must not modify the file it is validating. There is a test for that too. A hierarchical schematic only loads if its sub-sheets are reachable, so sibling `.kicad_sch` files are copied alongside it, capped at 64 MB. `runKicadCli: false` gives a fast structure-only check, or lets the tool work where KiCad is not installed.

## Test plan

- [x] 30 new tests in `tests/test_validate_kicad_files.py`. All but the three `@needs_cli` ones are hermetic (`runKicadCli: false`), so the suite does not depend on a KiCad install; the cli-backed ones skip when `resolve_kicad_cli()` returns `None`.
- [x] `pytest tests/` — 1769 passed. The 20 failures are pre-existing on `upstream/main` at `0dc3ee8` and unchanged by this branch.
- [x] `npm run build`, `npx vitest run` (70 passed), `eslint`, `prettier`, `black`, `isort`, `flake8`, `mypy` clean. The README headline count guard is updated to 148 tools / 14 categories.
- [x] Against real files with KiCad 10.0.4: a 487-symbol library and three schematics from a hierarchical project all validate clean; a deliberately corrupted copy of the library reports `unclosed_form` plus an `indent_depth_mismatch` at line 75, and the original file is byte-identical afterwards.

Registered in all five places (Python module, `kicad_interface` import and route, `tool_schemas`, TS tool file, and `registry.ts`), so `search_tools` can find them — the new `validation` category rather than an addition to `KNOWN_UNREGISTERED`.
