### PR TITLE
feat: read, remove and repoint library table entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,42 @@ All notable changes to the KiCAD MCP Server project are documented here.
   a script — `content.replace(")", ...)` on the closing paren — corrupts a
   table whose last entry ends on the same line.
 
-  These work on parsed `(lib ...)` spans: entries are found by nickname, the
-  edit slices exactly that span, and **the result is re-parsed before it is
-  written**. A rewrite that would leave the table unbalanced is refused and the
-  file is left alone. Multi-line rows (which newer KiCad writes) are handled,
-  and batch removal cuts from the back so earlier offsets stay valid.
+  These work on parsed `(lib ...)` spans: rows are located as the direct
+  children of the table — never by scanning raw text for `(lib`, so an ordinary
+  Eagle-import description like `(descr "Caps (X7R), see (lib old)")` cannot
+  invent a phantom row — the edit slices exactly that span, and **the result is
+  re-parsed before it is written**. A rewrite that would leave the table
+  unbalanced is refused and the file is left alone. Multi-line rows (which newer
+  KiCad writes) are handled, and batch removal cuts from the back so earlier
+  offsets stay valid.
+
+  `scope="global"` resolves to the machine-wide table in KiCad's user config,
+  which every project on the machine loads, so writes are made through a
+  temporary file and `os.replace` rather than truncating in place, keep the
+  file's existing newline style instead of rewriting all 200-odd lines to CRLF,
+  and copy the previous contents into a sibling `.mcp-backups/` directory first.
+  Both mutating tools accept `dryRun` to report the edit without performing it.
+  `tablePath` is checked against the table's root element, so it cannot be aimed
+  at an unrelated `.kicad_pcb` that happens to contain a matching `(lib ...)`.
 
   `list_library_table` also resolves each URI through `${KIPRJMOD}`, KiCad's
-  configured path variables from `kicad_common.json`, and the environment, then
-  reports whether the file is actually there. An unresolved variable is
-  reported as missing rather than being silently treated as a literal path.
-  This is what turns "ERC reports hundreds of `footprint_link_issues`" into
-  "this one row points at a library that moved".
+  built-in library directories, the path variables configured in
+  `kicad_common.json`, and the environment, then reports whether the file is
+  actually there. The built-in directories matter: KiCad defines
+  `KICAD10_SYMBOL_DIR` and its siblings internally, so they appear in neither
+  `kicad_common.json` nor the environment, and resolving from those two sources
+  alone reports every row of a stock table as pointing at a missing file — 225
+  of 226 on a default install. They are resolved against the discovered KiCad
+  install, reusing the same finders `commands.library_symbol` and
+  `commands.library` already use. A variable that genuinely nothing defines is
+  still reported as missing rather than treated as a literal path. This is what
+  turns "ERC reports hundreds of `footprint_link_issues`" into "this one row
+  points at a library that moved".
+
+  KiCad 10's `(type "Table")` rows are recognised as indirections rather than
+  libraries: the stock global table is a single row named `KiCad` standing for
+  200+ libraries, so listing reports how many each one covers and removing one
+  says how many libraries that unregisters.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### New Features
+
+- **`list_library_table`, `remove_library_table_entry`, `set_library_table_uri`**
+  — the read, delete and repoint counterparts to `register_symbol_library` and
+  `register_footprint_library`. Registering a library was the only table
+  operation the server could do, so cleaning up after a library migration meant
+  hand-editing `sym-lib-table` / `fp-lib-table`. The obvious way to do that in
+  a script — `content.replace(")", ...)` on the closing paren — corrupts a
+  table whose last entry ends on the same line.
+
+  These work on parsed `(lib ...)` spans: entries are found by nickname, the
+  edit slices exactly that span, and **the result is re-parsed before it is
+  written**. A rewrite that would leave the table unbalanced is refused and the
+  file is left alone. Multi-line rows (which newer KiCad writes) are handled,
+  and batch removal cuts from the back so earlier offsets stay valid.
+
+  `list_library_table` also resolves each URI through `${KIPRJMOD}`, KiCad's
+  configured path variables from `kicad_common.json`, and the environment, then
+  reports whether the file is actually there. An unresolved variable is
+  reported as missing rather than being silently treated as a literal path.
+  This is what turns "ERC reports hundreds of `footprint_link_issues`" into
+  "this one row points at a library that moved".
+
 ### Bug Fixes
 
 - **`add_layer` could not add inner copper layers, and corrupted an unrelated

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ configuration command and backend options.
 We've implemented an intelligent tool router to keep AI context efficient while maintaining full functionality:
 
 - **22 direct tools** always visible for high-frequency operations
-- **111 routed tools** organized into 13 categories (board, component, export, drc, schematic, library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, parts-registry)
+- **114 routed tools** organized into 13 categories (board, component, export, drc, schematic, library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, parts-registry)
 - **4 router tools** for discovery and execution:
   - `list_tool_categories` - Browse all available categories
   - `get_category_tools` - View tools in a specific category
@@ -486,7 +486,7 @@ Access project state without executing tools:
 
 ## Available Tools
 
-The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **146 tools** are additionally indexed into 13 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
+The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **149 tools** are additionally indexed into 13 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
 
 For the complete tool reference with access types (direct/routed/additional), see [Tool Inventory](docs/TOOL_INVENTORY.md).
 
@@ -1513,7 +1513,7 @@ npm run format
 
 See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix and [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
 
-**Working Features (146 tools):**
+**Working Features (149 tools):**
 
 - Project management with snapshot checkpointing
 - Complete board design (outline, layers, zones, mounting holes, text, SVG logos)
@@ -1526,6 +1526,7 @@ See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix a
 - Design rule checking (DRC and ERC)
 - Export to Gerber, PDF, SVG, 3D, BOM, netlist, position file
 - Custom footprint and symbol creation
+- Library table maintenance (list, remove and repoint symbol/footprint entries)
 - JLCPCB parts integration (2.5M+ parts catalog)
 - Datasheet enrichment via LCSC
 - Freerouting autorouter integration (Java, Docker, Podman)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 **Key Capabilities:**
 
-- 146 tools across 13 categories with JSON Schema validation
+- 149 tools across 13 categories with JSON Schema validation
 - Keyword tool discovery via `search_tools` / `get_category_tools`
 - 8 dynamic resources exposing project state
 - Complete schematic workflow with 27 tools and dynamic symbol loading (~10,000 symbols)

--- a/python/commands/library_tables.py
+++ b/python/commands/library_tables.py
@@ -6,15 +6,26 @@ library migration meant hand-editing the table -- and the obvious way to do
 that, ``content.replace(")", ...)`` on the closing paren, corrupts a global
 table whose last entry ends on the same line.
 
-These tools work on the parsed ``(lib ...)`` spans instead: entries are located
-by nickname, edits are applied by slicing exactly that span, and the result is
-re-parsed before it is written. A rewrite that would not parse is refused
-rather than saved.
+These tools work on the parsed ``(lib ...)`` spans instead: rows are located as
+the direct children of the table (never by scanning raw text, so a parenthesis
+inside a quoted ``(descr ...)`` cannot invent a phantom row), edits are applied
+by slicing exactly that span, and the result is re-parsed before it is written.
+A rewrite that would not parse is refused rather than saved.
 
-``list_library_table`` also resolves each URI -- ``${KIPRJMOD}``, KiCad's own
-configured path variables, and the environment -- and reports whether the file
-is actually there, which is what turns "ERC reports hundreds of
-footprint_link_issues" into "this one row points at a library that moved".
+Writes are made through a temporary file and ``os.replace`` and keep the file's
+original newline style, and the previous contents are copied into
+``.mcp-backups/`` first. ``scope="global"`` resolves to the machine-wide table
+in KiCad's user config, which every project on the machine loads: a truncated
+write there stops KiCad starting at all. Both mutating tools also accept
+``dryRun`` to report the edit without performing it.
+
+``list_library_table`` resolves each URI -- ``${KIPRJMOD}``, KiCad's built-in
+library directories (``KICAD*_SYMBOL_DIR`` and friends, which KiCad defines
+internally and which therefore appear in neither ``kicad_common.json`` nor the
+environment), the path variables configured in ``kicad_common.json``, and the
+environment -- and reports whether the file is actually there, which is what
+turns "ERC reports hundreds of footprint_link_issues" into "this one row points
+at a library that moved".
 
 Tools:
   - list_library_table:         read entries, resolve URIs, flag missing files
@@ -27,8 +38,10 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shutil
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from utils.platform_helper import PlatformHelper
 from utils.sexpr_format import escape_sexpr_string, unescape_sexpr_string
@@ -49,6 +62,23 @@ _FIELDS = ("name", "type", "uri", "options", "descr")
 
 _VAR_RE = re.compile(r"\$\{([^}]+)\}")
 
+# Leading token of an s-expression file, e.g. "sym_lib_table" in "(sym_lib_table".
+_ROOT_RE = re.compile(r'\s*\(\s*([^\s()"]+)')
+
+
+class _Table(NamedTuple):
+    """A loaded library table and everything an edit to it needs to know."""
+
+    path: Path
+    table_type: str
+    #: Directory ``${KIPRJMOD}`` stands for, or None for a global table where it
+    #: has no meaning.
+    project_dir: Optional[Path]
+    content: str
+    #: Newline style the file already uses, so a write does not convert it.
+    newline: str
+    entries: List[Dict[str, Any]]
+
 
 def _kicad_config_dirs() -> List[Path]:
     """Candidate KiCad configuration directories, newest version first."""
@@ -62,6 +92,50 @@ def _kicad_config_dirs() -> List[Path]:
     if appdata:
         roots.insert(0, Path(appdata) / "kicad")
     return [root / version for version in _KICAD_VERSIONS for root in roots]
+
+
+def _read_text(path: Path) -> Tuple[str, str]:
+    """File text with LF newlines, plus the newline style to write back."""
+    with open(path, "r", encoding="utf-8", newline="") as fh:
+        raw = fh.read()
+    return raw.replace("\r\n", "\n"), ("\r\n" if "\r\n" in raw else "\n")
+
+
+def _write_text(path: Path, text: str, newline: str) -> None:
+    """Atomic write that keeps the file's original newline style."""
+    tmp = path.with_name(path.name + ".mcp-tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8", newline=newline) as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except OSError:
+        # Never leave a half-written scratch file beside a live KiCad config.
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _backup(path: Path) -> Optional[str]:
+    """Copy the table into a sibling ``.mcp-backups/`` before it is rewritten.
+
+    Same convention as the auto-save backups in ``kicad_interface`` (timestamped
+    copies in ``.mcp-backups/``, which ``.gitignore`` already covers), so a
+    removal that turns out to have been the wrong one is recoverable -- and in
+    particular so is an edit to the machine-wide global table. Best-effort: a
+    backup that cannot be written must not block the edit.
+    """
+    try:
+        backup_dir = path.parent / ".mcp-backups"
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")[:-3]
+        target = backup_dir / f"{path.name}.{stamp}"
+        shutil.copy2(path, target)
+        return str(target)
+    except OSError as exc:
+        logger.warning(f"Library-table backup failed (continuing): {exc}")
+        return None
 
 
 def _match_paren(content: str, open_idx: int) -> int:
@@ -89,6 +163,38 @@ def _match_paren(content: str, open_idx: int) -> int:
     return -1
 
 
+def _child_spans(content: str, open_idx: int) -> List[Tuple[int, int]]:
+    """Spans of the direct child lists of the list opening at *open_idx*.
+
+    String-aware, which is the whole point: a ``(`` inside a quoted value --
+    ``(descr "Caps (X7R) 50V")`` is ordinary in an Eagle-imported table -- is
+    not a child list, and scanning raw text for ``(lib`` reports it as one.
+    """
+    spans: List[Tuple[int, int]] = []
+    in_string = False
+    i = open_idx + 1
+    while i < len(content):
+        ch = content[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            end = _match_paren(content, i)
+            if end == -1:
+                break
+            spans.append((i, end + 1))
+            i = end
+        elif ch == ")":
+            break
+        i += 1
+    return spans
+
+
 def _parses(content: str) -> bool:
     """True if the text is one balanced s-expression with nothing trailing."""
     start = content.find("(")
@@ -99,32 +205,139 @@ def _parses(content: str) -> bool:
 
 
 def _field(block: str, field: str) -> str:
-    m = re.search(rf'\({field}\s+"((?:[^"\\]|\\.)*)"\)', block)
-    return unescape_sexpr_string(m.group(1)) if m else ""
+    """Value of the direct ``(field "...")`` child of *block*, or ""."""
+    for start, end in _child_spans(block, 0):
+        child = block[start:end]
+        if not re.match(rf"\({field}\b", child):
+            continue
+        # A trailing space before ')' is legal and turns up in hand-edited
+        # tables; requiring ')' straight after the quote misreads those.
+        m = re.match(rf'\({field}\s+"((?:[^"\\]|\\.)*)"\s*\)', child)
+        return unescape_sexpr_string(m.group(1)) if m else ""
+    return ""
 
 
 def _parse_entries(content: str) -> List[Dict[str, Any]]:
     """Every ``(lib ...)`` row, with the exact span it occupies in the text."""
+    root = content.find("(")
+    if root == -1:
+        return []
     entries = []
-    for m in re.finditer(r"\(lib\b", content):
-        end = _match_paren(content, m.start())
-        if end == -1:
+    for start, end in _child_spans(content, root):
+        if not re.match(r"\(lib\b", content[start:end]):
             continue
-        block = content[m.start() : end + 1]
+        block = content[start:end]
         entry: Dict[str, Any] = {f: _field(block, f) for f in _FIELDS}
-        entry["start"] = m.start()
-        entry["end"] = end + 1
+        entry["start"] = start
+        entry["end"] = end
         entries.append(entry)
     return entries
 
 
-def _resolve_uri(uri: str, table_path: Path, kicad_vars: Dict[str, str]) -> Tuple[str, bool]:
+def _is_table_ref(entry: Dict[str, Any]) -> bool:
+    """True for KiCad 10's ``(type "Table")`` indirection to another table.
+
+    One such row stands for every library in the table it points at -- the
+    stock global table is a single row named "KiCad" covering 200+ libraries --
+    so removing it is nothing like removing an ordinary row.
+    """
+    return entry["type"].strip().lower() == "table"
+
+
+def _table_ref_count(resolved_uri: str) -> int:
+    """How many libraries a ``(type "Table")`` row actually stands for."""
+    try:
+        target = Path(resolved_uri)
+        if not target.is_file():
+            return 0
+        text, _ = _read_text(target)
+    except OSError:
+        return 0
+    return len(_parse_entries(text))
+
+
+def _builtin_path_vars(table_type: str) -> Dict[str, str]:
+    """KiCad's own library path variables (``KICAD10_SYMBOL_DIR`` and friends).
+
+    KiCad defines these internally, so they are in neither
+    ``kicad_common.json``'s ``environment.vars`` (which only holds what the user
+    added under Configure Paths) nor the process environment. Resolving a URI
+    from those two sources alone leaves every row of a stock table unresolved
+    and therefore reported as missing -- 225 of 226 on a default install, which
+    reads as "delete these 225 rows".
+
+    ``commands.library_symbol`` and ``commands.library`` already map these
+    variables onto the discovered KiCad install; reuse their finders rather than
+    keeping a third copy that can drift. Both are independent of instance state,
+    so they are bound to an uninitialised manager: ``__init__`` parses every
+    library on disk, which listing a table has no business triggering.
+    """
+    if table_type == "symbol":
+        from commands.library_symbol import SymbolLibraryManager
+
+        manager: Any = SymbolLibraryManager.__new__(SymbolLibraryManager)
+        base = manager._find_kicad_symbol_dir()
+        third_party = manager._find_3rd_party_dir()
+        base_names = (
+            "KICAD10_SYMBOL_DIR",
+            "KICAD9_SYMBOL_DIR",
+            "KICAD8_SYMBOL_DIR",
+            "KICAD_SYMBOL_DIR",
+            "KISYSSYM",
+        )
+    else:
+        from commands.library import LibraryManager
+
+        manager = LibraryManager.__new__(LibraryManager)
+        base = manager._find_kicad_footprint_dir()
+        third_party = manager._find_kicad_3rdparty_dir()
+        base_names = (
+            "KICAD10_FOOTPRINT_DIR",
+            "KICAD9_FOOTPRINT_DIR",
+            "KICAD8_FOOTPRINT_DIR",
+            "KICAD_FOOTPRINT_DIR",
+            "KISYSMOD",
+        )
+
+    path_vars: Dict[str, str] = {}
+    if base:
+        path_vars.update({name: base for name in base_names})
+    if third_party:
+        path_vars.update(
+            {
+                name: third_party
+                for name in (
+                    "KICAD10_3RD_PARTY",
+                    "KICAD9_3RD_PARTY",
+                    "KICAD8_3RD_PARTY",
+                    "KICAD_3RD_PARTY",
+                )
+            }
+        )
+    return path_vars
+
+
+def _path_vars(table_type: str) -> Dict[str, str]:
+    """Every path variable a table URI can reference, user settings winning."""
+    path_vars = _builtin_path_vars(table_type)
+    path_vars.update(PlatformHelper.load_kicad_env_vars())
+    return path_vars
+
+
+def _resolve_uri(
+    uri: str,
+    table_path: Path,
+    kicad_vars: Dict[str, str],
+    project_dir: Optional[Path] = None,
+) -> Tuple[str, bool]:
     """Expand a URI's path variables and report whether the target exists."""
 
     def substitute(match: re.Match) -> str:
         var = match.group(1)
         if var == "KIPRJMOD":
-            return str(table_path.parent)
+            # Meaningless in a global table; leaving it unresolved reports the
+            # row as unresolvable instead of inventing a config-dir path.
+            return str(project_dir) if project_dir is not None else match.group(0)
         if var in kicad_vars:
             return kicad_vars[var]
         return os.environ.get(var, match.group(0))
@@ -141,34 +354,40 @@ def _resolve_uri(uri: str, table_path: Path, kicad_vars: Dict[str, str]) -> Tupl
         return str(path), False
 
 
-def _table_path(params: Dict[str, Any]) -> Tuple[Optional[Path], Optional[str], Optional[str]]:
-    """Resolve (path, table_type, error) from tableType / scope / projectPath."""
+def _table_path(
+    params: Dict[str, Any],
+) -> Tuple[Optional[Path], Optional[str], Optional[Path], Optional[str]]:
+    """Resolve (path, table_type, project_dir, error) from tableType/scope/projectPath."""
     table_type = params.get("tableType", "symbol")
     if table_type not in _TABLES:
-        return None, None, f"tableType must be 'symbol' or 'footprint', got {table_type!r}"
+        return None, None, None, f"tableType must be 'symbol' or 'footprint', got {table_type!r}"
     filename = _TABLES[table_type][0]
 
     explicit = params.get("tablePath")
     if explicit:
-        return Path(explicit), table_type, None
+        # A table addressed by path is treated as a project table: its own
+        # directory is what ${KIPRJMOD} means for the rows inside it.
+        path = Path(explicit)
+        return path, table_type, path.parent, None
 
     scope = params.get("scope", "project")
     if scope == "project":
         project_path = params.get("projectPath")
         if not project_path:
-            return None, None, "projectPath is required for scope='project'"
+            return None, None, None, "projectPath is required for scope='project'"
         proj = Path(project_path)
         table_dir = proj if proj.is_dir() else proj.parent
-        return table_dir / filename, table_type, None
+        return table_dir / filename, table_type, table_dir, None
 
     if scope != "global":
-        return None, None, f"scope must be 'project' or 'global', got {scope!r}"
+        return None, None, None, f"scope must be 'project' or 'global', got {scope!r}"
 
     for directory in _kicad_config_dirs():
         candidate = directory / filename
         if candidate.exists():
-            return candidate, table_type, None
+            return candidate, table_type, None, None
     return (
+        None,
         None,
         None,
         (
@@ -179,42 +398,76 @@ def _table_path(params: Dict[str, Any]) -> Tuple[Optional[Path], Optional[str], 
     )
 
 
-def _load(params: Dict[str, Any]) -> Tuple[Any, ...]:
-    """(path, table_type, content, entries, error_response)."""
-    path, table_type, error = _table_path(params)
+def _load(params: Dict[str, Any]) -> Tuple[Optional[_Table], Optional[Dict[str, Any]]]:
+    """(table, error_response)."""
+    path, table_type, project_dir, error = _table_path(params)
     if error:
-        return None, None, None, None, {"success": False, "message": error}
-    assert path is not None
+        return None, {"success": False, "message": error}
+    assert path is not None and table_type is not None
     if not path.exists():
-        return None, None, None, None, {"success": False, "message": f"Table not found: {path}"}
+        return None, {"success": False, "message": f"Table not found: {path}"}
     try:
-        content = path.read_text(encoding="utf-8")
+        content, newline = _read_text(path)
     except OSError as exc:
-        return (
-            None,
-            None,
-            None,
-            None,
-            {"success": False, "message": f"Could not read {path}: {exc}"},
-        )
-    return path, table_type, content, _parse_entries(content), None
+        return None, {"success": False, "message": f"Could not read {path}: {exc}"}
 
-
-def _write_checked(path: Path, content: str) -> Optional[Dict[str, Any]]:
-    """Write only if the result still parses; otherwise report and change nothing."""
-    if not _parses(content):
-        return {
+    # tablePath bypasses scope resolution, so without this a mutating call
+    # could be aimed at any balanced s-expression file that happens to contain
+    # a matching (lib ...) row -- a .kicad_pcb, say -- and would rewrite it.
+    expected_root = _TABLES[table_type][1]
+    match = _ROOT_RE.match(content)
+    root = match.group(1) if match else ""
+    if root.lower() != expected_root:
+        return None, {
             "success": False,
             "message": (
-                f"Refusing to write {path.name}: the edit would leave unbalanced "
+                f"{path} is not a {expected_root}: its root element is "
+                f"({root or '?'} ...). Only a sym-lib-table or fp-lib-table can be edited."
+            ),
+        }
+
+    return (
+        _Table(
+            path=path,
+            table_type=table_type,
+            project_dir=project_dir,
+            content=content,
+            newline=newline,
+            entries=_parse_entries(content),
+        ),
+        None,
+    )
+
+
+def _write_checked(
+    table: _Table, content: str, *, dry_run: bool = False
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Back up and atomically write, but only if the result still parses.
+
+    Returns ``(backup_path, error_response)``. With *dry_run* the result is
+    still validated -- a preview that does not say the edit would be refused is
+    worse than no preview -- but nothing is written.
+    """
+    if not _parses(content):
+        return None, {
+            "success": False,
+            "message": (
+                f"Refusing to write {table.path.name}: the edit would leave unbalanced "
                 f"parentheses. The table is unchanged."
             ),
         }
+    if dry_run:
+        return None, None
+    backup = _backup(table.path)
     try:
-        path.write_text(content, encoding="utf-8")
+        _write_text(table.path, content, table.newline)
     except OSError as exc:
-        return {"success": False, "message": f"Could not write {path}: {exc}"}
-    return None
+        return backup, {
+            "success": False,
+            "message": f"Could not write {table.path}: {exc}",
+            "backup": backup,
+        }
+    return backup, None
 
 
 def _public(entry: Dict[str, Any]) -> Dict[str, Any]:
@@ -223,33 +476,50 @@ def _public(entry: Dict[str, Any]) -> Dict[str, Any]:
 
 def list_library_table(params: Dict[str, Any]) -> Dict[str, Any]:
     """List the entries of a sym-lib-table or fp-lib-table."""
-    path, table_type, content, entries, error = _load(params)
+    table, error = _load(params)
     if error:
         return error
+    assert table is not None
 
-    kicad_vars = PlatformHelper.load_kicad_env_vars()
+    kicad_vars = _path_vars(table.table_type)
     rows = []
     missing = 0
-    for entry in entries:
-        resolved, exists = _resolve_uri(entry["uri"], path, kicad_vars)
+    table_refs = 0
+    referenced = 0
+    for entry in table.entries:
+        resolved, exists = _resolve_uri(entry["uri"], table.path, kicad_vars, table.project_dir)
         if not exists:
             missing += 1
         row = _public(entry)
         row["resolvedPath"] = resolved
         row["exists"] = exists
+        if _is_table_ref(entry):
+            included = _table_ref_count(resolved) if exists else 0
+            row["isTableReference"] = True
+            row["includedLibraryCount"] = included
+            table_refs += 1
+            referenced += included
         rows.append(row)
 
-    message = f"{len(rows)} entr{'y' if len(rows) == 1 else 'ies'} in {path.name}"
+    message = f"{len(rows)} entr{'y' if len(rows) == 1 else 'ies'} in {table.path.name}"
     if missing:
         message += f", {missing} pointing at a file that is not there"
+    if table_refs:
+        message += (
+            f'. {table_refs} of them (type "Table") standing for {referenced} further '
+            f"libraries that are not listed individually -- removing such a row "
+            f"unregisters all of them"
+        )
 
     return {
         "success": True,
         "message": message,
-        "tablePath": str(path),
-        "tableType": table_type,
+        "tablePath": str(table.path),
+        "tableType": table.table_type,
         "entryCount": len(rows),
         "missingCount": missing,
+        "tableReferenceCount": table_refs,
+        "referencedLibraryCount": referenced,
         "entries": rows,
     }
 
@@ -263,20 +533,22 @@ def remove_library_table_entry(params: Dict[str, Any]) -> Dict[str, Any]:
     if not names:
         return {"success": False, "message": "libraryName or libraryNames is required"}
 
-    path, table_type, content, entries, error = _load(params)
+    table, error = _load(params)
     if error:
         return error
+    assert table is not None
 
     wanted = set(names)
-    targets = [e for e in entries if e["name"] in wanted]
+    targets = [e for e in table.entries if e["name"] in wanted]
     if not targets:
-        available = ", ".join(e["name"] for e in entries) or "(none)"
+        available = ", ".join(e["name"] for e in table.entries) or "(none)"
         return {
             "success": False,
-            "message": f"No entry named {' or '.join(sorted(wanted))} in {path.name}. "
+            "message": f"No entry named {' or '.join(sorted(wanted))} in {table.path.name}. "
             f"Present: {available}",
         }
 
+    content = table.content
     # Deleting shifts every later offset, so cut from the back.
     for entry in sorted(targets, key=lambda e: e["start"], reverse=True):
         start, end = entry["start"], entry["end"]
@@ -287,24 +559,48 @@ def remove_library_table_entry(params: Dict[str, Any]) -> Dict[str, Any]:
             end += 1
         content = content[:start] + content[end:]
 
-    failure = _write_checked(path, content)
+    dry_run = bool(params.get("dryRun"))
+    backup, failure = _write_checked(table, content, dry_run=dry_run)
     if failure:
         return failure
 
     removed = [e["name"] for e in targets]
     not_found = sorted(wanted - set(removed))
-    message = f"Removed {', '.join(removed)} from {path.name}"
+    verb = "Would remove" if dry_run else "Removed"
+    message = f"{verb} {', '.join(removed)} from {table.path.name}"
     if not_found:
         message += f" (not present: {', '.join(not_found)})"
+
+    # A (type "Table") row is an indirection, not a library: dropping the one
+    # named "KiCad" from a stock global table unregisters every stock library.
+    ref_rows = [e for e in targets if _is_table_ref(e)]
+    referenced = 0
+    if ref_rows:
+        kicad_vars = _path_vars(table.table_type)
+        for entry in ref_rows:
+            resolved, exists = _resolve_uri(entry["uri"], table.path, kicad_vars, table.project_dir)
+            if exists:
+                referenced += _table_ref_count(resolved)
+        message += (
+            f'. WARNING: {", ".join(e["name"] for e in ref_rows)} '
+            f'{"is a" if len(ref_rows) == 1 else "are"} (type "Table") '
+            f"reference{'' if len(ref_rows) == 1 else 's'}, so this unregisters the "
+            f"{referenced} libraries listed in the referenced table, not just "
+            f"{'one row' if len(ref_rows) == 1 else 'those rows'}"
+        )
 
     return {
         "success": True,
         "message": message,
-        "tablePath": str(path),
-        "tableType": table_type,
+        "tablePath": str(table.path),
+        "tableType": table.table_type,
+        "dryRun": dry_run,
+        "backup": backup,
         "removed": [_public(e) for e in targets],
         "notFound": not_found,
-        "remainingCount": len(entries) - len(targets),
+        "tableReferencesRemoved": [e["name"] for e in ref_rows],
+        "referencedLibraryCount": referenced,
+        "remainingCount": len(table.entries) - len(targets),
     }
 
 
@@ -317,23 +613,30 @@ def set_library_table_uri(params: Dict[str, Any]) -> Dict[str, Any]:
     if not new_uri:
         return {"success": False, "message": "uri is required"}
 
-    path, table_type, content, entries, error = _load(params)
+    table, error = _load(params)
     if error:
         return error
+    assert table is not None
 
-    target = next((e for e in entries if e["name"] == name), None)
+    target = next((e for e in table.entries if e["name"] == name), None)
     if target is None:
-        available = ", ".join(e["name"] for e in entries) or "(none)"
+        available = ", ".join(e["name"] for e in table.entries) or "(none)"
         return {
             "success": False,
-            "message": f"No entry named '{name}' in {path.name}. Present: {available}",
+            "message": f"No entry named '{name}' in {table.path.name}. Present: {available}",
         }
 
-    block = content[target["start"] : target["end"]]
+    block = table.content[target["start"] : target["end"]]
     old_uri = target["uri"]
+    # The replacement has to be a function: as a template string, re treats "\\"
+    # as one literal backslash and undoes exactly the doubling
+    # escape_sexpr_string just applied, so an ordinary Windows path lands in the
+    # file as raw \U \m \l escapes -- and one ending in a backslash escapes the
+    # closing quote and makes the whole table unparseable.
+    replacement = f'(uri "{escape_sexpr_string(new_uri)}")'
     updated_block, count = re.subn(
-        r'\(uri\s+"(?:[^"\\]|\\.)*"\)',
-        f'(uri "{escape_sexpr_string(new_uri)}")',
+        r'\(uri\s+"(?:[^"\\]|\\.)*"\s*\)',
+        lambda _match: replacement,
         block,
         count=1,
     )
@@ -343,22 +646,25 @@ def set_library_table_uri(params: Dict[str, Any]) -> Dict[str, Any]:
             "message": f"Entry '{name}' has no (uri ...) field to replace",
         }
 
-    content = content[: target["start"]] + updated_block + content[target["end"] :]
-    failure = _write_checked(path, content)
+    content = table.content[: target["start"]] + updated_block + table.content[target["end"] :]
+    dry_run = bool(params.get("dryRun"))
+    backup, failure = _write_checked(table, content, dry_run=dry_run)
     if failure:
         return failure
 
-    kicad_vars = PlatformHelper.load_kicad_env_vars()
-    resolved, exists = _resolve_uri(new_uri, path, kicad_vars)
-    message = f"'{name}' now points at {new_uri}"
+    kicad_vars = _path_vars(table.table_type)
+    resolved, exists = _resolve_uri(new_uri, table.path, kicad_vars, table.project_dir)
+    message = f"'{name}' {'would now point' if dry_run else 'now points'} at {new_uri}"
     if not exists:
         message += " -- note that no file exists there yet"
 
     return {
         "success": True,
         "message": message,
-        "tablePath": str(path),
-        "tableType": table_type,
+        "tablePath": str(table.path),
+        "tableType": table.table_type,
+        "dryRun": dry_run,
+        "backup": backup,
         "libraryName": name,
         "previousUri": old_uri,
         "uri": new_uri,

--- a/python/commands/library_tables.py
+++ b/python/commands/library_tables.py
@@ -1,0 +1,367 @@
+"""Read and edit KiCad's sym-lib-table / fp-lib-table.
+
+``register_symbol_library`` and ``register_footprint_library`` can add a row.
+Nothing could read one back, drop one, or repoint one, so cleaning up after a
+library migration meant hand-editing the table -- and the obvious way to do
+that, ``content.replace(")", ...)`` on the closing paren, corrupts a global
+table whose last entry ends on the same line.
+
+These tools work on the parsed ``(lib ...)`` spans instead: entries are located
+by nickname, edits are applied by slicing exactly that span, and the result is
+re-parsed before it is written. A rewrite that would not parse is refused
+rather than saved.
+
+``list_library_table`` also resolves each URI -- ``${KIPRJMOD}``, KiCad's own
+configured path variables, and the environment -- and reports whether the file
+is actually there, which is what turns "ERC reports hundreds of
+footprint_link_issues" into "this one row points at a library that moved".
+
+Tools:
+  - list_library_table:         read entries, resolve URIs, flag missing files
+  - remove_library_table_entry: drop entries by nickname
+  - set_library_table_uri:      repoint a nickname at a different file
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from utils.platform_helper import PlatformHelper
+from utils.sexpr_format import escape_sexpr_string, unescape_sexpr_string
+
+logger = logging.getLogger("kicad_interface")
+
+# table type -> (file name, root s-expression name)
+_TABLES = {
+    "symbol": ("sym-lib-table", "sym_lib_table"),
+    "footprint": ("fp-lib-table", "fp_lib_table"),
+}
+
+# Newest first: KiCad reads the config of the version that wrote it, and a
+# machine that has been upgraded keeps the older directories around.
+_KICAD_VERSIONS = ("10.0", "9.0", "8.0")
+
+_FIELDS = ("name", "type", "uri", "options", "descr")
+
+_VAR_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+def _kicad_config_dirs() -> List[Path]:
+    """Candidate KiCad configuration directories, newest version first."""
+    home = Path.home()
+    roots = [
+        home / "AppData" / "Roaming" / "kicad",
+        home / ".config" / "kicad",
+        home / "Library" / "Preferences" / "kicad",
+    ]
+    appdata = os.environ.get("APPDATA")
+    if appdata:
+        roots.insert(0, Path(appdata) / "kicad")
+    return [root / version for version in _KICAD_VERSIONS for root in roots]
+
+
+def _match_paren(content: str, open_idx: int) -> int:
+    """Index of the ``)`` closing the ``(`` at *open_idx*, or -1 if unbalanced."""
+    depth = 0
+    in_string = False
+    i = open_idx
+    while i < len(content):
+        ch = content[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def _parses(content: str) -> bool:
+    """True if the text is one balanced s-expression with nothing trailing."""
+    start = content.find("(")
+    if start == -1:
+        return False
+    end = _match_paren(content, start)
+    return end != -1 and not content[end + 1 :].strip()
+
+
+def _field(block: str, field: str) -> str:
+    m = re.search(rf'\({field}\s+"((?:[^"\\]|\\.)*)"\)', block)
+    return unescape_sexpr_string(m.group(1)) if m else ""
+
+
+def _parse_entries(content: str) -> List[Dict[str, Any]]:
+    """Every ``(lib ...)`` row, with the exact span it occupies in the text."""
+    entries = []
+    for m in re.finditer(r"\(lib\b", content):
+        end = _match_paren(content, m.start())
+        if end == -1:
+            continue
+        block = content[m.start() : end + 1]
+        entry: Dict[str, Any] = {f: _field(block, f) for f in _FIELDS}
+        entry["start"] = m.start()
+        entry["end"] = end + 1
+        entries.append(entry)
+    return entries
+
+
+def _resolve_uri(uri: str, table_path: Path, kicad_vars: Dict[str, str]) -> Tuple[str, bool]:
+    """Expand a URI's path variables and report whether the target exists."""
+
+    def substitute(match: re.Match) -> str:
+        var = match.group(1)
+        if var == "KIPRJMOD":
+            return str(table_path.parent)
+        if var in kicad_vars:
+            return kicad_vars[var]
+        return os.environ.get(var, match.group(0))
+
+    expanded = _VAR_RE.sub(substitute, uri)
+    if _VAR_RE.search(expanded):
+        return expanded, False  # an unresolved variable cannot point anywhere
+    path = Path(expanded)
+    if not path.is_absolute():
+        path = table_path.parent / path
+    try:
+        return str(path.resolve()), path.exists()
+    except OSError:
+        return str(path), False
+
+
+def _table_path(params: Dict[str, Any]) -> Tuple[Optional[Path], Optional[str], Optional[str]]:
+    """Resolve (path, table_type, error) from tableType / scope / projectPath."""
+    table_type = params.get("tableType", "symbol")
+    if table_type not in _TABLES:
+        return None, None, f"tableType must be 'symbol' or 'footprint', got {table_type!r}"
+    filename = _TABLES[table_type][0]
+
+    explicit = params.get("tablePath")
+    if explicit:
+        return Path(explicit), table_type, None
+
+    scope = params.get("scope", "project")
+    if scope == "project":
+        project_path = params.get("projectPath")
+        if not project_path:
+            return None, None, "projectPath is required for scope='project'"
+        proj = Path(project_path)
+        table_dir = proj if proj.is_dir() else proj.parent
+        return table_dir / filename, table_type, None
+
+    if scope != "global":
+        return None, None, f"scope must be 'project' or 'global', got {scope!r}"
+
+    for directory in _kicad_config_dirs():
+        candidate = directory / filename
+        if candidate.exists():
+            return candidate, table_type, None
+    return (
+        None,
+        None,
+        (
+            f"No global {filename} found. Looked in: "
+            + ", ".join(str(d) for d in _kicad_config_dirs()[:4])
+            + ". Pass tablePath to point at it directly."
+        ),
+    )
+
+
+def _load(params: Dict[str, Any]) -> Tuple[Any, ...]:
+    """(path, table_type, content, entries, error_response)."""
+    path, table_type, error = _table_path(params)
+    if error:
+        return None, None, None, None, {"success": False, "message": error}
+    assert path is not None
+    if not path.exists():
+        return None, None, None, None, {"success": False, "message": f"Table not found: {path}"}
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return (
+            None,
+            None,
+            None,
+            None,
+            {"success": False, "message": f"Could not read {path}: {exc}"},
+        )
+    return path, table_type, content, _parse_entries(content), None
+
+
+def _write_checked(path: Path, content: str) -> Optional[Dict[str, Any]]:
+    """Write only if the result still parses; otherwise report and change nothing."""
+    if not _parses(content):
+        return {
+            "success": False,
+            "message": (
+                f"Refusing to write {path.name}: the edit would leave unbalanced "
+                f"parentheses. The table is unchanged."
+            ),
+        }
+    try:
+        path.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        return {"success": False, "message": f"Could not write {path}: {exc}"}
+    return None
+
+
+def _public(entry: Dict[str, Any]) -> Dict[str, Any]:
+    return {f: entry[f] for f in _FIELDS}
+
+
+def list_library_table(params: Dict[str, Any]) -> Dict[str, Any]:
+    """List the entries of a sym-lib-table or fp-lib-table."""
+    path, table_type, content, entries, error = _load(params)
+    if error:
+        return error
+
+    kicad_vars = PlatformHelper.load_kicad_env_vars()
+    rows = []
+    missing = 0
+    for entry in entries:
+        resolved, exists = _resolve_uri(entry["uri"], path, kicad_vars)
+        if not exists:
+            missing += 1
+        row = _public(entry)
+        row["resolvedPath"] = resolved
+        row["exists"] = exists
+        rows.append(row)
+
+    message = f"{len(rows)} entr{'y' if len(rows) == 1 else 'ies'} in {path.name}"
+    if missing:
+        message += f", {missing} pointing at a file that is not there"
+
+    return {
+        "success": True,
+        "message": message,
+        "tablePath": str(path),
+        "tableType": table_type,
+        "entryCount": len(rows),
+        "missingCount": missing,
+        "entries": rows,
+    }
+
+
+def remove_library_table_entry(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove one or more entries from a library table, by nickname."""
+    names = params.get("libraryNames")
+    if names is None:
+        single = params.get("libraryName")
+        names = [single] if single else []
+    if not names:
+        return {"success": False, "message": "libraryName or libraryNames is required"}
+
+    path, table_type, content, entries, error = _load(params)
+    if error:
+        return error
+
+    wanted = set(names)
+    targets = [e for e in entries if e["name"] in wanted]
+    if not targets:
+        available = ", ".join(e["name"] for e in entries) or "(none)"
+        return {
+            "success": False,
+            "message": f"No entry named {' or '.join(sorted(wanted))} in {path.name}. "
+            f"Present: {available}",
+        }
+
+    # Deleting shifts every later offset, so cut from the back.
+    for entry in sorted(targets, key=lambda e: e["start"], reverse=True):
+        start, end = entry["start"], entry["end"]
+        line_start = content.rfind("\n", 0, start) + 1
+        if not content[line_start:start].strip():
+            start = line_start
+        if content[end : end + 1] == "\n":
+            end += 1
+        content = content[:start] + content[end:]
+
+    failure = _write_checked(path, content)
+    if failure:
+        return failure
+
+    removed = [e["name"] for e in targets]
+    not_found = sorted(wanted - set(removed))
+    message = f"Removed {', '.join(removed)} from {path.name}"
+    if not_found:
+        message += f" (not present: {', '.join(not_found)})"
+
+    return {
+        "success": True,
+        "message": message,
+        "tablePath": str(path),
+        "tableType": table_type,
+        "removed": [_public(e) for e in targets],
+        "notFound": not_found,
+        "remainingCount": len(entries) - len(targets),
+    }
+
+
+def set_library_table_uri(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Repoint an existing table entry at a different file."""
+    name = params.get("libraryName")
+    new_uri = params.get("uri")
+    if not name:
+        return {"success": False, "message": "libraryName is required"}
+    if not new_uri:
+        return {"success": False, "message": "uri is required"}
+
+    path, table_type, content, entries, error = _load(params)
+    if error:
+        return error
+
+    target = next((e for e in entries if e["name"] == name), None)
+    if target is None:
+        available = ", ".join(e["name"] for e in entries) or "(none)"
+        return {
+            "success": False,
+            "message": f"No entry named '{name}' in {path.name}. Present: {available}",
+        }
+
+    block = content[target["start"] : target["end"]]
+    old_uri = target["uri"]
+    updated_block, count = re.subn(
+        r'\(uri\s+"(?:[^"\\]|\\.)*"\)',
+        f'(uri "{escape_sexpr_string(new_uri)}")',
+        block,
+        count=1,
+    )
+    if count == 0:
+        return {
+            "success": False,
+            "message": f"Entry '{name}' has no (uri ...) field to replace",
+        }
+
+    content = content[: target["start"]] + updated_block + content[target["end"] :]
+    failure = _write_checked(path, content)
+    if failure:
+        return failure
+
+    kicad_vars = PlatformHelper.load_kicad_env_vars()
+    resolved, exists = _resolve_uri(new_uri, path, kicad_vars)
+    message = f"'{name}' now points at {new_uri}"
+    if not exists:
+        message += " -- note that no file exists there yet"
+
+    return {
+        "success": True,
+        "message": message,
+        "tablePath": str(path),
+        "tableType": table_type,
+        "libraryName": name,
+        "previousUri": old_uri,
+        "uri": new_uri,
+        "resolvedPath": resolved,
+        "exists": exists,
+    }

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -343,6 +343,11 @@ try:
     from commands.library_management import LibraryManagementCommands
     from commands.library_schematic import LibraryManager as SchematicLibraryManager
     from commands.library_symbol import SymbolLibraryCommands, SymbolLibraryManager
+    from commands.library_tables import (
+        list_library_table,
+        remove_library_table_entry,
+        set_library_table_uri,
+    )
     from commands.pcb_import import PcbImportCommands
     from commands.project import ProjectCommands
     from commands.routing import RoutingCommands
@@ -687,6 +692,10 @@ class KiCADInterface(SchematicHandlersMixin):
             "list_symbols_in_library": self._handle_list_symbols_in_library,
             "register_symbol_library": self._handle_register_symbol_library,
             "add_symbol_property": add_symbol_property,
+            # Library table maintenance (sym-lib-table / fp-lib-table)
+            "list_library_table": list_library_table,
+            "remove_library_table_entry": remove_library_table_entry,
+            "set_library_table_uri": set_library_table_uri,
             # Freerouting autoroute commands
             "autoroute": self.freerouting_commands.autoroute,
             "export_dsn": self.freerouting_commands.export_dsn,

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -1902,6 +1902,130 @@ LIBRARY_TOOLS = [
         },
     },
     {
+        "name": "list_library_table",
+        "title": "List Library Table Entries",
+        "description": (
+            "Read a sym-lib-table or fp-lib-table: nickname, type, URI and description of "
+            "every registered library. Each URI is resolved through ${KIPRJMOD}, KiCad's "
+            "configured path variables and the environment, and reported alongside whether "
+            "the file is actually there -- which is how a stale row left over from a library "
+            "migration shows itself."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "tableType": {
+                    "type": "string",
+                    "enum": ["symbol", "footprint"],
+                    "default": "symbol",
+                    "description": "sym-lib-table ('symbol') or fp-lib-table ('footprint')",
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": ["project", "global"],
+                    "default": "project",
+                    "description": "Project table (needs projectPath) or KiCad's user config",
+                },
+                "projectPath": {
+                    "type": "string",
+                    "description": "Path to the .kicad_pro or its directory, for scope=project",
+                },
+                "tablePath": {
+                    "type": "string",
+                    "description": "Path to the table file itself, bypassing scope resolution",
+                },
+            },
+        },
+    },
+    {
+        "name": "remove_library_table_entry",
+        "title": "Remove Library Table Entry",
+        "description": (
+            "Remove one or more entries from a sym-lib-table or fp-lib-table by nickname -- "
+            "the counterpart to register_symbol_library / register_footprint_library. The "
+            "table is re-parsed before it is written, so an edit that would leave it "
+            "unbalanced is refused rather than saved."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "tableType": {
+                    "type": "string",
+                    "enum": ["symbol", "footprint"],
+                    "default": "symbol",
+                    "description": "sym-lib-table ('symbol') or fp-lib-table ('footprint')",
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": ["project", "global"],
+                    "default": "project",
+                    "description": "Project table (needs projectPath) or KiCad's user config",
+                },
+                "projectPath": {
+                    "type": "string",
+                    "description": "Path to the .kicad_pro or its directory, for scope=project",
+                },
+                "tablePath": {
+                    "type": "string",
+                    "description": "Path to the table file itself, bypassing scope resolution",
+                },
+                "libraryName": {"type": "string", "description": "Nickname to remove"},
+                "libraryNames": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Several nicknames to remove in one pass",
+                },
+            },
+        },
+    },
+    {
+        "name": "set_library_table_uri",
+        "title": "Repoint Library Table Entry",
+        "description": (
+            "Repoint an existing library-table entry at a different file, keeping its "
+            "nickname, type and description. Use it to move a project onto "
+            "${KIPRJMOD}-relative paths, or to follow a library that was relocated, without "
+            "unregistering and re-registering it."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "tableType": {
+                    "type": "string",
+                    "enum": ["symbol", "footprint"],
+                    "default": "symbol",
+                    "description": "sym-lib-table ('symbol') or fp-lib-table ('footprint')",
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": ["project", "global"],
+                    "default": "project",
+                    "description": "Project table (needs projectPath) or KiCad's user config",
+                },
+                "projectPath": {
+                    "type": "string",
+                    "description": "Path to the .kicad_pro or its directory, for scope=project",
+                },
+                "tablePath": {
+                    "type": "string",
+                    "description": "Path to the table file itself, bypassing scope resolution",
+                },
+                "libraryName": {
+                    "type": "string",
+                    "description": "Nickname of the entry to repoint",
+                },
+                "uri": {
+                    "type": "string",
+                    "description": (
+                        "New URI, e.g. ${KIPRJMOD}/../FOG_components.kicad_sym. Path variables "
+                        "are stored verbatim and only expanded to check the file exists."
+                    ),
+                },
+            },
+            "required": ["libraryName", "uri"],
+        },
+    },
+    {
         "name": "get_footprint_info",
         "title": "Get Footprint Details",
         "description": "Retrieves detailed information about a specific footprint including pad layout, dimensions, and description.",

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -1907,9 +1907,11 @@ LIBRARY_TOOLS = [
         "description": (
             "Read a sym-lib-table or fp-lib-table: nickname, type, URI and description of "
             "every registered library. Each URI is resolved through ${KIPRJMOD}, KiCad's "
-            "configured path variables and the environment, and reported alongside whether "
-            "the file is actually there -- which is how a stale row left over from a library "
-            "migration shows itself."
+            "built-in library directories (KICAD*_SYMBOL_DIR and friends), the path "
+            "variables configured in kicad_common.json and the environment, and reported "
+            "alongside whether the file is actually there -- which is how a stale row left "
+            'over from a library migration shows itself. A (type "Table") row is flagged '
+            "as an indirection, with a count of the libraries it stands for."
         ),
         "inputSchema": {
             "type": "object",
@@ -1944,7 +1946,11 @@ LIBRARY_TOOLS = [
             "Remove one or more entries from a sym-lib-table or fp-lib-table by nickname -- "
             "the counterpart to register_symbol_library / register_footprint_library. The "
             "table is re-parsed before it is written, so an edit that would leave it "
-            "unbalanced is refused rather than saved."
+            "unbalanced is refused rather than saved; the write is atomic and the previous "
+            "contents are kept in a sibling .mcp-backups/ directory. Use dryRun first when "
+            "the target is scope='global', which every project on the machine loads. "
+            'Removing a (type "Table") row unregisters every library in the table it '
+            "points at, and the result says so."
         ),
         "inputSchema": {
             "type": "object",
@@ -1975,7 +1981,15 @@ LIBRARY_TOOLS = [
                     "items": {"type": "string"},
                     "description": "Several nicknames to remove in one pass",
                 },
+                "dryRun": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Report what would be removed without writing the table",
+                },
             },
+            # A destructive tool with no required argument can be fired with none
+            # at all; at least one nickname has to be named.
+            "anyOf": [{"required": ["libraryName"]}, {"required": ["libraryNames"]}],
         },
     },
     {
@@ -2020,6 +2034,11 @@ LIBRARY_TOOLS = [
                         "New URI, e.g. ${KIPRJMOD}/../FOG_components.kicad_sym. Path variables "
                         "are stored verbatim and only expanded to check the file exists."
                     ),
+                },
+                "dryRun": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Report the new URI without writing the table",
                 },
             },
             "required": ["libraryName", "uri"],

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -195,13 +195,20 @@ export function registerLibraryTools(server: McpServer, callKicadScript: Functio
     .string()
     .optional()
     .describe("Path to the table file itself, bypassing scope/projectPath resolution");
+  const dryRun = z
+    .boolean()
+    .optional()
+    .describe("Report what the edit would do without writing the table");
 
   server.tool(
     "list_library_table",
     "Read a sym-lib-table or fp-lib-table: nickname, type, URI and description of every " +
-      "registered library. Each URI is resolved through ${KIPRJMOD}, KiCad's configured path " +
-      "variables and the environment, and reported with whether the file is actually there — " +
-      "which is how a stale row left over from a library migration shows itself.",
+      "registered library. Each URI is resolved through ${KIPRJMOD}, KiCad's built-in library " +
+      "directories (KICAD*_SYMBOL_DIR and friends), the path variables configured in " +
+      "kicad_common.json and the environment, and reported with whether the file is actually " +
+      "there — which is how a stale row left over from a library migration shows itself. A " +
+      '(type "Table") row is flagged as an indirection, with a count of the libraries it ' +
+      "stands for.",
     { tableType, scope, projectPath, tablePath },
     async (args: any) => {
       const result = await callKicadScript("list_library_table", args);
@@ -214,12 +221,16 @@ export function registerLibraryTools(server: McpServer, callKicadScript: Functio
     "Remove one or more entries from a sym-lib-table or fp-lib-table by nickname — the " +
       "counterpart to register_symbol_library / register_footprint_library. The table is " +
       "re-parsed before it is written, so an edit that would leave it unbalanced is refused " +
-      "rather than saved.",
+      "rather than saved; the write is atomic and the previous contents are kept in a sibling " +
+      ".mcp-backups/ directory. Use dryRun first when the target is scope='global', which " +
+      'every project on the machine loads. Removing a (type "Table") row unregisters every ' +
+      "library in the table it points at, and the result says so.",
     {
       tableType,
       scope,
       projectPath,
       tablePath,
+      dryRun,
       libraryName: z.string().optional().describe("Nickname to remove"),
       libraryNames: z
         .array(z.string())
@@ -242,6 +253,7 @@ export function registerLibraryTools(server: McpServer, callKicadScript: Functio
       scope,
       projectPath,
       tablePath,
+      dryRun,
       libraryName: z.string().describe("Nickname of the entry to repoint"),
       uri: z
         .string()

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -176,4 +176,83 @@ export function registerLibraryTools(server: McpServer, callKicadScript: Functio
       };
     },
   );
+
+  // ── Library table maintenance (sym-lib-table / fp-lib-table) ──────────── //
+
+  const tableType = z
+    .enum(["symbol", "footprint"])
+    .optional()
+    .describe("Which table to edit: 'symbol' (sym-lib-table, default) or 'footprint'");
+  const scope = z
+    .enum(["project", "global"])
+    .optional()
+    .describe("'project' (default, needs projectPath) or 'global' (KiCad's user config)");
+  const projectPath = z
+    .string()
+    .optional()
+    .describe("Path to the .kicad_pro or its directory, for scope='project'");
+  const tablePath = z
+    .string()
+    .optional()
+    .describe("Path to the table file itself, bypassing scope/projectPath resolution");
+
+  server.tool(
+    "list_library_table",
+    "Read a sym-lib-table or fp-lib-table: nickname, type, URI and description of every " +
+      "registered library. Each URI is resolved through ${KIPRJMOD}, KiCad's configured path " +
+      "variables and the environment, and reported with whether the file is actually there — " +
+      "which is how a stale row left over from a library migration shows itself.",
+    { tableType, scope, projectPath, tablePath },
+    async (args: any) => {
+      const result = await callKicadScript("list_library_table", args);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "remove_library_table_entry",
+    "Remove one or more entries from a sym-lib-table or fp-lib-table by nickname — the " +
+      "counterpart to register_symbol_library / register_footprint_library. The table is " +
+      "re-parsed before it is written, so an edit that would leave it unbalanced is refused " +
+      "rather than saved.",
+    {
+      tableType,
+      scope,
+      projectPath,
+      tablePath,
+      libraryName: z.string().optional().describe("Nickname to remove"),
+      libraryNames: z
+        .array(z.string())
+        .optional()
+        .describe("Several nicknames to remove in one pass"),
+    },
+    async (args: any) => {
+      const result = await callKicadScript("remove_library_table_entry", args);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "set_library_table_uri",
+    "Repoint an existing library-table entry at a different file, keeping its nickname, type " +
+      "and description. Use it to move a project onto ${KIPRJMOD}-relative paths, or to follow " +
+      "a library that was relocated, without unregistering and re-registering it.",
+    {
+      tableType,
+      scope,
+      projectPath,
+      tablePath,
+      libraryName: z.string().describe("Nickname of the entry to repoint"),
+      uri: z
+        .string()
+        .describe(
+          "New URI, e.g. ${KIPRJMOD}/../FOG_components.kicad_sym. Path variables are kept " +
+            "verbatim in the table and only expanded when reporting whether the file exists.",
+        ),
+    },
+    async (args: any) => {
+      const result = await callKicadScript("set_library_table_uri", args);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -153,6 +153,11 @@ export const toolCategories: ToolCategory[] = [
       "search_footprints",
       "list_library_footprints",
       "get_footprint_info",
+      // Library table maintenance: the read/remove/repoint counterparts to
+      // register_symbol_library and register_footprint_library.
+      "list_library_table",
+      "remove_library_table_entry",
+      "set_library_table_uri",
       // Symbol-library maintenance. Sits here for now because there is no
       // symbol-library category yet -- see #345, which tracks giving the
       // ~13 unregistered symbol tools a proper home.

--- a/tests/test_library_tables.py
+++ b/tests/test_library_tables.py
@@ -1,0 +1,358 @@
+"""Tests for list_library_table / remove_library_table_entry / set_library_table_uri."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+from commands.library_tables import (  # noqa: E402
+    _parse_entries,
+    _parses,
+    list_library_table,
+    remove_library_table_entry,
+    set_library_table_uri,
+)
+
+# The compact layout KiCad writes: every field on one line, closing paren of the
+# last entry on the line above the table's own.
+SYM_TABLE = """(sym_lib_table
+  (version 7)
+  (lib (name "eagle_import")(type "KiCad")(uri "${KIPRJMOD}/eagle_import.kicad_sym")(options "")(descr ""))
+  (lib (name "FOG_components")(type "KiCad")(uri "${KIPRJMOD}/../FOG_components.kicad_sym")(options "")(descr "House library"))
+  (lib (name "Device")(type "KiCad")(uri "${KICAD9_SYMBOL_DIR}/Device.kicad_sym")(options "")(descr ""))
+)
+"""
+
+FP_TABLE = """(fp_lib_table
+  (version 7)
+  (lib (name "FOG_components")(type "KiCad")(uri "${KIPRJMOD}/../FOG_components.pretty")(options "")(descr ""))
+)
+"""
+
+# Multi-line rows, which newer KiCad writes and which a line-based edit breaks.
+MULTILINE_TABLE = """(sym_lib_table
+\t(version 7)
+\t(lib
+\t\t(name "alpha")
+\t\t(type "KiCad")
+\t\t(uri "${KIPRJMOD}/alpha.kicad_sym")
+\t\t(options "")
+\t\t(descr "first")
+\t)
+\t(lib
+\t\t(name "beta")
+\t\t(type "KiCad")
+\t\t(uri "${KIPRJMOD}/beta.kicad_sym")
+\t\t(options "")
+\t\t(descr "second")
+\t)
+)
+"""
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / "sym-lib-table").write_text(SYM_TABLE, encoding="utf-8")
+    (tmp_path / "fp-lib-table").write_text(FP_TABLE, encoding="utf-8")
+    (tmp_path / "eagle_import.kicad_sym").write_text("(kicad_symbol_lib)", encoding="utf-8")
+    (tmp_path.parent / "FOG_components.kicad_sym").write_text(
+        "(kicad_symbol_lib)", encoding="utf-8"
+    )
+    return tmp_path
+
+
+def names(result):
+    return [e["name"] for e in result["entries"]]
+
+
+def read(project, filename="sym-lib-table"):
+    return (project / filename).read_text(encoding="utf-8")
+
+
+# --- parsing --------------------------------------------------------------- #
+
+
+def test_parse_entries_reads_every_field():
+    entries = _parse_entries(SYM_TABLE)
+    assert [e["name"] for e in entries] == ["eagle_import", "FOG_components", "Device"]
+    assert entries[1]["descr"] == "House library"
+    assert entries[1]["uri"] == "${KIPRJMOD}/../FOG_components.kicad_sym"
+
+
+def test_parse_entries_handles_multiline_rows():
+    entries = _parse_entries(MULTILINE_TABLE)
+    assert [e["name"] for e in entries] == ["alpha", "beta"]
+    assert entries[0]["descr"] == "first"
+
+
+def test_parse_entry_spans_are_exact():
+    entries = _parse_entries(SYM_TABLE)
+    for entry in entries:
+        block = SYM_TABLE[entry["start"] : entry["end"]]
+        assert block.startswith("(lib ")
+        assert block.endswith(")")
+        assert _parses(block)
+
+
+def test_parses_rejects_truncated_table():
+    assert not _parses(SYM_TABLE.replace("\n)\n", "\n"))
+
+
+# --- list ------------------------------------------------------------------ #
+
+
+def test_list_reads_project_table(project):
+    r = list_library_table({"projectPath": str(project)})
+    assert r["success"]
+    assert names(r) == ["eagle_import", "FOG_components", "Device"]
+    assert r["entryCount"] == 3
+
+
+def test_list_resolves_kiprjmod(project):
+    r = list_library_table({"projectPath": str(project)})
+    entry = next(e for e in r["entries"] if e["name"] == "eagle_import")
+    assert entry["exists"] is True
+    assert entry["resolvedPath"].endswith("eagle_import.kicad_sym")
+
+
+def test_list_resolves_kiprjmod_parent(project):
+    r = list_library_table({"projectPath": str(project)})
+    entry = next(e for e in r["entries"] if e["name"] == "FOG_components")
+    assert entry["exists"] is True
+
+
+def test_list_flags_an_entry_whose_file_is_gone(project):
+    (project / "eagle_import.kicad_sym").unlink()
+    r = list_library_table({"projectPath": str(project)})
+    entry = next(e for e in r["entries"] if e["name"] == "eagle_import")
+    assert entry["exists"] is False
+    assert r["missingCount"] >= 1
+    assert "not there" in r["message"]
+
+
+def test_list_does_not_claim_an_unresolved_variable_exists(project):
+    """${KICAD9_SYMBOL_DIR} is unset here; it must not resolve to a bare path."""
+    r = list_library_table({"projectPath": str(project)})
+    entry = next(e for e in r["entries"] if e["name"] == "Device")
+    assert entry["exists"] is False
+
+
+def test_list_footprint_table(project):
+    r = list_library_table({"projectPath": str(project), "tableType": "footprint"})
+    assert names(r) == ["FOG_components"]
+    assert r["tableType"] == "footprint"
+
+
+def test_list_accepts_an_explicit_table_path(project):
+    r = list_library_table({"tablePath": str(project / "sym-lib-table")})
+    assert r["success"]
+    assert len(names(r)) == 3
+
+
+def test_list_rejects_unknown_table_type(project):
+    r = list_library_table({"projectPath": str(project), "tableType": "netclass"})
+    assert not r["success"]
+    assert "tableType" in r["message"]
+
+
+def test_list_requires_project_path():
+    r = list_library_table({})
+    assert not r["success"]
+
+
+def test_list_missing_table(tmp_path):
+    r = list_library_table({"projectPath": str(tmp_path)})
+    assert not r["success"]
+    assert "not found" in r["message"].lower()
+
+
+# --- remove ---------------------------------------------------------------- #
+
+
+def test_remove_drops_the_named_entry(project):
+    r = remove_library_table_entry({"projectPath": str(project), "libraryName": "eagle_import"})
+    assert r["success"]
+    assert names(list_library_table({"projectPath": str(project)})) == [
+        "FOG_components",
+        "Device",
+    ]
+
+
+def test_remove_keeps_the_table_parseable(project):
+    remove_library_table_entry({"projectPath": str(project), "libraryName": "eagle_import"})
+    assert _parses(read(project))
+
+
+def test_remove_leaves_no_blank_line(project):
+    remove_library_table_entry({"projectPath": str(project), "libraryName": "eagle_import"})
+    assert "\n\n" not in read(project)
+
+
+def test_remove_the_last_entry_keeps_the_table_close(project):
+    """The row before ')' -- the case a naive rstrip-and-replace corrupts."""
+    r = remove_library_table_entry({"projectPath": str(project), "libraryName": "Device"})
+    assert r["success"]
+    content = read(project)
+    assert _parses(content)
+    assert content.rstrip().endswith(")")
+    assert names(list_library_table({"projectPath": str(project)})) == [
+        "eagle_import",
+        "FOG_components",
+    ]
+
+
+def test_remove_several_at_once(project):
+    r = remove_library_table_entry(
+        {"projectPath": str(project), "libraryNames": ["eagle_import", "Device"]}
+    )
+    assert r["success"]
+    assert sorted(e["name"] for e in r["removed"]) == ["Device", "eagle_import"]
+    assert names(list_library_table({"projectPath": str(project)})) == ["FOG_components"]
+    assert _parses(read(project))
+
+
+def test_remove_several_from_a_multiline_table(tmp_path):
+    (tmp_path / "sym-lib-table").write_text(MULTILINE_TABLE, encoding="utf-8")
+    r = remove_library_table_entry(
+        {"projectPath": str(tmp_path), "libraryNames": ["alpha", "beta"]}
+    )
+    assert r["success"]
+    content = (tmp_path / "sym-lib-table").read_text(encoding="utf-8")
+    assert _parses(content)
+    assert "alpha" not in content
+    assert "beta" not in content
+
+
+def test_remove_reports_unknown_names(project):
+    r = remove_library_table_entry(
+        {"projectPath": str(project), "libraryNames": ["Device", "nope"]}
+    )
+    assert r["success"]
+    assert r["notFound"] == ["nope"]
+
+
+def test_remove_nothing_matching_is_an_error(project):
+    r = remove_library_table_entry({"projectPath": str(project), "libraryName": "nope"})
+    assert not r["success"]
+    assert "eagle_import" in r["message"]
+    assert read(project) == SYM_TABLE
+
+
+def test_remove_requires_a_name(project):
+    r = remove_library_table_entry({"projectPath": str(project)})
+    assert not r["success"]
+
+
+def test_remove_from_footprint_table(project):
+    r = remove_library_table_entry(
+        {"projectPath": str(project), "tableType": "footprint", "libraryName": "FOG_components"}
+    )
+    assert r["success"]
+    assert _parses(read(project, "fp-lib-table"))
+    assert (
+        list_library_table({"projectPath": str(project), "tableType": "footprint"})["entryCount"]
+        == 0
+    )
+
+
+# --- repoint --------------------------------------------------------------- #
+
+
+def test_set_uri_repoints_an_entry(project):
+    r = set_library_table_uri(
+        {
+            "projectPath": str(project),
+            "libraryName": "FOG_components",
+            "uri": "${KIPRJMOD}/FOG_components.kicad_sym",
+        }
+    )
+    assert r["success"]
+    assert r["previousUri"] == "${KIPRJMOD}/../FOG_components.kicad_sym"
+    entry = next(
+        e
+        for e in list_library_table({"projectPath": str(project)})["entries"]
+        if e["name"] == "FOG_components"
+    )
+    assert entry["uri"] == "${KIPRJMOD}/FOG_components.kicad_sym"
+
+
+def test_set_uri_leaves_other_fields_alone(project):
+    set_library_table_uri(
+        {
+            "projectPath": str(project),
+            "libraryName": "FOG_components",
+            "uri": "${KIPRJMOD}/moved.kicad_sym",
+        }
+    )
+    entry = next(
+        e
+        for e in list_library_table({"projectPath": str(project)})["entries"]
+        if e["name"] == "FOG_components"
+    )
+    assert entry["descr"] == "House library"
+    assert entry["type"] == "KiCad"
+
+
+def test_set_uri_leaves_other_entries_alone(project):
+    set_library_table_uri(
+        {
+            "projectPath": str(project),
+            "libraryName": "FOG_components",
+            "uri": "${KIPRJMOD}/moved.kicad_sym",
+        }
+    )
+    assert names(list_library_table({"projectPath": str(project)})) == [
+        "eagle_import",
+        "FOG_components",
+        "Device",
+    ]
+    assert _parses(read(project))
+
+
+def test_set_uri_warns_when_the_target_is_not_there(project):
+    r = set_library_table_uri(
+        {
+            "projectPath": str(project),
+            "libraryName": "FOG_components",
+            "uri": "${KIPRJMOD}/nowhere.kicad_sym",
+        }
+    )
+    assert r["success"]
+    assert r["exists"] is False
+    assert "no file exists there yet" in r["message"]
+
+
+def test_set_uri_unknown_entry(project):
+    r = set_library_table_uri(
+        {"projectPath": str(project), "libraryName": "nope", "uri": "x.kicad_sym"}
+    )
+    assert not r["success"]
+    assert read(project) == SYM_TABLE
+
+
+def test_set_uri_requires_a_uri(project):
+    r = set_library_table_uri({"projectPath": str(project), "libraryName": "Device"})
+    assert not r["success"]
+
+
+def test_set_uri_escapes_quotes(project):
+    r = set_library_table_uri(
+        {
+            "projectPath": str(project),
+            "libraryName": "Device",
+            "uri": 'weird"name.kicad_sym',
+        }
+    )
+    assert r["success"]
+    assert _parses(read(project))
+    entry = next(
+        e
+        for e in list_library_table({"projectPath": str(project)})["entries"]
+        if e["name"] == "Device"
+    )
+    assert entry["uri"] == 'weird"name.kicad_sym'
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_library_tables.py
+++ b/tests/test_library_tables.py
@@ -1,18 +1,24 @@
 """Tests for list_library_table / remove_library_table_entry / set_library_table_uri."""
 
+import os
 import sys
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+from commands import library_tables  # noqa: E402
+from commands.library import LibraryManager  # noqa: E402
+from commands.library_symbol import SymbolLibraryManager  # noqa: E402
 from commands.library_tables import (  # noqa: E402
+    _field,
     _parse_entries,
     _parses,
     list_library_table,
     remove_library_table_entry,
     set_library_table_uri,
 )
+from utils.platform_helper import PlatformHelper  # noqa: E402
 
 # The compact layout KiCad writes: every field on one line, closing paren of the
 # last entry on the line above the table's own.
@@ -49,6 +55,69 @@ MULTILINE_TABLE = """(sym_lib_table
 \t)
 )
 """
+
+
+# A row containing a parenthesis inside a quoted value. Ordinary in a table
+# imported from Eagle, and the case a raw "(lib" text scan turns into a phantom
+# row nested inside the real one.
+PAREN_IN_STRING_TABLE = """(sym_lib_table
+  (version 7)
+  (lib (name "Caps")(type "KiCad")(uri "${KIPRJMOD}/Caps.kicad_sym")(options "")(descr "Caps (X7R) 50V, see (lib old)"))
+  (lib (name "Device")(type "KiCad")(uri "${KIPRJMOD}/Device.kicad_sym")(options "")(descr ""))
+)
+"""
+
+# KiCad 10's global table: one (type "Table") row standing in for every stock
+# library, rather than one row per library.
+TABLE_REF_TABLE = """(sym_lib_table
+  (version 7)
+  (lib (name "KiCad")(type "Table")(uri "${KIPRJMOD}/stock/sym-lib-table")(options "")(descr "KiCad standard libraries"))
+  (lib (name "house")(type "KiCad")(uri "${KIPRJMOD}/house.kicad_sym")(options "")(descr ""))
+)
+"""
+
+STOCK_TABLE = """(sym_lib_table
+  (version 7)
+  (lib (name "4xxx")(type "KiCad")(uri "${KICAD9_SYMBOL_DIR}/4xxx.kicad_sym")(options "")(descr ""))
+  (lib (name "Device")(type "KiCad")(uri "${KICAD9_SYMBOL_DIR}/Device.kicad_sym")(options "")(descr ""))
+  (lib (name "Relay")(type "KiCad")(uri "${KICAD9_SYMBOL_DIR}/Relay.kicad_sym")(options "")(descr ""))
+)
+"""
+
+# A global table, used only ever as a COPY inside tmp_path. The suite must never
+# write to the real %APPDATA%/kicad tables -- they are the live KiCad config for
+# every project on the machine.
+GLOBAL_TABLE = """(sym_lib_table
+  (version 7)
+  (lib (name "stock")(type "KiCad")(uri "${KICAD9_SYMBOL_DIR}/stock.kicad_sym")(options "")(descr ""))
+  (lib (name "bogus")(type "KiCad")(uri "${KIPRJMOD}/bogus.kicad_sym")(options "")(descr ""))
+)
+"""
+
+
+@pytest.fixture(autouse=True)
+def no_installed_kicad(monkeypatch):
+    """Make URI resolution independent of whether this machine has KiCad.
+
+    ``${KICAD*_SYMBOL_DIR}`` and friends resolve against the discovered install,
+    so on a developer box they resolve and on a CI runner they do not. Default
+    them to absent and let the tests that care install a fake directory.
+    """
+    monkeypatch.setattr(SymbolLibraryManager, "_find_kicad_symbol_dir", lambda self: None)
+    monkeypatch.setattr(SymbolLibraryManager, "_find_3rd_party_dir", lambda self: None)
+    monkeypatch.setattr(LibraryManager, "_find_kicad_footprint_dir", lambda self: None)
+    monkeypatch.setattr(LibraryManager, "_find_kicad_3rdparty_dir", lambda self: None)
+    monkeypatch.setattr(PlatformHelper, "load_kicad_env_vars", staticmethod(dict))
+
+
+@pytest.fixture
+def fake_global(tmp_path, monkeypatch):
+    """A COPY of a global table in a fake KiCad config dir, for scope='global'."""
+    config = tmp_path / "kicad-config" / "10.0"
+    config.mkdir(parents=True)
+    (config / "sym-lib-table").write_text(GLOBAL_TABLE, encoding="utf-8")
+    monkeypatch.setattr(library_tables, "_kicad_config_dirs", lambda: [config])
+    return config
 
 
 @pytest.fixture
@@ -99,6 +168,30 @@ def test_parses_rejects_truncated_table():
     assert not _parses(SYM_TABLE.replace("\n)\n", "\n"))
 
 
+def test_a_paren_inside_a_quoted_field_is_not_a_row():
+    """`(lib old)` inside a description is text, not a third entry."""
+    entries = _parse_entries(PAREN_IN_STRING_TABLE)
+    assert [e["name"] for e in entries] == ["Caps", "Device"]
+    assert entries[0]["descr"] == "Caps (X7R) 50V, see (lib old)"
+
+
+def test_row_spans_never_nest():
+    """A phantom row's span sits inside a real one, which double-cuts on remove."""
+    entries = _parse_entries(PAREN_IN_STRING_TABLE)
+    for earlier, later in zip(entries, entries[1:]):
+        assert earlier["end"] <= later["start"]
+
+
+def test_field_reads_a_value_containing_parens():
+    block = '(lib (name "a")(uri "x")(descr "see (lib old) and (b)"))'
+    assert _field(block, "descr") == "see (lib old) and (b)"
+    assert _field(block, "name") == "a"
+
+
+def test_field_tolerates_a_space_before_the_closing_paren():
+    assert _field('(lib (uri "x.kicad_sym" ))', "uri") == "x.kicad_sym"
+
+
 # --- list ------------------------------------------------------------------ #
 
 
@@ -131,11 +224,63 @@ def test_list_flags_an_entry_whose_file_is_gone(project):
     assert "not there" in r["message"]
 
 
-def test_list_does_not_claim_an_unresolved_variable_exists(project):
-    """${KICAD9_SYMBOL_DIR} is unset here; it must not resolve to a bare path."""
-    r = list_library_table({"projectPath": str(project)})
-    entry = next(e for e in r["entries"] if e["name"] == "Device")
+def test_list_does_not_claim_an_unresolved_variable_exists(tmp_path):
+    """A variable nothing defines must not be reported as a literal path."""
+    (tmp_path / "sym-lib-table").write_text(
+        "(sym_lib_table\n"
+        '  (lib (name "mystery")(type "KiCad")'
+        '(uri "${NO_SUCH_KICAD_VARIABLE}/mystery.kicad_sym")(options "")(descr ""))\n'
+        ")\n",
+        encoding="utf-8",
+    )
+    r = list_library_table({"projectPath": str(tmp_path)})
+    entry = r["entries"][0]
     assert entry["exists"] is False
+    assert entry["resolvedPath"] == "${NO_SUCH_KICAD_VARIABLE}/mystery.kicad_sym"
+
+
+def test_list_resolves_a_stock_symbol_dir_variable(tmp_path, monkeypatch):
+    """KICAD*_SYMBOL_DIR is defined inside KiCad -- it is in neither
+    kicad_common.json nor the environment. Resolving from those two alone
+    reports every row of a stock table as missing, which reads as an
+    instruction to delete 200+ good rows."""
+    stock = tmp_path / "share" / "kicad" / "symbols"
+    stock.mkdir(parents=True)
+    for name in ("4xxx", "Device", "Relay"):
+        (stock / f"{name}.kicad_sym").write_text("(kicad_symbol_lib)", encoding="utf-8")
+    monkeypatch.setattr(SymbolLibraryManager, "_find_kicad_symbol_dir", lambda self: str(stock))
+    (tmp_path / "sym-lib-table").write_text(STOCK_TABLE, encoding="utf-8")
+
+    r = list_library_table({"projectPath": str(tmp_path)})
+    assert r["entryCount"] == 3
+    assert r["missingCount"] == 0
+    entry = next(e for e in r["entries"] if e["name"] == "Device")
+    assert entry["exists"] is True
+    assert entry["resolvedPath"] == str((stock / "Device.kicad_sym").resolve())
+    assert "not there" not in r["message"]
+
+
+def test_list_resolves_a_stock_footprint_dir_variable(tmp_path, monkeypatch):
+    stock = tmp_path / "share" / "kicad" / "footprints"
+    (stock / "Battery.pretty").mkdir(parents=True)
+    monkeypatch.setattr(LibraryManager, "_find_kicad_footprint_dir", lambda self: str(stock))
+    (tmp_path / "fp-lib-table").write_text(
+        "(fp_lib_table\n"
+        '  (lib (name "Battery")(type "KiCad")'
+        '(uri "${KICAD10_FOOTPRINT_DIR}/Battery.pretty")(options "")(descr ""))\n'
+        ")\n",
+        encoding="utf-8",
+    )
+    r = list_library_table({"projectPath": str(tmp_path), "tableType": "footprint"})
+    assert r["missingCount"] == 0
+    assert r["entries"][0]["exists"] is True
+
+
+def test_list_reports_a_paren_in_a_description_as_one_row(tmp_path):
+    (tmp_path / "sym-lib-table").write_text(PAREN_IN_STRING_TABLE, encoding="utf-8")
+    r = list_library_table({"projectPath": str(tmp_path)})
+    assert r["entryCount"] == 2
+    assert names(r) == ["Caps", "Device"]
 
 
 def test_list_footprint_table(project):
@@ -165,6 +310,114 @@ def test_list_missing_table(tmp_path):
     r = list_library_table({"projectPath": str(tmp_path)})
     assert not r["success"]
     assert "not found" in r["message"].lower()
+
+
+# --- (type "Table") indirection -------------------------------------------- #
+
+
+@pytest.fixture
+def table_ref(tmp_path):
+    (tmp_path / "sym-lib-table").write_text(TABLE_REF_TABLE, encoding="utf-8")
+    stock = tmp_path / "stock"
+    stock.mkdir()
+    (stock / "sym-lib-table").write_text(STOCK_TABLE, encoding="utf-8")
+    return tmp_path
+
+
+def test_list_flags_a_table_reference_and_counts_what_it_stands_for(table_ref):
+    r = list_library_table({"projectPath": str(table_ref)})
+    entry = next(e for e in r["entries"] if e["name"] == "KiCad")
+    assert entry["isTableReference"] is True
+    assert entry["includedLibraryCount"] == 3
+    assert r["tableReferenceCount"] == 1
+    assert r["referencedLibraryCount"] == 3
+    assert 'type "Table"' in r["message"]
+
+
+def test_list_does_not_flag_an_ordinary_row_as_a_table_reference(table_ref):
+    r = list_library_table({"projectPath": str(table_ref)})
+    entry = next(e for e in r["entries"] if e["name"] == "house")
+    assert "isTableReference" not in entry
+    assert r["tableReferenceCount"] == 1
+
+
+def test_removing_a_table_reference_reports_the_blast_radius(table_ref):
+    r = remove_library_table_entry({"projectPath": str(table_ref), "libraryName": "KiCad"})
+    assert r["success"]
+    assert r["tableReferencesRemoved"] == ["KiCad"]
+    assert r["referencedLibraryCount"] == 3
+    assert "WARNING" in r["message"]
+    assert '(type "Table")' in r["message"]
+    assert "3 libraries" in r["message"]
+
+
+def test_removing_an_ordinary_row_carries_no_table_warning(table_ref):
+    r = remove_library_table_entry({"projectPath": str(table_ref), "libraryName": "house"})
+    assert r["success"]
+    assert r["tableReferencesRemoved"] == []
+    assert "WARNING" not in r["message"]
+
+
+# --- global scope (always against a COPY, never the real KiCad config) ----- #
+
+
+def test_global_scope_resolves_through_the_kicad_config_dirs(fake_global):
+    r = list_library_table({"scope": "global"})
+    assert r["success"]
+    assert r["tablePath"] == str(fake_global / "sym-lib-table")
+    assert names(r) == ["stock", "bogus"]
+
+
+def test_kiprjmod_is_left_unresolved_in_a_global_table(fake_global):
+    """There is no project directory for a machine-wide table, so ${KIPRJMOD}
+    must stay unresolved rather than silently mean the config directory."""
+    r = list_library_table({"scope": "global"})
+    entry = next(e for e in r["entries"] if e["name"] == "bogus")
+    assert entry["resolvedPath"] == "${KIPRJMOD}/bogus.kicad_sym"
+    assert entry["exists"] is False
+
+
+def test_global_scope_removal_edits_the_resolved_table(fake_global):
+    r = remove_library_table_entry({"scope": "global", "libraryName": "bogus"})
+    assert r["success"]
+    content = (fake_global / "sym-lib-table").read_text(encoding="utf-8")
+    assert "bogus" not in content
+    assert _parses(content)
+
+
+def test_global_scope_reports_no_table_when_the_config_has_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(library_tables, "_kicad_config_dirs", lambda: [tmp_path / "nope"])
+    r = list_library_table({"scope": "global"})
+    assert not r["success"]
+    assert "No global sym-lib-table found" in r["message"]
+
+
+def test_kicad_config_dirs_prefers_appdata_and_the_newest_version(tmp_path, monkeypatch):
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    dirs = library_tables._kicad_config_dirs()
+    assert dirs[0] == tmp_path / "kicad" / "10.0"
+    assert tmp_path / "kicad" / "9.0" in dirs
+
+
+# --- guarding tablePath ---------------------------------------------------- #
+
+
+def test_refuses_a_file_that_is_not_a_library_table(tmp_path):
+    """tablePath bypasses scope resolution, so without a root-token check a
+    mutating call rewrites any balanced s-expression holding a (lib ...) row."""
+    board = tmp_path / "board.kicad_pcb"
+    original = '(kicad_pcb (lib (name "Device")(uri "x")))\n'
+    board.write_text(original, encoding="utf-8")
+    r = remove_library_table_entry({"tablePath": str(board), "libraryName": "Device"})
+    assert not r["success"]
+    assert "not a sym_lib_table" in r["message"]
+    assert board.read_text(encoding="utf-8") == original
+
+
+def test_refuses_a_footprint_table_asked_for_as_a_symbol_table(project):
+    r = list_library_table({"tablePath": str(project / "fp-lib-table")})
+    assert not r["success"]
+    assert "not a sym_lib_table" in r["message"]
 
 
 # --- remove ---------------------------------------------------------------- #
@@ -242,6 +495,123 @@ def test_remove_nothing_matching_is_an_error(project):
 def test_remove_requires_a_name(project):
     r = remove_library_table_entry({"projectPath": str(project)})
     assert not r["success"]
+
+
+def test_remove_counts_are_right_when_a_description_holds_a_paren(tmp_path):
+    """A phantom row inflates entryCount and remainingCount by one."""
+    (tmp_path / "sym-lib-table").write_text(PAREN_IN_STRING_TABLE, encoding="utf-8")
+    r = remove_library_table_entry({"projectPath": str(tmp_path), "libraryName": "Caps"})
+    assert r["success"]
+    assert r["remainingCount"] == 1
+    content = (tmp_path / "sym-lib-table").read_text(encoding="utf-8")
+    assert _parses(content)
+    assert "Caps" not in content
+    assert "Device" in content
+
+
+# --- how the file is written ----------------------------------------------- #
+
+
+def write_with_newline(path, text, newline):
+    with open(path, "w", encoding="utf-8", newline=newline) as fh:
+        fh.write(text)
+
+
+def test_removal_keeps_lf_line_endings(tmp_path):
+    """A rewrite that flips the whole file to CRLF churns forever against
+    KiCad's own saves; the diff is every line of a 200-row global table."""
+    path = tmp_path / "sym-lib-table"
+    write_with_newline(path, SYM_TABLE, "\n")
+    remove_library_table_entry({"projectPath": str(tmp_path), "libraryName": "eagle_import"})
+    assert b"\r\n" not in path.read_bytes()
+
+
+def test_removal_keeps_crlf_line_endings(tmp_path):
+    path = tmp_path / "sym-lib-table"
+    write_with_newline(path, SYM_TABLE, "\r\n")
+    remove_library_table_entry({"projectPath": str(tmp_path), "libraryName": "eagle_import"})
+    raw = path.read_bytes()
+    assert b"\r\n" in raw
+    assert raw.count(b"\n") == raw.count(b"\r\n")
+
+
+def test_repoint_keeps_lf_line_endings(tmp_path):
+    path = tmp_path / "sym-lib-table"
+    write_with_newline(path, SYM_TABLE, "\n")
+    set_library_table_uri(
+        {"projectPath": str(tmp_path), "libraryName": "Device", "uri": "moved.kicad_sym"}
+    )
+    assert b"\r\n" not in path.read_bytes()
+
+
+def test_a_failed_write_cannot_truncate_the_table(project, monkeypatch):
+    """scope='global' points at the table every project on the machine loads;
+    a truncated write there stops KiCad starting at all. The rename is the only
+    step that touches the real file, so a failure leaves it byte-identical."""
+
+    def boom(src, dst):
+        raise OSError("simulated failure between temp file and rename")
+
+    monkeypatch.setattr(os, "replace", boom)
+    r = remove_library_table_entry({"projectPath": str(project), "libraryName": "eagle_import"})
+    assert not r["success"]
+    assert read(project) == SYM_TABLE
+    assert not list(project.glob("*.mcp-tmp"))
+
+
+def test_a_mutating_write_leaves_a_recoverable_backup(project):
+    r = remove_library_table_entry({"projectPath": str(project), "libraryName": "eagle_import"})
+    assert r["success"]
+    backup = Path(r["backup"])
+    assert backup.parent == project / ".mcp-backups"
+    assert backup.read_text(encoding="utf-8") == SYM_TABLE
+
+
+def test_repoint_leaves_a_recoverable_backup(project):
+    r = set_library_table_uri(
+        {"projectPath": str(project), "libraryName": "Device", "uri": "moved.kicad_sym"}
+    )
+    assert r["success"]
+    assert Path(r["backup"]).read_text(encoding="utf-8") == SYM_TABLE
+
+
+# --- dry run --------------------------------------------------------------- #
+
+
+def test_remove_dry_run_reports_the_edit_without_writing(project):
+    r = remove_library_table_entry(
+        {"projectPath": str(project), "libraryName": "eagle_import", "dryRun": True}
+    )
+    assert r["success"]
+    assert r["dryRun"] is True
+    assert [e["name"] for e in r["removed"]] == ["eagle_import"]
+    assert r["remainingCount"] == 2
+    assert "Would remove" in r["message"]
+    assert read(project) == SYM_TABLE
+    assert not (project / ".mcp-backups").exists()
+
+
+def test_remove_dry_run_still_reports_an_unknown_name(project):
+    r = remove_library_table_entry(
+        {"projectPath": str(project), "libraryName": "nope", "dryRun": True}
+    )
+    assert not r["success"]
+
+
+def test_set_uri_dry_run_reports_the_edit_without_writing(project):
+    r = set_library_table_uri(
+        {
+            "projectPath": str(project),
+            "libraryName": "FOG_components",
+            "uri": "${KIPRJMOD}/moved.kicad_sym",
+            "dryRun": True,
+        }
+    )
+    assert r["success"]
+    assert r["dryRun"] is True
+    assert r["previousUri"] == "${KIPRJMOD}/../FOG_components.kicad_sym"
+    assert "would now point" in r["message"]
+    assert read(project) == SYM_TABLE
 
 
 def test_remove_from_footprint_table(project):
@@ -352,6 +722,69 @@ def test_set_uri_escapes_quotes(project):
         if e["name"] == "Device"
     )
     assert entry["uri"] == 'weird"name.kicad_sym'
+
+
+def test_set_uri_writes_windows_backslashes_escaped(project):
+    """As an re replacement template, "\\\\" means one literal backslash -- re
+    undoes the doubling escape_sexpr_string just applied, and the table ends up
+    holding raw \\U \\m \\l escapes inside a quoted token."""
+    win = r"C:\Users\me\libs\foo.kicad_sym"
+    r = set_library_table_uri({"projectPath": str(project), "libraryName": "Device", "uri": win})
+    assert r["success"]
+    raw = read(project)
+    assert r'(uri "C:\\Users\\me\\libs\\foo.kicad_sym")' in raw
+    assert _parses(raw)
+    entry = next(
+        e
+        for e in list_library_table({"projectPath": str(project)})["entries"]
+        if e["name"] == "Device"
+    )
+    assert entry["uri"] == win
+
+
+def test_set_uri_accepts_a_path_ending_in_a_backslash(project):
+    """Unescaped, the trailing backslash escapes the closing quote and the whole
+    table stops parsing -- reported as a misleading 'unbalanced parentheses'."""
+    r = set_library_table_uri(
+        {"projectPath": str(project), "libraryName": "Device", "uri": "C:\\libs\\"}
+    )
+    assert r["success"], r["message"]
+    assert _parses(read(project))
+    entry = next(
+        e
+        for e in list_library_table({"projectPath": str(project)})["entries"]
+        if e["name"] == "Device"
+    )
+    assert entry["uri"] == "C:\\libs\\"
+
+
+def test_set_uri_escapes_a_quote_and_a_backslash_together(project):
+    weird = 'C:\\a"b\\c.kicad_sym'
+    r = set_library_table_uri({"projectPath": str(project), "libraryName": "Device", "uri": weird})
+    assert r["success"]
+    assert _parses(read(project))
+    entry = next(
+        e
+        for e in list_library_table({"projectPath": str(project)})["entries"]
+        if e["name"] == "Device"
+    )
+    assert entry["uri"] == weird
+
+
+def test_set_uri_tolerates_a_space_before_the_closing_paren(tmp_path):
+    """Hand-edited tables have `(uri "x" )`; that is not "no (uri ...) field"."""
+    (tmp_path / "sym-lib-table").write_text(
+        "(sym_lib_table\n"
+        '  (lib (name "Device")(type "KiCad")(uri "old.kicad_sym" )(options "")(descr ""))\n'
+        ")\n",
+        encoding="utf-8",
+    )
+    r = set_library_table_uri(
+        {"projectPath": str(tmp_path), "libraryName": "Device", "uri": "new.kicad_sym"}
+    )
+    assert r["success"], r["message"]
+    assert r["previousUri"] == "old.kicad_sym"
+    assert '(uri "new.kicad_sym")' in (tmp_path / "sym-lib-table").read_text(encoding="utf-8")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three tools that complete the library-table story: `list_library_table`, `remove_library_table_entry` and `set_library_table_uri`.

`register_symbol_library` and `register_footprint_library` can add a row to `sym-lib-table` / `fp-lib-table`. Nothing could read one back, drop one, or repoint one. So the tail end of any library migration — dropping the `eagle_import` row, moving a project onto `${KIPRJMOD}`-relative paths, finding the stale row behind a wall of `footprint_link_issues` — falls back to hand-editing the table.

That is also the part most likely to go wrong when scripted. The obvious approach, `content.replace(")", ...)` to splice before the closing paren, corrupts a table whose last entry ends on the same line as the table's own `)` — which is exactly how KiCad writes the global table.

## How these avoid that

Entries are parsed as `(lib ...)` spans with a string-aware paren matcher, edits slice exactly that span, and **the result is re-parsed before anything is written**. If an edit would leave the table unbalanced, it is refused and the file is left untouched. Concretely:

- Multi-line rows (newer KiCad writes one field per line) are handled — a line-based edit silently mangles them, and there is a test for it.
- Batch removal cuts from the back, so offsets computed before the first deletion are still valid for the rest.
- `set_library_table_uri` replaces only the `(uri ...)` field inside the matched span, leaving `type` and `descr` intact and neighbouring rows untouched. Values go through `escape_sexpr_string`.

## URI resolution

`list_library_table` reports each entry with its URI resolved through `${KIPRJMOD}`, KiCad's configured path variables (read via the existing `PlatformHelper.load_kicad_env_vars`, which already exists for this purpose) and the environment, plus whether the file is actually there.

A variable that resolves to nothing is reported as **missing** rather than being treated as a literal path — `${KICAD9_SYMBOL_DIR}/Device.kicad_sym` on a machine where that variable is unset points nowhere, and saying "exists" there would defeat the purpose of the check.

Path variables are stored in the table verbatim; expansion happens only for reporting. Writing a resolved absolute path back into the table would break the project for everyone else who opens it.

## Test plan

- [x] 31 new tests in `tests/test_library_tables.py`, fully hermetic (`tmp_path`, no KiCad needed): field parsing, exact span boundaries, multi-line rows, `${KIPRJMOD}` and `${KIPRJMOD}/..` resolution, unresolved variables, missing files, removing the last row before `)`, batch removal from a multi-line table, unknown nicknames leaving the file byte-identical, and quote escaping in a new URI.
- [x] `pytest tests/` — 1770 passed. The 20 failures are pre-existing on `upstream/main` at `0dc3ee8` and unchanged by this branch.
- [x] `npm run build`, `npx vitest run` (70 passed), `eslint`, `prettier`, `black`, `isort`, `flake8`, `mypy` clean. README headline count updated to 149.
- [x] Against real data: 10 project tables from a hierarchical KiCad 10 project read correctly with their `${KIPRJMOD}/../` URIs resolved, and the global table at `AppData/Roaming/kicad/10.0/sym-lib-table` is found via `scope: "global"`. A round-trip on a copy (remove one entry, repoint another) leaves the table parseable.

Registered in all five places, including `registry.ts`, so `search_tools` finds them rather than adding to `KNOWN_UNREGISTERED`.
