### PR TITLE
feat: add backannotate_footprints (PCB footprints -> schematic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,25 +14,51 @@ All notable changes to the KiCAD MCP Server project are documented here.
   projects have the same problem from day one: the schematic-side fields never
   matched the placed parts.
 
-  Matches by reference designator across every `.kicad_sch` beside the board (or
-  one named sheet), updates all units of a multi-unit symbol, and skips virtual
-  references starting with `#` (power and ground symbols carry no footprint).
-  Instances with no `Footprint` field get one added unless `addMissing` is
-  false; `dryRun` reports the diff without writing. Position and `hide` are
-  carried over from the existing field, so back-annotating does not move or
-  reveal a field the user had placed. The `lib_symbols` cache is left alone —
-  instance fields override it, and rewriting the cache is a different tool.
+  Matches by reference designator, updates all units of a multi-unit symbol, and
+  skips virtual references starting with `#` (power and ground symbols carry no
+  footprint). Instances with no `Footprint` field get one added unless
+  `addMissing` is false; `dryRun` reports the diff without writing. The
+  `lib_symbols` cache is left alone — instance fields override it, and rewriting
+  the cache is a different tool.
+
+  The designators come from each symbol's `(instances ...)` block, which is
+  where KiCad 7+ keeps one per sheet instance; the `(property "Reference" ...)`
+  holds only one of them. A sub-sheet placed twice therefore contributes both
+  designators, and because those instances share a single `Footprint` field,
+  nothing is written when the board disagrees between them — the references and
+  the differing footprints go into `conflicts` instead. A reference the board
+  carries on two footprints is refused the same way. Footprints placed on the
+  board with no matching symbol — the mounting holes and test points added
+  directly in pcbnew — are listed under `notInSchematic` rather than dropped.
+
+  Updating a field rewrites _only_ the quoted value token, so `hide`,
+  `show_name`, `unlocked`, justification, font and the field's exact layout are
+  left byte-for-byte alone: the file stays what eeschema would have written. Only
+  the `addMissing` insertion path builds a field from scratch, because there is
+  no existing state to keep. Writes are atomic and preserve each file's existing
+  line endings, so a one-field edit is a one-line diff on an LF checkout.
+
+  Sheets are found by walking the real sheet tree from the root schematic beside
+  the board, so `.history` snapshots, backup copies, unrelated projects in the
+  same directory and orphaned sheets are never rewritten. Every sheet is planned
+  before any is written, and a write that fails lands in `failures` with the rest
+  of the report intact instead of leaving earlier sheets edited.
 
   Parsing is structural rather than regex-based, which matters for two real
   cases: footprint names containing parentheses (`HRS_U.FL-R-SMT-1(10)` is a
   stock Hirose connector) and board files whose indentation does not track
-  nesting. Verified end to end on a 71-footprint board: it found two genuine
-  mismatches (`0402S` where the board had `0402HF`), `kicad-cli sch upgrade`
-  accepted the result, and a second pass was a no-op.
+  nesting. Verified end to end on copies of two real projects: on a 251-footprint
+  board it rewrote 263 stale fields in the one sheet of the design, left the
+  `.history` copy and a second project in the same directory untouched, reported
+  four board-only mounting holes, and `kicad-cli sch upgrade` accepted the
+  result; on a 244-footprint hierarchical board already in sync it reported no
+  changes, walked 9 of the 10 `.kicad_sch` files (the tenth is referenced by
+  nothing) and flagged one genuine duplicate board reference. Both second passes
+  were byte-for-byte no-ops.
 
-  The s-expression walkers this needed (`match_paren`, `iter_child_offsets`)
-  moved into `utils/sexpr_format.py`, replacing private copies in
-  `add_symbol_property` and `library_tables`.
+  The s-expression walkers this needed (`match_paren`, `iter_child_offsets`) live
+  in `utils/sexpr_format.py` so later tools can share them instead of carrying
+  another private paren counter.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### New Tools
+
+- **`backannotate_footprints`** — copy footprint assignments from a `.kicad_pcb`
+  back into the schematic's `Footprint` fields. The server had
+  `sync_schematic_to_board` (F8) but nothing in the reverse direction, so after
+  a layout pass — where footprints get swapped in pcbnew — the schematic kept
+  stale values, and every ECO run pushed them back onto the board. Imported
+  projects have the same problem from day one: the schematic-side fields never
+  matched the placed parts.
+
+  Matches by reference designator across every `.kicad_sch` beside the board (or
+  one named sheet), updates all units of a multi-unit symbol, and skips virtual
+  references starting with `#` (power and ground symbols carry no footprint).
+  Instances with no `Footprint` field get one added unless `addMissing` is
+  false; `dryRun` reports the diff without writing. Position and `hide` are
+  carried over from the existing field, so back-annotating does not move or
+  reveal a field the user had placed. The `lib_symbols` cache is left alone —
+  instance fields override it, and rewriting the cache is a different tool.
+
+  Parsing is structural rather than regex-based, which matters for two real
+  cases: footprint names containing parentheses (`HRS_U.FL-R-SMT-1(10)` is a
+  stock Hirose connector) and board files whose indentation does not track
+  nesting. Verified end to end on a 71-footprint board: it found two genuine
+  mismatches (`0402S` where the board had `0402HF`), `kicad-cli sch upgrade`
+  accepted the result, and a second pass was a no-op.
+
+  The s-expression walkers this needed (`match_paren`, `iter_child_offsets`)
+  moved into `utils/sexpr_format.py`, replacing private copies in
+  `add_symbol_property` and `library_tables`.
+
 ### Bug Fixes
 
 - **`add_layer` could not add inner copper layers, and corrupted an unrelated

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ configuration command and backend options.
 We've implemented an intelligent tool router to keep AI context efficient while maintaining full functionality:
 
 - **22 direct tools** always visible for high-frequency operations
-- **111 routed tools** organized into 13 categories (board, component, export, drc, schematic, library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, parts-registry)
+- **112 routed tools** organized into 13 categories (board, component, export, drc, schematic, library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, parts-registry)
 - **4 router tools** for discovery and execution:
   - `list_tool_categories` - Browse all available categories
   - `get_category_tools` - View tools in a specific category
@@ -486,7 +486,7 @@ Access project state without executing tools:
 
 ## Available Tools
 
-The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **146 tools** are additionally indexed into 13 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
+The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **147 tools** are additionally indexed into 13 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
 
 For the complete tool reference with access types (direct/routed/additional), see [Tool Inventory](docs/TOOL_INVENTORY.md).
 
@@ -1513,7 +1513,7 @@ npm run format
 
 See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix and [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
 
-**Working Features (146 tools):**
+**Working Features (147 tools):**
 
 - Project management with snapshot checkpointing
 - Complete board design (outline, layers, zones, mounting holes, text, SVG logos)
@@ -1522,7 +1522,7 @@ See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix a
 - Complete schematic workflow with dynamic symbol loading (~10,000 symbols)
 - Intelligent wiring system with pin discovery and smart routing
 - FFC/ribbon cable passthrough workflow
-- Schematic-to-board synchronization
+- Schematic-to-board synchronization, plus footprint back-annotation from the board
 - Design rule checking (DRC and ERC)
 - Export to Gerber, PDF, SVG, 3D, BOM, netlist, position file
 - Custom footprint and symbol creation

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 **Key Capabilities:**
 
-- 146 tools across 13 categories with JSON Schema validation
+- 147 tools across 13 categories with JSON Schema validation
 - Keyword tool discovery via `search_tools` / `get_category_tools`
 - 8 dynamic resources exposing project state
 - Complete schematic workflow with 27 tools and dynamic symbol loading (~10,000 symbols)

--- a/python/commands/backannotate_footprints.py
+++ b/python/commands/backannotate_footprints.py
@@ -7,10 +7,28 @@ fields that never matched the placed parts. Recovering meant parsing
 ``.kicad_pcb`` by hand and editing each ``(property "Footprint" ...)``.
 
 Matching is by reference designator, the same key ``sync_schematic_to_board``
-uses. References beginning with ``#`` are power and other virtual symbols; they
-carry no footprint and are skipped. Multi-unit symbols appear as several
-instance blocks sharing one reference and all of them are updated, because
-KiCad treats a disagreement between units as a conflict.
+uses. From KiCad 7 on the designators a symbol actually carries live in its
+``(instances ...)`` block, one per sheet instance -- the ``(property
+"Reference" ...)`` holds only one of them -- so the candidates for a symbol come
+from there, falling back to the property when the block is absent. That matters
+for a sub-sheet instantiated more than once: its single ``Footprint`` field is
+shared by every instance, so if the board disagrees between them nothing is
+written and a ``conflicts`` entry names the references and the footprints.
+
+References beginning with ``#`` are power and other virtual symbols; they carry
+no footprint and are skipped. Multi-unit symbols appear as several instance
+blocks sharing one reference and all of them are updated, because KiCad treats a
+disagreement between units as a conflict.
+
+Updating an existing field replaces only the quoted value token, so ``hide``,
+``show_name``, ``unlocked``, justification, font and the field's exact layout
+survive untouched -- the file stays byte-identical to what eeschema would write
+apart from the value. Only the ``addMissing`` insertion path builds a field from
+scratch, because there is no existing state to keep.
+
+Sheets are found by walking the real sheet tree from the root schematic beside
+the board, so local history, backup copies and unrelated projects under the same
+directory are never rewritten.
 
 Nesting is tracked structurally rather than by indentation: KiCad's writers
 emit board files whose indentation does not always match depth.
@@ -22,9 +40,10 @@ Tools:
 from __future__ import annotations
 
 import logging
+import os
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple
 
 from utils.sexpr_format import (
     QUOTED_VALUE,
@@ -46,22 +65,58 @@ _FOOTPRINT_HEAD = re.compile(rf"\(footprint\s+{QUOTED_VALUE}")
 
 _INSTANCE_HEAD = re.compile(r"\(symbol[\s(]")
 
+# '(sheet ' only -- '(sheet_instances' is a different list at the same depth.
+_SHEET_HEAD = re.compile(r"\(sheet[\s(]")
+
+_REFERENCE_TOKEN = re.compile(rf"\(reference\s+{QUOTED_VALUE}")
+
 # KiCad 6+ stores a footprint's designator as a property; KiCad 5 used fp_text.
 _FP_TEXT_REFERENCE = re.compile(rf"\(fp_text\s+reference\s+{QUOTED_VALUE}")
 
 
-def _read(path: Path, kind: str) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+def _read_text(path: Path) -> Tuple[str, str]:
+    """File text with LF newlines, plus the newline style to write back."""
+    with open(path, "r", encoding="utf-8", newline="") as fh:
+        raw = fh.read()
+    return raw.replace("\r\n", "\n"), ("\r\n" if "\r\n" in raw else "\n")
+
+
+def _write_text(path: Path, text: str, newline: str) -> None:
+    """Atomic write that keeps the file's original newline style."""
+    tmp = path.with_name(path.name + ".mcp-tmp")
+    with open(tmp, "w", encoding="utf-8", newline=newline) as fh:
+        fh.write(text)
+    os.replace(tmp, path)
+
+
+def _read(path: Path, kind: str) -> Tuple[Optional[str], str, Optional[Dict[str, Any]]]:
+    """Text and newline style of *path*, or an error payload."""
     if not path.exists():
-        return None, {"success": False, "message": f"{kind} not found: {path}"}
+        return None, "\n", {"success": False, "message": f"{kind} not found: {path}"}
     try:
-        return path.read_text(encoding="utf-8"), None
+        text, newline = _read_text(path)
     except (OSError, UnicodeDecodeError) as exc:
-        return None, {"success": False, "message": f"Could not read {path}: {exc}"}
+        return None, "\n", {"success": False, "message": f"Could not read {path}: {exc}"}
+    return text, newline, None
 
 
-def _properties(block: str) -> Dict[str, Tuple[str, int, int]]:
-    """Direct-child properties of a block: name -> (value, start, end)."""
-    found: Dict[str, Tuple[str, int, int]] = {}
+class _Property(NamedTuple):
+    """One ``(property "name" "value" ...)`` list located inside a block.
+
+    ``value_start``/``value_end`` bound the escaped value *between* its quotes,
+    which is the only span an update is allowed to touch.
+    """
+
+    value: str
+    start: int
+    end: int
+    value_start: int
+    value_end: int
+
+
+def _properties(block: str) -> Dict[str, _Property]:
+    """Direct-child properties of a block, by name."""
+    found: Dict[str, _Property] = {}
     for offset in iter_child_offsets(block):
         m = _PROPERTY_HEAD.match(block, offset)
         if not m:
@@ -70,13 +125,27 @@ def _properties(block: str) -> Dict[str, Tuple[str, int, int]]:
         if end == -1:
             continue
         name = unescape_sexpr_string(m.group(1))
-        found.setdefault(name, (unescape_sexpr_string(m.group(2)), offset, end + 1))
+        found.setdefault(
+            name,
+            _Property(
+                value=unescape_sexpr_string(m.group(2)),
+                start=offset,
+                end=end + 1,
+                value_start=m.start(2),
+                value_end=m.end(2),
+            ),
+        )
     return found
 
 
-def read_board_footprints(board_text: str) -> Dict[str, str]:
-    """Reference designator -> footprint lib id, as placed on the board."""
-    placed: Dict[str, str] = {}
+def read_board_placements(board_text: str) -> Dict[str, List[str]]:
+    """Reference designator -> every footprint the board gives it, in file order.
+
+    A reference should appear once. When it appears twice the board is what is
+    ambiguous, so both are kept for the caller to refuse rather than one of them
+    silently overwriting the other.
+    """
+    placements: Dict[str, List[str]] = {}
     for offset in iter_child_offsets(board_text):
         m = _FOOTPRINT_HEAD.match(board_text, offset)
         if not m:
@@ -87,15 +156,24 @@ def read_board_footprints(board_text: str) -> Dict[str, str]:
         block = board_text[offset : end + 1]
         props = _properties(block)
         if "Reference" in props:
-            reference = props["Reference"][0]
+            reference = props["Reference"].value
         else:
             legacy = _FP_TEXT_REFERENCE.search(block)
             if not legacy:
                 continue
             reference = unescape_sexpr_string(legacy.group(1))
         if reference:
-            placed[reference] = unescape_sexpr_string(m.group(1))
-    return placed
+            placements.setdefault(reference, []).append(unescape_sexpr_string(m.group(1)))
+    return placements
+
+
+def read_board_footprints(board_text: str) -> Dict[str, str]:
+    """Reference designator -> footprint lib id, as placed on the board.
+
+    Duplicated references keep the first placement; use
+    :func:`read_board_placements` to see the ambiguity.
+    """
+    return {reference: values[0] for reference, values in read_board_placements(board_text).items()}
 
 
 def _indent_of(block: str, offset: int) -> str:
@@ -105,6 +183,7 @@ def _indent_of(block: str, offset: int) -> str:
 
 
 def _build_footprint_property(value: str, at_text: str, indent: str) -> str:
+    """A brand-new Footprint field. Only for insertion -- never for an update."""
     inner = indent + ("\t" if "\t" in indent else "  ")
     return "\n".join(
         [
@@ -128,12 +207,146 @@ def _at_token(block: str, prop_span: Tuple[int, int]) -> str:
     return "(at 0 0 0)"
 
 
+def _instance_references(block: str) -> List[str]:
+    """Reference designators from a symbol's ``(instances ...)``, in file order.
+
+    KiCad 7+ keeps one per sheet instance here; the ``Reference`` property is
+    only ever one of them, so a sub-sheet placed twice has a second designator
+    that exists nowhere else.
+    """
+    references: List[str] = []
+    for offset in iter_child_offsets(block):
+        if not block.startswith("(instances", offset):
+            continue
+        end = match_paren(block, offset)
+        if end == -1:
+            continue
+        instances = block[offset : end + 1]
+        for project_offset in iter_child_offsets(instances):
+            project_end = match_paren(instances, project_offset)
+            if project_end == -1:
+                continue
+            project = instances[project_offset : project_end + 1]
+            for path_offset in iter_child_offsets(project):
+                if not project.startswith("(path", path_offset):
+                    continue
+                path_end = match_paren(project, path_offset)
+                if path_end == -1:
+                    continue
+                path_block = project[path_offset : path_end + 1]
+                for token_offset in iter_child_offsets(path_block):
+                    m = _REFERENCE_TOKEN.match(path_block, token_offset)
+                    if m:
+                        references.append(unescape_sexpr_string(m.group(1)))
+    return references
+
+
+def _candidate_references(block: str, props: Dict[str, _Property]) -> List[str]:
+    """Every designator the symbol's shared Footprint field speaks for."""
+    found = _instance_references(block)
+    if not found and "Reference" in props:
+        found = [props["Reference"].value]
+    ordered: List[str] = []
+    for reference in found:
+        if reference and reference not in ordered:
+            ordered.append(reference)
+    return ordered
+
+
+def _sub_sheet_files(text: str) -> List[str]:
+    """The ``Sheetfile`` of every ``(sheet ...)`` in one schematic."""
+    files: List[str] = []
+    for offset in iter_child_offsets(text):
+        if not _SHEET_HEAD.match(text, offset):
+            continue
+        end = match_paren(text, offset)
+        if end == -1:
+            continue
+        props = _properties(text[offset : end + 1])
+        prop = props.get("Sheetfile") or props.get("Sheet file")
+        if prop is not None and prop.value:
+            files.append(prop.value)
+    return files
+
+
+def _real_key(path: Path) -> str:
+    """Identity of a file on disk, so the same sheet is never visited twice."""
+    return os.path.normcase(os.path.realpath(str(path)))
+
+
+def _sheet_tree(root: Path) -> List[Path]:
+    """Sheets reachable from *root*, root first, one entry per file on disk.
+
+    Walking the tree is what bounds the edit to the design. Globbing the board's
+    directory also picks up ``.history`` snapshots, backup copies and unrelated
+    projects -- and rewriting a backup destroys the fallback at the same moment
+    as the risky edit.
+    """
+    order: List[Path] = []
+    seen: Set[str] = set()
+    queue: List[Path] = [root]
+    while queue:
+        sheet = queue.pop(0)
+        key = _real_key(sheet)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not sheet.is_file():
+            continue
+        order.append(sheet)
+        try:
+            text, _newline = _read_text(sheet)
+        except (OSError, UnicodeDecodeError):
+            continue
+        for name in _sub_sheet_files(text):
+            queue.append(sheet.parent / name)
+    return order
+
+
+def _sheets_beside(board_path: Path) -> List[Path]:
+    """Fallback when no root schematic is named after the board.
+
+    Non-recursive, which puts ``.history`` and backup directories out of reach by
+    construction -- the ``.history``/``backup`` path filter
+    ``update_symbol_from_library`` needs for its recursive walk would only ever
+    match an ancestor here, and would then exclude the whole project. KiCad's
+    autosave copies do sit in the project directory, so those are named out.
+    """
+    return sorted(
+        p
+        for p in board_path.parent.glob("*.kicad_sch")
+        if not p.name.startswith(("_autosave-", "#auto_saved_"))
+    )
+
+
+def _display(sheet: Path, root_dir: Path) -> str:
+    """Project-relative path, so two sheets named ``s.kicad_sch`` differ."""
+    try:
+        return sheet.relative_to(root_dir).as_posix()
+    except ValueError:
+        return str(sheet)
+
+
+class _SheetPlan(NamedTuple):
+    sheet: Path
+    label: str
+    text: str
+    newline: str
+    edits: List[Dict[str, Any]]
+
+
 def _plan_sheet(
-    text: str, placed: Dict[str, str], wanted: Optional[set], add_missing: bool
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    text: str,
+    placed: Dict[str, str],
+    ambiguous: Dict[str, List[str]],
+    wanted: Optional[Set[str]],
+    add_missing: bool,
+    seen: Set[str],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Work out the edits for one sheet without applying them."""
     edits: List[Dict[str, Any]] = []
     skipped: List[Dict[str, Any]] = []
+    conflicts: List[Dict[str, Any]] = []
 
     # Depth 2 is a direct child of (kicad_sch ...), which is where placed
     # instances live. The lib_symbols cache is a sibling, so its symbol
@@ -146,34 +359,72 @@ def _plan_sheet(
             continue
         block = text[offset : end + 1]
         props = _properties(block)
-        if "Reference" not in props:
+        references = [
+            r for r in _candidate_references(block, props) if not _VIRTUAL_REFERENCE.match(r)
+        ]
+        if not references:
             continue
-        reference = props["Reference"][0]
-        if _VIRTUAL_REFERENCE.match(reference):
-            continue
-        if wanted is not None and reference not in wanted:
-            continue
-        if reference not in placed:
-            skipped.append({"reference": reference, "reason": "not on the board"})
+        # Recorded before the filter: what the board has that the schematic does
+        # not is a fact about the design, not about this invocation's filter.
+        seen.update(references)
+        if wanted is not None and not wanted.intersection(references):
             continue
 
-        board_footprint = placed[reference]
+        resolvable: Dict[str, str] = {}
+        for reference in references:
+            if reference in ambiguous:
+                skipped.append(
+                    {
+                        "reference": reference,
+                        "reason": "the board assigns more than one footprint to this reference",
+                    }
+                )
+            elif reference in placed:
+                resolvable[reference] = placed[reference]
+            elif reference.endswith("?"):
+                skipped.append(
+                    {"reference": reference, "reason": "not annotated yet -- annotate first"}
+                )
+            else:
+                skipped.append({"reference": reference, "reason": "not on the board"})
+        if not resolvable:
+            continue
+
+        # One Footprint field serves every instance of the symbol, so the board
+        # has to agree about them before anything may be written.
+        if len(set(resolvable.values())) > 1:
+            conflicts.append(
+                {
+                    "references": sorted(resolvable),
+                    "footprints": sorted(set(resolvable.values())),
+                    "reason": (
+                        "instances sharing one Footprint field are assigned "
+                        "different footprints on the board"
+                    ),
+                }
+            )
+            continue
+        board_footprint = next(iter(resolvable.values()))
+        # Name the change after a designator the board actually knows about, not
+        # merely the first one the symbol carries.
+        reference = next(iter(resolvable))
+
         if "Footprint" in props:
-            current, prop_start, prop_end = props["Footprint"]
-            if current == board_footprint:
+            existing = props["Footprint"]
+            if existing.value == board_footprint:
                 continue
-            indent = _indent_of(block, prop_start)
-            at_text = _at_token(block, (prop_start, prop_end))
+            # Only the quoted value token moves. Rebuilding the field would
+            # discard hide, show_name, unlocked, justify and the font the user
+            # set, and reflow what eeschema wrote.
             edits.append(
                 {
                     "reference": reference,
-                    "from": current,
+                    "references": sorted(resolvable),
+                    "from": existing.value,
                     "to": board_footprint,
-                    "start": offset + prop_start,
-                    "end": offset + prop_end,
-                    "text": _build_footprint_property(board_footprint, at_text, indent).lstrip(
-                        "\t "
-                    ),
+                    "start": offset + existing.value_start,
+                    "end": offset + existing.value_end,
+                    "text": escape_sexpr_string(board_footprint),
                 }
             )
         elif add_missing:
@@ -183,23 +434,23 @@ def _plan_sheet(
                     {"reference": reference, "reason": "no anchor field to insert after"}
                 )
                 continue
-            _, anchor_start, anchor_end = anchor
-            indent = _indent_of(block, anchor_start)
-            at_text = _at_token(block, (anchor_start, anchor_end))
+            indent = _indent_of(block, anchor.start)
+            at_text = _at_token(block, (anchor.start, anchor.end))
             edits.append(
                 {
                     "reference": reference,
+                    "references": sorted(resolvable),
                     "from": None,
                     "to": board_footprint,
-                    "start": offset + anchor_end,
-                    "end": offset + anchor_end,
+                    "start": offset + anchor.end,
+                    "end": offset + anchor.end,
                     "text": "\n" + _build_footprint_property(board_footprint, at_text, indent),
                 }
             )
         else:
             skipped.append({"reference": reference, "reason": "no Footprint field"})
 
-    return edits, skipped
+    return edits, skipped, conflicts
 
 
 def _apply(text: str, edits: List[Dict[str, Any]]) -> str:
@@ -217,63 +468,106 @@ def backannotate_footprints(params: Dict[str, Any]) -> Dict[str, Any]:
     references = params.get("references")
     wanted = set(references) if references else None
 
-    board_text, error = _read(board_path, "Board")
+    board_text, _newline, error = _read(board_path, "Board")
     if error:
         return error
     assert board_text is not None
 
-    placed = read_board_footprints(board_text)
-    if not placed:
+    placements = read_board_placements(board_text)
+    if not placements:
         return {
             "success": False,
             "message": f"No placed footprints found in {board_path.name}",
         }
 
+    # A reference the board uses twice cannot be back-annotated: there is no
+    # single right answer, and picking one writes a possibly-wrong footprint.
+    ambiguous = {ref: values for ref, values in placements.items() if len(values) > 1}
+    placed = {ref: values[0] for ref, values in placements.items() if ref not in ambiguous}
+
+    conflicts: List[Dict[str, Any]] = [
+        {
+            "references": [ref],
+            "footprints": sorted(set(ambiguous[ref])),
+            "reason": "the board has more than one footprint carrying this reference",
+        }
+        for ref in sorted(ambiguous)
+    ]
+
+    warnings: List[str] = []
+    root_sheet = board_path.with_suffix(".kicad_sch")
+    tree = _sheet_tree(root_sheet) if root_sheet.is_file() else []
+
     sheet_param = params.get("schematicPath")
     if sheet_param:
         sheets = [Path(sheet_param)]
+        if tree and _real_key(sheets[0]) not in {_real_key(p) for p in tree}:
+            warnings.append(
+                f"{sheet_param} is not part of {root_sheet.name}'s sheet tree; "
+                "updating it anyway because it was named explicitly"
+            )
     else:
-        sheets = sorted(board_path.parent.rglob("*.kicad_sch"))
+        sheets = tree or _sheets_beside(board_path)
     if not sheets:
         return {
             "success": False,
             "message": f"No .kicad_sch files found next to {board_path.name}",
         }
 
+    root_dir = board_path.parent
     changes: List[Dict[str, Any]] = []
     skipped: List[Dict[str, Any]] = []
+    failures: List[Dict[str, Any]] = []
     updated_files: List[str] = []
+    seen: Set[str] = set()
 
+    # Plan every sheet before touching any of them: a write that fails halfway
+    # through used to leave the earlier sheets edited and drop the report.
+    plans: List[_SheetPlan] = []
     for sheet in sheets:
-        text, error = _read(sheet, "Schematic")
+        label = _display(sheet, root_dir)
+        text, newline, error = _read(sheet, "Schematic")
         if error:
-            return error
+            failures.append({"sheet": label, "path": str(sheet), "error": error["message"]})
+            continue
         assert text is not None
 
-        edits, sheet_skipped = _plan_sheet(text, placed, wanted, add_missing)
+        edits, sheet_skipped, sheet_conflicts = _plan_sheet(
+            text, placed, ambiguous, wanted, add_missing, seen
+        )
         for item in sheet_skipped:
-            item["sheet"] = sheet.name
+            item["sheet"] = label
         skipped.extend(sheet_skipped)
+        for item in sheet_conflicts:
+            item["sheet"] = label
+        conflicts.extend(sheet_conflicts)
         if not edits:
             continue
-
+        plans.append(_SheetPlan(sheet, label, text, newline, edits))
         for edit in edits:
             changes.append(
                 {
-                    "sheet": sheet.name,
+                    "sheet": label,
                     "reference": edit["reference"],
+                    "references": edit["references"],
                     "from": edit["from"],
                     "to": edit["to"],
                     "action": "added" if edit["from"] is None else "updated",
                 }
             )
 
-        if not dry_run:
+    if not dry_run:
+        for plan in plans:
             try:
-                sheet.write_text(_apply(text, edits), encoding="utf-8")
+                _write_text(plan.sheet, _apply(plan.text, plan.edits), plan.newline)
             except OSError as exc:
-                return {"success": False, "message": f"Could not write {sheet}: {exc}"}
-            updated_files.append(str(sheet))
+                logger.error("backannotate_footprints could not write %s: %s", plan.sheet, exc)
+                failures.append({"sheet": plan.label, "path": str(plan.sheet), "error": str(exc)})
+                continue
+            updated_files.append(str(plan.sheet))
+
+    on_board = set(placed) & wanted if wanted is not None else set(placed)
+    not_in_schematic = sorted(on_board - seen)
 
     verb = "Would update" if dry_run else "Updated"
     if changes:
@@ -283,16 +577,24 @@ def backannotate_footprints(params: Dict[str, Any]) -> Dict[str, Any]:
         )
     else:
         message = "Every schematic footprint field already matches the board"
+    if conflicts:
+        message += f"; {len(conflicts)} conflict(s) left untouched"
+    if failures:
+        message += f"; {len(failures)} sheet(s) failed"
 
     return {
-        "success": True,
+        "success": not failures,
         "message": message,
         "dryRun": dry_run,
         "boardPath": str(board_path),
-        "boardFootprintCount": len(placed),
-        "sheetsScanned": [s.name for s in sheets],
+        "boardFootprintCount": len(placements),
+        "sheetsScanned": [_display(s, root_dir) for s in sheets],
         "updatedFiles": updated_files,
         "changeCount": len(changes),
         "changes": changes,
         "skipped": skipped,
+        "conflicts": conflicts,
+        "notInSchematic": not_in_schematic,
+        "warnings": warnings,
+        "failures": failures,
     }

--- a/python/commands/backannotate_footprints.py
+++ b/python/commands/backannotate_footprints.py
@@ -1,0 +1,298 @@
+"""Copy footprint assignments from a board back into its schematic.
+
+``sync_schematic_to_board`` pushes the schematic onto the PCB. There was no way
+back, and after a layout pass the board is the side that is right: footprints
+get swapped in pcbnew, and an Eagle import lands with schematic-side footprint
+fields that never matched the placed parts. Recovering meant parsing
+``.kicad_pcb`` by hand and editing each ``(property "Footprint" ...)``.
+
+Matching is by reference designator, the same key ``sync_schematic_to_board``
+uses. References beginning with ``#`` are power and other virtual symbols; they
+carry no footprint and are skipped. Multi-unit symbols appear as several
+instance blocks sharing one reference and all of them are updated, because
+KiCad treats a disagreement between units as a conflict.
+
+Nesting is tracked structurally rather than by indentation: KiCad's writers
+emit board files whose indentation does not always match depth.
+
+Tools:
+  - backannotate_footprints: PCB footprint assignments -> schematic instances
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from utils.sexpr_format import (
+    QUOTED_VALUE,
+    escape_sexpr_string,
+    iter_child_offsets,
+    match_paren,
+    unescape_sexpr_string,
+)
+
+logger = logging.getLogger("kicad_interface")
+
+# Power, ground and other virtual symbols. They have no physical part, and
+# KiCad leaves their Footprint field empty on purpose.
+_VIRTUAL_REFERENCE = re.compile(r"^#")
+
+_PROPERTY_HEAD = re.compile(rf"\(property\s+{QUOTED_VALUE}\s+{QUOTED_VALUE}")
+
+_FOOTPRINT_HEAD = re.compile(rf"\(footprint\s+{QUOTED_VALUE}")
+
+_INSTANCE_HEAD = re.compile(r"\(symbol[\s(]")
+
+# KiCad 6+ stores a footprint's designator as a property; KiCad 5 used fp_text.
+_FP_TEXT_REFERENCE = re.compile(rf"\(fp_text\s+reference\s+{QUOTED_VALUE}")
+
+
+def _read(path: Path, kind: str) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    if not path.exists():
+        return None, {"success": False, "message": f"{kind} not found: {path}"}
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, {"success": False, "message": f"Could not read {path}: {exc}"}
+
+
+def _properties(block: str) -> Dict[str, Tuple[str, int, int]]:
+    """Direct-child properties of a block: name -> (value, start, end)."""
+    found: Dict[str, Tuple[str, int, int]] = {}
+    for offset in iter_child_offsets(block):
+        m = _PROPERTY_HEAD.match(block, offset)
+        if not m:
+            continue
+        end = match_paren(block, offset)
+        if end == -1:
+            continue
+        name = unescape_sexpr_string(m.group(1))
+        found.setdefault(name, (unescape_sexpr_string(m.group(2)), offset, end + 1))
+    return found
+
+
+def read_board_footprints(board_text: str) -> Dict[str, str]:
+    """Reference designator -> footprint lib id, as placed on the board."""
+    placed: Dict[str, str] = {}
+    for offset in iter_child_offsets(board_text):
+        m = _FOOTPRINT_HEAD.match(board_text, offset)
+        if not m:
+            continue
+        end = match_paren(board_text, offset)
+        if end == -1:
+            continue
+        block = board_text[offset : end + 1]
+        props = _properties(block)
+        if "Reference" in props:
+            reference = props["Reference"][0]
+        else:
+            legacy = _FP_TEXT_REFERENCE.search(block)
+            if not legacy:
+                continue
+            reference = unescape_sexpr_string(legacy.group(1))
+        if reference:
+            placed[reference] = unescape_sexpr_string(m.group(1))
+    return placed
+
+
+def _indent_of(block: str, offset: int) -> str:
+    line_start = block.rfind("\n", 0, offset) + 1
+    prefix = block[line_start:offset]
+    return prefix if prefix.strip() == "" else "\t\t"
+
+
+def _build_footprint_property(value: str, at_text: str, indent: str) -> str:
+    inner = indent + ("\t" if "\t" in indent else "  ")
+    return "\n".join(
+        [
+            f'{indent}(property "Footprint" "{escape_sexpr_string(value)}"',
+            f"{inner}{at_text}",
+            f"{inner}(hide yes)",
+            f"{inner}(effects (font (size 1.27 1.27)))",
+            f"{indent})",
+        ]
+    )
+
+
+def _at_token(block: str, prop_span: Tuple[int, int]) -> str:
+    """The ``(at ...)`` of an existing property, so a new field lands with it."""
+    prop = block[prop_span[0] : prop_span[1]]
+    for offset in iter_child_offsets(prop):
+        if prop.startswith("(at ", offset):
+            end = match_paren(prop, offset)
+            if end != -1:
+                return prop[offset : end + 1]
+    return "(at 0 0 0)"
+
+
+def _plan_sheet(
+    text: str, placed: Dict[str, str], wanted: Optional[set], add_missing: bool
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Work out the edits for one sheet without applying them."""
+    edits: List[Dict[str, Any]] = []
+    skipped: List[Dict[str, Any]] = []
+
+    # Depth 2 is a direct child of (kicad_sch ...), which is where placed
+    # instances live. The lib_symbols cache is a sibling, so its symbol
+    # definitions sit a level deeper and are excluded by construction.
+    for offset in iter_child_offsets(text, depth=2):
+        if not _INSTANCE_HEAD.match(text, offset):
+            continue
+        end = match_paren(text, offset)
+        if end == -1:
+            continue
+        block = text[offset : end + 1]
+        props = _properties(block)
+        if "Reference" not in props:
+            continue
+        reference = props["Reference"][0]
+        if _VIRTUAL_REFERENCE.match(reference):
+            continue
+        if wanted is not None and reference not in wanted:
+            continue
+        if reference not in placed:
+            skipped.append({"reference": reference, "reason": "not on the board"})
+            continue
+
+        board_footprint = placed[reference]
+        if "Footprint" in props:
+            current, prop_start, prop_end = props["Footprint"]
+            if current == board_footprint:
+                continue
+            indent = _indent_of(block, prop_start)
+            at_text = _at_token(block, (prop_start, prop_end))
+            edits.append(
+                {
+                    "reference": reference,
+                    "from": current,
+                    "to": board_footprint,
+                    "start": offset + prop_start,
+                    "end": offset + prop_end,
+                    "text": _build_footprint_property(board_footprint, at_text, indent).lstrip(
+                        "\t "
+                    ),
+                }
+            )
+        elif add_missing:
+            anchor = props.get("Value") or props.get("Reference")
+            if anchor is None:
+                skipped.append(
+                    {"reference": reference, "reason": "no anchor field to insert after"}
+                )
+                continue
+            _, anchor_start, anchor_end = anchor
+            indent = _indent_of(block, anchor_start)
+            at_text = _at_token(block, (anchor_start, anchor_end))
+            edits.append(
+                {
+                    "reference": reference,
+                    "from": None,
+                    "to": board_footprint,
+                    "start": offset + anchor_end,
+                    "end": offset + anchor_end,
+                    "text": "\n" + _build_footprint_property(board_footprint, at_text, indent),
+                }
+            )
+        else:
+            skipped.append({"reference": reference, "reason": "no Footprint field"})
+
+    return edits, skipped
+
+
+def _apply(text: str, edits: List[Dict[str, Any]]) -> str:
+    """Splice edits in, back to front, so earlier offsets stay valid."""
+    for edit in sorted(edits, key=lambda e: e["start"], reverse=True):
+        text = text[: edit["start"]] + edit["text"] + text[edit["end"] :]
+    return text
+
+
+def backannotate_footprints(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Copy footprint assignments from a .kicad_pcb into its schematic sheets."""
+    board_path = Path(params["boardPath"])
+    dry_run = bool(params.get("dryRun", False))
+    add_missing = bool(params.get("addMissing", True))
+    references = params.get("references")
+    wanted = set(references) if references else None
+
+    board_text, error = _read(board_path, "Board")
+    if error:
+        return error
+    assert board_text is not None
+
+    placed = read_board_footprints(board_text)
+    if not placed:
+        return {
+            "success": False,
+            "message": f"No placed footprints found in {board_path.name}",
+        }
+
+    sheet_param = params.get("schematicPath")
+    if sheet_param:
+        sheets = [Path(sheet_param)]
+    else:
+        sheets = sorted(board_path.parent.rglob("*.kicad_sch"))
+    if not sheets:
+        return {
+            "success": False,
+            "message": f"No .kicad_sch files found next to {board_path.name}",
+        }
+
+    changes: List[Dict[str, Any]] = []
+    skipped: List[Dict[str, Any]] = []
+    updated_files: List[str] = []
+
+    for sheet in sheets:
+        text, error = _read(sheet, "Schematic")
+        if error:
+            return error
+        assert text is not None
+
+        edits, sheet_skipped = _plan_sheet(text, placed, wanted, add_missing)
+        for item in sheet_skipped:
+            item["sheet"] = sheet.name
+        skipped.extend(sheet_skipped)
+        if not edits:
+            continue
+
+        for edit in edits:
+            changes.append(
+                {
+                    "sheet": sheet.name,
+                    "reference": edit["reference"],
+                    "from": edit["from"],
+                    "to": edit["to"],
+                    "action": "added" if edit["from"] is None else "updated",
+                }
+            )
+
+        if not dry_run:
+            try:
+                sheet.write_text(_apply(text, edits), encoding="utf-8")
+            except OSError as exc:
+                return {"success": False, "message": f"Could not write {sheet}: {exc}"}
+            updated_files.append(str(sheet))
+
+    verb = "Would update" if dry_run else "Updated"
+    if changes:
+        message = (
+            f"{verb} {len(changes)} footprint field(s) across "
+            f"{len({c['sheet'] for c in changes})} sheet(s)"
+        )
+    else:
+        message = "Every schematic footprint field already matches the board"
+
+    return {
+        "success": True,
+        "message": message,
+        "dryRun": dry_run,
+        "boardPath": str(board_path),
+        "boardFootprintCount": len(placed),
+        "sheetsScanned": [s.name for s in sheets],
+        "updatedFiles": updated_files,
+        "changeCount": len(changes),
+        "changes": changes,
+        "skipped": skipped,
+    }

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -323,6 +323,7 @@ try:
     logger.info("Importing command handlers...")
     from commands.add_library_symbol_property import add_library_symbol_property
     from commands.add_symbol_property import add_symbol_property
+    from commands.backannotate_footprints import backannotate_footprints
     from commands.board import BoardCommands
     from commands.board.origin import BoardOriginCommands
     from commands.component import ComponentCommands
@@ -629,6 +630,7 @@ class KiCADInterface(SchematicHandlersMixin):
             "export_sch_python_bom": self._handle_export_sch_python_bom,
             "generate_netlist": self._handle_generate_netlist,
             "sync_schematic_to_board": self._handle_sync_schematic_to_board,
+            "backannotate_footprints": backannotate_footprints,
             "create_board_from_schematic": self._handle_create_board_from_schematic,
             "list_schematic_libraries": self._handle_list_schematic_libraries,
             "get_schematic_view": self._handle_get_schematic_view,

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -2533,9 +2533,15 @@ SCHEMATIC_TOOLS = [
             "Footprint fields -- the reverse of sync_schematic_to_board. After a layout "
             "pass the board is the side that is right: footprints get swapped in pcbnew, "
             "and imported projects land with schematic-side fields that never matched the "
-            "placed parts. Matching is by reference designator; virtual references "
-            "starting with '#' (power, ground) are skipped, and every unit of a multi-unit "
-            "symbol is updated. Instances missing a Footprint field get one added unless "
+            "placed parts. Matching is by reference designator, taken from each symbol's "
+            "(instances ...) block so a sheet placed more than once contributes all of its "
+            "designators; virtual references starting with '#' (power, ground) are skipped, "
+            "and every unit of a multi-unit symbol is updated. Only the quoted value is "
+            "rewritten, so field visibility, font and position survive. Nothing is written "
+            "for a reference the board uses twice, or for instances that share one Footprint "
+            "field but disagree on the board -- those are listed under 'conflicts'. "
+            "Footprints on the board with no matching symbol are listed under "
+            "'notInSchematic'. Instances missing a Footprint field get one added unless "
             "addMissing is false. Use dryRun to see the diff first."
         ),
         "inputSchema": {
@@ -2545,8 +2551,10 @@ SCHEMATIC_TOOLS = [
                 "schematicPath": {
                     "type": "string",
                     "description": (
-                        "Single sheet to update. Omit to update every .kicad_sch beside "
-                        "the board, which is what a hierarchical design needs."
+                        "Single sheet to update. Omit to walk the sheet tree from the root "
+                        "schematic named after the board, which is what a hierarchical "
+                        "design needs; local history, backup copies and other projects "
+                        "under the same directory are left alone."
                     ),
                 },
                 "references": {

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -2526,6 +2526,49 @@ SCHEMATIC_TOOLS = [
         },
     },
     {
+        "name": "backannotate_footprints",
+        "title": "Back-annotate Footprints (PCB to Schematic)",
+        "description": (
+            "Copy footprint assignments from a .kicad_pcb back into the schematic's "
+            "Footprint fields -- the reverse of sync_schematic_to_board. After a layout "
+            "pass the board is the side that is right: footprints get swapped in pcbnew, "
+            "and imported projects land with schematic-side fields that never matched the "
+            "placed parts. Matching is by reference designator; virtual references "
+            "starting with '#' (power, ground) are skipped, and every unit of a multi-unit "
+            "symbol is updated. Instances missing a Footprint field get one added unless "
+            "addMissing is false. Use dryRun to see the diff first."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "boardPath": {"type": "string", "description": "Path to the .kicad_pcb file"},
+                "schematicPath": {
+                    "type": "string",
+                    "description": (
+                        "Single sheet to update. Omit to update every .kicad_sch beside "
+                        "the board, which is what a hierarchical design needs."
+                    ),
+                },
+                "references": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Limit the update to these reference designators",
+                },
+                "addMissing": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Add a Footprint field to instances that have none",
+                },
+                "dryRun": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Report the changes without writing them",
+                },
+            },
+            "required": ["boardPath"],
+        },
+    },
+    {
         "name": "create_board_from_schematic",
         "title": "Create Board From Schematic",
         "description": "Creates a fresh .kicad_pcb file, then updates it from the schematic so footprints and nets are present.",

--- a/python/utils/sexpr_format.py
+++ b/python/utils/sexpr_format.py
@@ -76,6 +76,77 @@ QUOTED_VALUE = r'"((?:[^"\\]|\\.)*)"'
 QUOTED_VALUE_SKIP = r'"(?:[^"\\]|\\.)*"'
 
 
+# ---------------------------------------------------------------------------
+# String-aware structure walking
+# ---------------------------------------------------------------------------
+#
+# Tools that edit KiCad files as text need to know where a list ends without
+# re-serializing the file. Counting parens is not enough: a Description of
+# ``"Ceramic (X7R) 50V"`` or a footprint named ``HRS_U.FL-R-SMT-1(10)`` puts
+# unbalanced parens inside quoted tokens, and real libraries contain both.
+#
+# These two helpers skip quoted text, so callers can slice a block out of a
+# file and splice a new one back without a parser.
+
+
+def match_paren(content: str, open_idx: int) -> int:
+    """Index of the ``)`` closing the ``(`` at *open_idx*, or -1 if unbalanced.
+
+    Parens inside quoted tokens are literal text, not structure.
+    """
+    depth = 0
+    in_string = False
+    i = open_idx
+    while i < len(content):
+        ch = content[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def iter_child_offsets(block: str, depth: int = 2):
+    """Yield the offset of every list nested *depth* levels inside *block*.
+
+    *block* starts at its own ``(``, which is depth 1, so the default yields
+    its direct children. Depth is counted structurally rather than from
+    indentation: KiCad's own writers emit files whose indentation does not
+    always match nesting.
+    """
+    current = 0
+    in_string = False
+    i = 0
+    while i < len(block):
+        ch = block[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            current += 1
+            if current == depth:
+                yield i
+        elif ch == ")":
+            current -= 1
+        i += 1
+
+
 def escape_sexpr_string(value: str) -> str:
     """Escape a string for insertion into a KiCad double-quoted token.
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -137,6 +137,7 @@ export const toolCategories: ToolCategory[] = [
       "get_wire_connections",
       "generate_netlist",
       "sync_schematic_to_board",
+      "backannotate_footprints",
       "get_schematic_view",
       "export_schematic_svg",
       "export_schematic_pdf",

--- a/src/tools/schematic.ts
+++ b/src/tools/schematic.ts
@@ -1588,6 +1588,47 @@ edit_schematic_component and set its value to an empty string.`,
   );
 
   server.tool(
+    "backannotate_footprints",
+    "Copy footprint assignments from a .kicad_pcb back into the schematic's Footprint " +
+      "fields — the reverse of sync_schematic_to_board. After a layout pass the board is " +
+      "the side that is right: footprints get swapped in pcbnew, and imported projects land " +
+      "with schematic-side fields that never matched the placed parts. Matching is by " +
+      "reference designator; virtual references starting with '#' (power, ground) are " +
+      "skipped, and every unit of a multi-unit symbol is updated.",
+    {
+      boardPath: z.string().describe("Absolute path to the .kicad_pcb board file"),
+      schematicPath: z
+        .string()
+        .optional()
+        .describe(
+          "Single sheet to update. Omit to update every .kicad_sch beside the board, " +
+            "which is what a hierarchical design needs.",
+        ),
+      references: z
+        .array(z.string())
+        .optional()
+        .describe("Limit the update to these reference designators"),
+      addMissing: z
+        .boolean()
+        .optional()
+        .describe("Add a Footprint field to instances that have none (default true)"),
+      dryRun: z.boolean().optional().describe("Report the changes without writing them"),
+    },
+    async (args: {
+      boardPath: string;
+      schematicPath?: string;
+      references?: string[];
+      addMissing?: boolean;
+      dryRun?: boolean;
+    }) => {
+      const result = await callKicadScript("backannotate_footprints", args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
     "create_board_from_schematic",
     "Create a new .kicad_pcb file from a schematic, then update the PCB from that schematic so footprints and nets are present.",
     {

--- a/src/tools/schematic.ts
+++ b/src/tools/schematic.ts
@@ -1593,16 +1593,21 @@ edit_schematic_component and set its value to an empty string.`,
       "fields — the reverse of sync_schematic_to_board. After a layout pass the board is " +
       "the side that is right: footprints get swapped in pcbnew, and imported projects land " +
       "with schematic-side fields that never matched the placed parts. Matching is by " +
-      "reference designator; virtual references starting with '#' (power, ground) are " +
-      "skipped, and every unit of a multi-unit symbol is updated.",
+      "reference designator, taken from each symbol's (instances ...) block so a sheet " +
+      "placed more than once contributes all of its designators; virtual references " +
+      "starting with '#' (power, ground) are skipped, and every unit of a multi-unit " +
+      "symbol is updated. Only the quoted value is rewritten, so field visibility, font " +
+      "and position survive. Ambiguous cases are reported under 'conflicts' and left " +
+      "unwritten; footprints with no matching symbol under 'notInSchematic'.",
     {
       boardPath: z.string().describe("Absolute path to the .kicad_pcb board file"),
       schematicPath: z
         .string()
         .optional()
         .describe(
-          "Single sheet to update. Omit to update every .kicad_sch beside the board, " +
-            "which is what a hierarchical design needs.",
+          "Single sheet to update. Omit to walk the sheet tree from the root schematic " +
+            "named after the board, which is what a hierarchical design needs; local " +
+            "history, backup copies and other projects under the same directory are left alone.",
         ),
       references: z
         .array(z.string())

--- a/tests/test_backannotate_footprints.py
+++ b/tests/test_backannotate_footprints.py
@@ -9,7 +9,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
 from commands.backannotate_footprints import (  # noqa: E402
     backannotate_footprints,
     read_board_footprints,
+    read_board_placements,
 )
+from utils.sexpr_format import match_paren  # noqa: E402
+
+FIXTURES = Path(__file__).parent / "fixtures"
 
 
 def footprint(reference, lib_id, extra=""):
@@ -37,17 +41,16 @@ BOARD = (
 )
 
 
-def instance(reference, value, footprint_value, unit=1):
-    field = (
-        ""
-        if footprint_value is None
-        else f"""\t\t(property "Footprint" "{footprint_value}"
-\t\t\t(at 5 6 0)
-\t\t\t(hide yes)
-\t\t\t(effects (font (size 1.27 1.27)))
-\t\t)
-"""
-    )
+def instance(reference, value, footprint_value, unit=1, instances="", footprint_body=None):
+    if footprint_value is None:
+        field = ""
+    else:
+        body = (
+            footprint_body
+            if footprint_body is not None
+            else "\t\t\t(at 5 6 0)\n\t\t\t(hide yes)\n\t\t\t(effects (font (size 1.27 1.27)))\n"
+        )
+        field = f'\t\t(property "Footprint" "{footprint_value}"\n{body}\t\t)\n'
     return f"""\t(symbol
 \t\t(lib_id "Device:R")
 \t\t(at 100 100 0)
@@ -61,8 +64,26 @@ def instance(reference, value, footprint_value, unit=1):
 \t\t\t(at 3 4 0)
 \t\t\t(effects (font (size 1.27 1.27)))
 \t\t)
-{field}\t)
+{field}{instances}\t)
 """
+
+
+def instances_block(*paths):
+    """An (instances ...) block: one (path ... (reference ...)) per sheet instance."""
+    body = "".join(
+        f'\t\t\t\t(path "{path}"\n\t\t\t\t\t(reference "{reference}")\n'
+        f"\t\t\t\t\t(unit 1)\n\t\t\t\t)\n"
+        for path, reference in paths
+    )
+    return '\t\t(instances\n\t\t\t(project "proj"\n' + body + "\t\t\t)\n\t\t)\n"
+
+
+def sheet_ref(name, uuid, filename):
+    return (
+        f'\t(sheet\n\t\t(at 10 10)\n\t\t(uuid "{uuid}")\n'
+        f'\t\t(property "Sheetname" "{name}"\n\t\t\t(at 10 9 0)\n\t\t)\n'
+        f'\t\t(property "Sheetfile" "{filename}"\n\t\t\t(at 10 11 0)\n\t\t)\n\t)\n'
+    )
 
 
 LIB_SYMBOLS = """\t(lib_symbols
@@ -89,23 +110,9 @@ SCH = (
 
 
 def balance(text):
-    depth, in_string, i = 0, False, 0
-    while i < len(text):
-        ch = text[i]
-        if in_string:
-            if ch == "\\":
-                i += 2
-                continue
-            if ch == '"':
-                in_string = False
-        elif ch == '"':
-            in_string = True
-        elif ch == "(":
-            depth += 1
-        elif ch == ")":
-            depth -= 1
-        i += 1
-    return depth
+    """Zero when the file is one balanced top-level list, non-zero otherwise."""
+    closing = match_paren(text, text.index("("))
+    return 0 if closing == len(text.rstrip()) - 1 else 1
 
 
 @pytest.fixture
@@ -125,6 +132,13 @@ def sch_text(project):
 
 def by_reference(result):
     return {c["reference"]: c for c in result["changes"]}
+
+
+def footprint_field(text, reference):
+    """The Footprint field belonging to the symbol carrying *reference*."""
+    block = text[text.index(f'"Reference" "{reference}"') :]
+    start = block.index('(property "Footprint"')
+    return block[start : match_paren(block, start) + 1]
 
 
 # --- board side ------------------------------------------------------------ #
@@ -157,6 +171,43 @@ def test_board_indentation_is_ignored():
         '\t(footprint "FOG_components:0402"', '\t\t\t(footprint "FOG_components:0402"'
     )
     assert read_board_footprints(ragged)["R1"] == "FOG_components:0402"
+
+
+# --- W4: duplicate references on the board --------------------------------- #
+
+
+def test_duplicate_board_reference_keeps_both_placements():
+    dup = (
+        "(kicad_pcb\n"
+        + footprint("R1", "FOG_components:0402")
+        + footprint("R1", "FOG_components:0805")
+        + ")\n"
+    )
+    assert read_board_placements(dup)["R1"] == [
+        "FOG_components:0402",
+        "FOG_components:0805",
+    ]
+
+
+def test_duplicate_board_reference_is_a_conflict_not_a_silent_overwrite(tmp_path):
+    """Two footprints carrying R1: the earlier one used to be discarded."""
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n"
+        + footprint("R1", "FOG_components:0402")
+        + footprint("R1", "FOG_components:0805")
+        + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.kicad_sch").write_text(
+        "(kicad_sch\n" + instance("R1", "10K", "old:fp") + ")\n", encoding="utf-8"
+    )
+    r = backannotate_footprints({"boardPath": str(tmp_path / "b.kicad_pcb")})
+    assert r["changeCount"] == 0
+    assert '"old:fp"' in (tmp_path / "b.kicad_sch").read_text(encoding="utf-8")
+    conflict = next(c for c in r["conflicts"] if c["references"] == ["R1"])
+    assert conflict["footprints"] == ["FOG_components:0402", "FOG_components:0805"]
+    assert "more than one footprint" in conflict["reason"]
+    assert any(s["reference"] == "R1" for s in r["skipped"])
 
 
 # --- schematic side -------------------------------------------------------- #
@@ -245,13 +296,435 @@ def test_every_unit_of_a_multi_unit_symbol_is_updated(tmp_path):
     assert "old:fp" not in text
 
 
+# --- C2: the existing field's own state survives an update ----------------- #
+
+
+VISIBLE_FIELD_BODY = """\t\t\t(at 5 6 90)
+\t\t\t(unlocked yes)
+\t\t\t(show_name yes)
+\t\t\t(do_not_autoplace no)
+\t\t\t(effects
+\t\t\t\t(font
+\t\t\t\t\t(size 2.54 2.54)
+\t\t\t\t\t(bold yes)
+\t\t\t\t)
+\t\t\t\t(justify left)
+\t\t\t)
+"""
+
+
+@pytest.fixture
+def visible_field_project(tmp_path):
+    """A Footprint field the user deliberately made visible, big, bold and left."""
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n" + footprint("R1", "FOG_components:0402") + ")\n", encoding="utf-8"
+    )
+    (tmp_path / "b.kicad_sch").write_text(
+        "(kicad_sch\n" + instance("R1", "10K", "old:fp", footprint_body=VISIBLE_FIELD_BODY) + ")\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_a_visible_footprint_field_is_not_hidden_by_the_update(visible_field_project):
+    """Rebuilding the field forced (hide yes) onto a field the user had shown."""
+    backannotate_footprints({"boardPath": str(visible_field_project / "b.kicad_pcb")})
+    field = footprint_field(
+        (visible_field_project / "b.kicad_sch").read_text(encoding="utf-8"), "R1"
+    )
+    assert '"FOG_components:0402"' in field
+    assert "(hide yes)" not in field
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "(at 5 6 90)",
+        "(unlocked yes)",
+        "(show_name yes)",
+        "(do_not_autoplace no)",
+        "(size 2.54 2.54)",
+        "(bold yes)",
+        "(justify left)",
+    ],
+)
+def test_every_other_token_of_the_field_survives_the_update(visible_field_project, token):
+    backannotate_footprints({"boardPath": str(visible_field_project / "b.kicad_pcb")})
+    field = footprint_field(
+        (visible_field_project / "b.kicad_sch").read_text(encoding="utf-8"), "R1"
+    )
+    assert token in field
+
+
+def test_only_the_value_token_changes(visible_field_project):
+    """Byte-for-byte: the whole file bar the quoted value is untouched."""
+    before = (visible_field_project / "b.kicad_sch").read_bytes()
+    backannotate_footprints({"boardPath": str(visible_field_project / "b.kicad_pcb")})
+    after = (visible_field_project / "b.kicad_sch").read_bytes()
+    assert after == before.replace(b'"old:fp"', b'"FOG_components:0402"')
+
+
+def test_canonical_schematic_keeps_its_canonical_layout(tmp_path):
+    """The fixture is what eeschema writes; only the value may differ after."""
+    canonical = (FIXTURES / "canonical_schematic.kicad_sch").read_bytes()
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n" + footprint("C9", "Capacitor_SMD:C_0402_1005Metric") + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.kicad_sch").write_bytes(canonical)
+    r = backannotate_footprints({"boardPath": str(tmp_path / "b.kicad_pcb")})
+    assert r["changeCount"] == 1
+    after = (tmp_path / "b.kicad_sch").read_bytes()
+    assert after == canonical.replace(
+        b'"Capacitor_SMD:C_0603_1608Metric"', b'"Capacitor_SMD:C_0402_1005Metric"'
+    )
+
+
 def test_hidden_and_position_are_preserved_on_update(project):
     run(project)
-    text = sch_text(project)
-    block = text[text.index('"Reference" "R1"') :]
-    field = block[block.index('"Footprint"') : block.index('"Footprint"') + 200]
+    field = footprint_field(sch_text(project), "R1")
     assert "(at 5 6 0)" in field
     assert "(hide yes)" in field
+
+
+def test_an_inserted_field_is_hidden_like_eeschema_writes_it(project):
+    run(project)
+    field = footprint_field(sch_text(project), "U1")
+    assert "(hide yes)" in field
+
+
+# --- C1: per-instance references from (instances ...) ---------------------- #
+
+
+@pytest.fixture
+def repeated_sheet_project(tmp_path):
+    """One sub.kicad_sch placed twice; the board gives R1 an 0402 and R2 an 0805."""
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n"
+        + footprint("R1", "FOG_components:0402")
+        + footprint("R2", "FOG_components:0805")
+        + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.kicad_sch").write_text(
+        '(kicad_sch\n\t(version 20231120)\n\t(generator "eeschema")\n'
+        + sheet_ref("A", "sheetA", "sub.kicad_sch")
+        + sheet_ref("B", "sheetB", "sub.kicad_sch")
+        + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "sub.kicad_sch").write_text(
+        '(kicad_sch\n\t(version 20231120)\n\t(generator "eeschema")\n'
+        + instance(
+            "R1",
+            "10K",
+            "old:fp",
+            instances=instances_block(("/root-uuid/sheetA", "R1"), ("/root-uuid/sheetB", "R2")),
+        )
+        + ")\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_a_repeated_sheet_with_disagreeing_footprints_is_left_alone(repeated_sheet_project):
+    """The two instances share one Footprint field, so neither may win."""
+    r = backannotate_footprints({"boardPath": str(repeated_sheet_project / "b.kicad_pcb")})
+    assert r["changeCount"] == 0
+    assert '"old:fp"' in (repeated_sheet_project / "sub.kicad_sch").read_text(encoding="utf-8")
+
+
+def test_a_repeated_sheet_conflict_names_both_references(repeated_sheet_project):
+    r = backannotate_footprints({"boardPath": str(repeated_sheet_project / "b.kicad_pcb")})
+    conflict = next(c for c in r["conflicts"] if c["sheet"] == "sub.kicad_sch")
+    assert conflict["references"] == ["R1", "R2"]
+    assert conflict["footprints"] == ["FOG_components:0402", "FOG_components:0805"]
+
+
+def test_the_second_instance_is_never_silently_dropped(repeated_sheet_project):
+    """R2 used to appear in neither changes nor skipped: the sheet never saw it."""
+    r = backannotate_footprints({"boardPath": str(repeated_sheet_project / "b.kicad_pcb")})
+    assert "R2" not in r["notInSchematic"]
+    per_sheet = (
+        {c["reference"] for c in r["changes"]}
+        | {s["reference"] for s in r["skipped"]}
+        | {ref for c in r["conflicts"] for ref in c["references"]}
+    )
+    assert "R2" in per_sheet
+
+
+def test_a_repeated_sheet_that_agrees_is_updated_once(tmp_path):
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n"
+        + footprint("R1", "FOG_components:0402")
+        + footprint("R2", "FOG_components:0402")
+        + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.kicad_sch").write_text(
+        "(kicad_sch\n"
+        + sheet_ref("A", "sheetA", "sub.kicad_sch")
+        + sheet_ref("B", "sheetB", "sub.kicad_sch")
+        + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "sub.kicad_sch").write_text(
+        "(kicad_sch\n"
+        + instance(
+            "R1",
+            "10K",
+            "old:fp",
+            instances=instances_block(("/root-uuid/sheetA", "R1"), ("/root-uuid/sheetB", "R2")),
+        )
+        + ")\n",
+        encoding="utf-8",
+    )
+    r = backannotate_footprints({"boardPath": str(tmp_path / "b.kicad_pcb")})
+    assert r["changeCount"] == 1
+    change = r["changes"][0]
+    assert change["references"] == ["R1", "R2"]
+    text = (tmp_path / "sub.kicad_sch").read_text(encoding="utf-8")
+    assert text.count('"FOG_components:0402"') == 1
+
+
+def test_a_reference_only_in_the_instances_block_is_matched(tmp_path):
+    """The Reference property still says R? while the design is annotated R5."""
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n" + footprint("R5", "FOG_components:0402") + ")\n", encoding="utf-8"
+    )
+    (tmp_path / "b.kicad_sch").write_text(
+        "(kicad_sch\n"
+        + instance("R?", "10K", "old:fp", instances=instances_block(("/root-uuid", "R5")))
+        + ")\n",
+        encoding="utf-8",
+    )
+    r = backannotate_footprints({"boardPath": str(tmp_path / "b.kicad_pcb")})
+    assert by_reference(r)["R5"]["to"] == "FOG_components:0402"
+
+
+def test_an_unannotated_reference_is_told_to_annotate(tmp_path):
+    """'not on the board' sent the user hunting for a missing footprint."""
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n" + footprint("R1", "FOG_components:0402") + ")\n", encoding="utf-8"
+    )
+    (tmp_path / "b.kicad_sch").write_text(
+        "(kicad_sch\n" + instance("R?", "10K", "old:fp") + ")\n", encoding="utf-8"
+    )
+    r = backannotate_footprints({"boardPath": str(tmp_path / "b.kicad_pcb")})
+    reason = next(s["reason"] for s in r["skipped"] if s["reference"] == "R?")
+    assert "annotat" in reason
+    assert "not on the board" not in reason
+
+
+# --- C3: which sheets get rewritten --------------------------------------- #
+
+
+@pytest.fixture
+def hierarchy_with_noise(tmp_path):
+    """A two-sheet design surrounded by history, backups and another project."""
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n"
+        + footprint("R1", "FOG_components:0402")
+        + footprint("C1", "FOG_components:0603")
+        + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.kicad_sch").write_text(
+        "(kicad_sch\n"
+        + sheet_ref("power", "sheet-1", "sub.kicad_sch")
+        + instance("R1", "10K", "stale:0402")
+        + ")\n",
+        encoding="utf-8",
+    )
+    noise = "(kicad_sch\n" + instance("C1", "100n", "stale:0603") + ")\n"
+    (tmp_path / "sub.kicad_sch").write_text(noise, encoding="utf-8")
+    for directory in (".history", "backups", "other_project"):
+        (tmp_path / directory).mkdir()
+        (tmp_path / directory / "s.kicad_sch").write_text(noise, encoding="utf-8")
+    return tmp_path
+
+
+def test_the_sheet_tree_is_scanned(hierarchy_with_noise):
+    r = backannotate_footprints({"boardPath": str(hierarchy_with_noise / "b.kicad_pcb")})
+    assert r["sheetsScanned"] == ["b.kicad_sch", "sub.kicad_sch"]
+    assert {c["sheet"] for c in r["changes"]} == {"b.kicad_sch", "sub.kicad_sch"}
+
+
+@pytest.mark.parametrize("directory", [".history", "backups", "other_project"])
+def test_a_sheet_outside_the_design_is_left_alone(hierarchy_with_noise, directory):
+    """Rewriting the backup destroys the fallback at the moment it is needed."""
+    outsider = hierarchy_with_noise / directory / "s.kicad_sch"
+    before = outsider.read_bytes()
+    r = backannotate_footprints({"boardPath": str(hierarchy_with_noise / "b.kicad_pcb")})
+    assert outsider.read_bytes() == before
+    assert not any(directory in s for s in r["sheetsScanned"])
+    assert not any(directory in p for p in r["updatedFiles"])
+
+
+def test_scanned_sheets_are_distinguishable(tmp_path):
+    """Two sheets both named s.kicad_sch used to report as one name twice."""
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n" + footprint("C1", "FOG_components:0603") + ")\n", encoding="utf-8"
+    )
+    (tmp_path / "parts").mkdir()
+    (tmp_path / "b.kicad_sch").write_text(
+        "(kicad_sch\n" + sheet_ref("deep", "sheet-1", "parts/s.kicad_sch") + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "parts" / "s.kicad_sch").write_text(
+        "(kicad_sch\n" + instance("C1", "100n", "stale:0603") + ")\n", encoding="utf-8"
+    )
+    r = backannotate_footprints({"boardPath": str(tmp_path / "b.kicad_pcb")})
+    assert r["sheetsScanned"] == ["b.kicad_sch", "parts/s.kicad_sch"]
+    assert r["changes"][0]["sheet"] == "parts/s.kicad_sch"
+
+
+def test_a_sheet_placed_twice_is_only_written_once(repeated_sheet_project):
+    """Both (sheet ...) blocks name sub.kicad_sch; it is one file on disk."""
+    r = backannotate_footprints({"boardPath": str(repeated_sheet_project / "b.kicad_pcb")})
+    assert r["sheetsScanned"] == ["b.kicad_sch", "sub.kicad_sch"]
+
+
+def test_sheets_beside_the_board_are_used_when_there_is_no_root_sheet(tmp_path):
+    (tmp_path / "board.kicad_pcb").write_text(BOARD, encoding="utf-8")
+    (tmp_path / "somethingelse.kicad_sch").write_text(SCH, encoding="utf-8")
+    (tmp_path / ".history").mkdir()
+    outsiders = [
+        tmp_path / ".history" / "somethingelse.kicad_sch",
+        tmp_path / "_autosave-somethingelse.kicad_sch",
+    ]
+    for outsider in outsiders:
+        outsider.write_text(SCH, encoding="utf-8")
+    r = backannotate_footprints({"boardPath": str(tmp_path / "board.kicad_pcb")})
+    assert r["sheetsScanned"] == ["somethingelse.kicad_sch"]
+    for outsider in outsiders:
+        assert outsider.read_text(encoding="utf-8") == SCH
+
+
+def test_a_named_sheet_outside_the_project_is_flagged(project):
+    other = project / "elsewhere"
+    other.mkdir()
+    stray = other / "unrelated.kicad_sch"
+    stray.write_text("(kicad_sch\n" + instance("R1", "10K", "old:fp") + ")\n", encoding="utf-8")
+    r = run(project, schematicPath=str(stray))
+    assert r["warnings"]
+    assert "sheet tree" in r["warnings"][0]
+
+
+# --- W3: on the board, missing from the schematic -------------------------- #
+
+
+def test_a_footprint_only_on_the_board_is_reported(project):
+    r = run(project)
+    assert r["notInSchematic"] == []
+    (project / "b.kicad_sch").write_text(
+        "(kicad_sch\n" + instance("R1", "10K", "old:fp") + ")\n", encoding="utf-8"
+    )
+    r = run(project)
+    assert r["notInSchematic"] == ["C1", "J2", "U1"]
+
+
+def test_notInSchematic_respects_the_references_filter(project):
+    (project / "b.kicad_sch").write_text(
+        "(kicad_sch\n" + instance("R1", "10K", "old:fp") + ")\n", encoding="utf-8"
+    )
+    r = run(project, references=["C1"])
+    assert r["notInSchematic"] == ["C1"]
+
+
+# --- W2: line endings ------------------------------------------------------ #
+
+
+def test_an_lf_schematic_stays_lf(tmp_path):
+    """Whole-file CRLF conversion turns a one-field edit into a 300-line diff."""
+    canonical = (FIXTURES / "canonical_schematic.kicad_sch").read_bytes()
+    assert b"\r\n" not in canonical
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n" + footprint("C9", "Capacitor_SMD:C_0402_1005Metric") + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.kicad_sch").write_bytes(canonical)
+    backannotate_footprints({"boardPath": str(tmp_path / "b.kicad_pcb")})
+    assert b"\r\n" not in (tmp_path / "b.kicad_sch").read_bytes()
+
+
+def test_a_crlf_schematic_stays_crlf(tmp_path):
+    canonical = (FIXTURES / "canonical_schematic.kicad_sch").read_bytes()
+    crlf = canonical.replace(b"\n", b"\r\n")
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n" + footprint("C9", "Capacitor_SMD:C_0402_1005Metric") + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.kicad_sch").write_bytes(crlf)
+    backannotate_footprints({"boardPath": str(tmp_path / "b.kicad_pcb")})
+    after = (tmp_path / "b.kicad_sch").read_bytes()
+    assert after.count(b"\r\n") == after.count(b"\n")
+    assert after == crlf.replace(
+        b'"Capacitor_SMD:C_0603_1608Metric"', b'"Capacitor_SMD:C_0402_1005Metric"'
+    )
+
+
+# --- W1: a write failure must not leave a half-edited design --------------- #
+
+
+@pytest.fixture
+def two_sheet_project(tmp_path):
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n"
+        + footprint("R1", "FOG_components:0402")
+        + footprint("C1", "FOG_components:0603")
+        + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.kicad_sch").write_text(
+        "(kicad_sch\n"
+        + sheet_ref("power", "sheet-1", "sub.kicad_sch")
+        + instance("R1", "10K", "stale:0402")
+        + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "sub.kicad_sch").write_text(
+        "(kicad_sch\n" + instance("C1", "100n", "stale:0603") + ")\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _fail_writes_to(monkeypatch, name):
+    import commands.backannotate_footprints as module
+
+    real = module._write_text
+
+    def guarded(path, text, newline):
+        if Path(path).name == name:
+            raise OSError("read-only file system")
+        return real(path, text, newline)
+
+    monkeypatch.setattr(module, "_write_text", guarded)
+
+
+def test_a_write_failure_still_reports_what_was_done(two_sheet_project, monkeypatch):
+    """The old code returned early and threw the whole record away."""
+    _fail_writes_to(monkeypatch, "sub.kicad_sch")
+    r = backannotate_footprints({"boardPath": str(two_sheet_project / "b.kicad_pcb")})
+    assert r["success"] is False
+    assert r["changeCount"] == 2
+    assert [f["sheet"] for f in r["failures"]] == ["sub.kicad_sch"]
+    assert "read-only file system" in r["failures"][0]["error"]
+    assert r["updatedFiles"] == [str(two_sheet_project / "b.kicad_sch")]
+
+
+def test_a_failure_on_the_first_sheet_does_not_stop_the_second(two_sheet_project, monkeypatch):
+    _fail_writes_to(monkeypatch, "b.kicad_sch")
+    r = backannotate_footprints({"boardPath": str(two_sheet_project / "b.kicad_pcb")})
+    assert [f["sheet"] for f in r["failures"]] == ["b.kicad_sch"]
+    assert '"FOG_components:0603"' in (two_sheet_project / "sub.kicad_sch").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_no_temporary_file_is_left_behind(two_sheet_project):
+    backannotate_footprints({"boardPath": str(two_sheet_project / "b.kicad_pcb")})
+    assert list(two_sheet_project.glob("*.mcp-tmp")) == []
 
 
 # --- options and errors ---------------------------------------------------- #
@@ -280,13 +753,11 @@ def test_second_run_is_a_no_op(project):
     assert "already matches" in r["message"]
 
 
-def test_all_sheets_beside_the_board_are_scanned(project):
-    (project / "sub.kicad_sch").write_text(
-        "(kicad_sch\n" + instance("C1", "100n", "stale:0603") + ")\n", encoding="utf-8"
-    )
-    r = run(project)
-    assert "sub.kicad_sch" in r["sheetsScanned"]
-    assert any(c["sheet"] == "sub.kicad_sch" for c in r["changes"])
+def test_a_second_run_is_byte_identical(project):
+    run(project)
+    once = (project / "b.kicad_sch").read_bytes()
+    run(project)
+    assert (project / "b.kicad_sch").read_bytes() == once
 
 
 def test_a_single_sheet_can_be_targeted(project):

--- a/tests/test_backannotate_footprints.py
+++ b/tests/test_backannotate_footprints.py
@@ -1,0 +1,321 @@
+"""Tests for backannotate_footprints — PCB footprint assignments -> schematic."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+from commands.backannotate_footprints import (  # noqa: E402
+    backannotate_footprints,
+    read_board_footprints,
+)
+
+
+def footprint(reference, lib_id, extra=""):
+    return f"""\t(footprint "{lib_id}"
+\t\t(layer "F.Cu")
+\t\t(property "Reference" "{reference}"
+\t\t\t(at 0 1.25 0)
+\t\t\t(effects (font (size 1 1)))
+\t\t)
+\t\t(property "Value" "x"
+\t\t\t(at 0 0 0)
+\t\t\t(effects (font (size 1 1)))
+\t\t){extra}
+\t)
+"""
+
+
+BOARD = (
+    '(kicad_pcb\n\t(version 20240108)\n\t(generator "pcbnew")\n'
+    + footprint("R1", "FOG_components:0402")
+    + footprint("C1", "FOG_components:0603")
+    + footprint("J2", "FOG_components:HRS_U.FL-R-SMT-1(10)")
+    + footprint("U1", "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm")
+    + ")\n"
+)
+
+
+def instance(reference, value, footprint_value, unit=1):
+    field = (
+        ""
+        if footprint_value is None
+        else f"""\t\t(property "Footprint" "{footprint_value}"
+\t\t\t(at 5 6 0)
+\t\t\t(hide yes)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+"""
+    )
+    return f"""\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 100 0)
+\t\t(unit {unit})
+\t\t(uuid "uuid-{reference}-{unit}")
+\t\t(property "Reference" "{reference}"
+\t\t\t(at 1 2 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "{value}"
+\t\t\t(at 3 4 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+{field}\t)
+"""
+
+
+LIB_SYMBOLS = """\t(lib_symbols
+\t\t(symbol "Device:R"
+\t\t\t(property "Footprint" "STALE:should_not_be_touched"
+\t\t\t\t(at 0 0 0)
+\t\t\t\t(effects (font (size 1.27 1.27)))
+\t\t\t)
+\t\t)
+\t)
+"""
+
+SCH = (
+    '(kicad_sch\n\t(version 20231120)\n\t(generator "eeschema")\n'
+    + LIB_SYMBOLS
+    + instance("R1", "10K", "eagle_import:0402HF")
+    + instance("C1", "100n", "FOG_components:0603")
+    + instance("J2", "conn", "wrong:thing")
+    + instance("U1", "opamp", None)
+    + instance("#GND1", "GND", "")
+    + instance("R99", "1K", "orphan:fp")
+    + ")\n"
+)
+
+
+def balance(text):
+    depth, in_string, i = 0, False, 0
+    while i < len(text):
+        ch = text[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        i += 1
+    return depth
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / "b.kicad_pcb").write_text(BOARD, encoding="utf-8")
+    (tmp_path / "b.kicad_sch").write_text(SCH, encoding="utf-8")
+    return tmp_path
+
+
+def run(project, **kw):
+    return backannotate_footprints({"boardPath": str(project / "b.kicad_pcb"), **kw})
+
+
+def sch_text(project):
+    return (project / "b.kicad_sch").read_text(encoding="utf-8")
+
+
+def by_reference(result):
+    return {c["reference"]: c for c in result["changes"]}
+
+
+# --- board side ------------------------------------------------------------ #
+
+
+def test_read_board_footprints():
+    placed = read_board_footprints(BOARD)
+    assert placed["R1"] == "FOG_components:0402"
+    assert placed["U1"] == "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"
+
+
+def test_board_footprint_name_containing_parens():
+    """HRS_U.FL-R-SMT-1(10) is a real part; naive paren counting loses it."""
+    assert read_board_footprints(BOARD)["J2"] == "FOG_components:HRS_U.FL-R-SMT-1(10)"
+
+
+def test_board_with_legacy_fp_text_reference():
+    legacy = (
+        "(kicad_pcb\n"
+        '\t(footprint "Lib:FP"\n'
+        '\t\t(fp_text reference "R7" (at 0 0))\n'
+        "\t)\n)\n"
+    )
+    assert read_board_footprints(legacy) == {"R7": "Lib:FP"}
+
+
+def test_board_indentation_is_ignored():
+    """KiCad writes board files whose indentation does not match nesting."""
+    ragged = BOARD.replace(
+        '\t(footprint "FOG_components:0402"', '\t\t\t(footprint "FOG_components:0402"'
+    )
+    assert read_board_footprints(ragged)["R1"] == "FOG_components:0402"
+
+
+# --- schematic side -------------------------------------------------------- #
+
+
+def test_updates_a_mismatched_footprint(project):
+    r = run(project)
+    assert r["success"]
+    assert by_reference(r)["R1"]["from"] == "eagle_import:0402HF"
+    assert by_reference(r)["R1"]["to"] == "FOG_components:0402"
+    assert '"Footprint" "FOG_components:0402"' in sch_text(project)
+
+
+def test_leaves_a_matching_footprint_alone(project):
+    r = run(project)
+    assert "C1" not in by_reference(r)
+
+
+def test_adds_a_missing_footprint_field(project):
+    r = run(project)
+    assert by_reference(r)["U1"]["action"] == "added"
+    text = sch_text(project)
+    assert '"Footprint" "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"' in text
+    assert balance(text) == 0
+
+
+def test_added_field_lands_inside_its_instance(project):
+    run(project)
+    text = sch_text(project)
+    start = text.index('"Reference" "U1"')
+    end = text.index('"Reference" "#GND1"')
+    assert start < text.index('"Package_SO:SOIC-8') < end
+
+
+def test_add_missing_can_be_turned_off(project):
+    r = run(project, addMissing=False)
+    assert "U1" not in by_reference(r)
+    assert {s["reference"] for s in r["skipped"]} >= {"U1"}
+
+
+def test_power_symbols_are_skipped(project):
+    r = run(project)
+    assert "#GND1" not in by_reference(r)
+    assert "#GND1" not in {s["reference"] for s in r["skipped"]}
+
+
+def test_symbol_absent_from_the_board_is_reported_not_changed(project):
+    r = run(project)
+    assert "R99" not in by_reference(r)
+    assert any(s["reference"] == "R99" and "not on the board" in s["reason"] for s in r["skipped"])
+    assert '"orphan:fp"' in sch_text(project)
+
+
+def test_lib_symbols_cache_is_not_touched(project):
+    """Instance fields override the cache; rewriting the cache is a different tool."""
+    run(project)
+    assert '"STALE:should_not_be_touched"' in sch_text(project)
+
+
+def test_result_stays_balanced(project):
+    run(project)
+    assert balance(sch_text(project)) == 0
+
+
+def test_footprint_with_parens_is_written_back(project):
+    run(project)
+    assert '"FOG_components:HRS_U.FL-R-SMT-1(10)"' in sch_text(project)
+    assert balance(sch_text(project)) == 0
+
+
+def test_every_unit_of_a_multi_unit_symbol_is_updated(tmp_path):
+    (tmp_path / "b.kicad_pcb").write_text(
+        "(kicad_pcb\n" + footprint("X1", "FOG_components:BUL") + ")\n", encoding="utf-8"
+    )
+    (tmp_path / "b.kicad_sch").write_text(
+        "(kicad_sch\n"
+        + instance("X1", "BUL", "old:fp", unit=1)
+        + instance("X1", "BUL", "old:fp", unit=2)
+        + ")\n",
+        encoding="utf-8",
+    )
+    r = backannotate_footprints({"boardPath": str(tmp_path / "b.kicad_pcb")})
+    assert r["changeCount"] == 2
+    text = (tmp_path / "b.kicad_sch").read_text(encoding="utf-8")
+    assert text.count('"FOG_components:BUL"') == 2
+    assert "old:fp" not in text
+
+
+def test_hidden_and_position_are_preserved_on_update(project):
+    run(project)
+    text = sch_text(project)
+    block = text[text.index('"Reference" "R1"') :]
+    field = block[block.index('"Footprint"') : block.index('"Footprint"') + 200]
+    assert "(at 5 6 0)" in field
+    assert "(hide yes)" in field
+
+
+# --- options and errors ---------------------------------------------------- #
+
+
+def test_dry_run_changes_nothing(project):
+    before = sch_text(project)
+    r = run(project, dryRun=True)
+    assert r["dryRun"] is True
+    assert r["changeCount"] > 0
+    assert "Would update" in r["message"]
+    assert sch_text(project) == before
+    assert r["updatedFiles"] == []
+
+
+def test_references_filter(project):
+    r = run(project, references=["R1"])
+    assert list(by_reference(r)) == ["R1"]
+    assert '"wrong:thing"' in sch_text(project)
+
+
+def test_second_run_is_a_no_op(project):
+    run(project)
+    r = run(project)
+    assert r["changeCount"] == 0
+    assert "already matches" in r["message"]
+
+
+def test_all_sheets_beside_the_board_are_scanned(project):
+    (project / "sub.kicad_sch").write_text(
+        "(kicad_sch\n" + instance("C1", "100n", "stale:0603") + ")\n", encoding="utf-8"
+    )
+    r = run(project)
+    assert "sub.kicad_sch" in r["sheetsScanned"]
+    assert any(c["sheet"] == "sub.kicad_sch" for c in r["changes"])
+
+
+def test_a_single_sheet_can_be_targeted(project):
+    (project / "sub.kicad_sch").write_text(
+        "(kicad_sch\n" + instance("C1", "100n", "stale:0603") + ")\n", encoding="utf-8"
+    )
+    r = run(project, schematicPath=str(project / "sub.kicad_sch"))
+    assert r["sheetsScanned"] == ["sub.kicad_sch"]
+    assert '"eagle_import:0402HF"' in sch_text(project)
+
+
+def test_board_not_found(tmp_path):
+    r = backannotate_footprints({"boardPath": str(tmp_path / "nope.kicad_pcb")})
+    assert not r["success"]
+
+
+def test_board_without_footprints(tmp_path):
+    (tmp_path / "b.kicad_pcb").write_text("(kicad_pcb\n)\n", encoding="utf-8")
+    r = backannotate_footprints({"boardPath": str(tmp_path / "b.kicad_pcb")})
+    assert not r["success"]
+    assert "No placed footprints" in r["message"]
+
+
+def test_no_schematic_beside_the_board(tmp_path):
+    (tmp_path / "b.kicad_pcb").write_text(BOARD, encoding="utf-8")
+    r = backannotate_footprints({"boardPath": str(tmp_path / "b.kicad_pcb")})
+    assert not r["success"]
+    assert ".kicad_sch" in r["message"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_sexpr_format.py
+++ b/tests/test_sexpr_format.py
@@ -15,7 +15,7 @@ PYTHON_DIR = Path(__file__).parent.parent / "python"
 sys.path.insert(0, str(PYTHON_DIR))
 
 from commands.wire_dragger import WireDragger  # noqa: E402
-from utils.sexpr_format import dumps, prettify  # noqa: E402
+from utils.sexpr_format import dumps, iter_child_offsets, match_paren, prettify  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -179,6 +179,40 @@ class TestWriteToolIntegration:
         assert sexpdata.loads(out) is not None  # still parses
         # Writing again is stable (idempotent formatting).
         assert prettify(out) == out
+
+
+class TestStructureWalking:
+    """match_paren / iter_child_offsets let text tools slice a block out safely."""
+
+    def test_match_paren_finds_the_closing_paren(self):
+        s = "(a (b) (c))"
+        assert match_paren(s, 0) == len(s) - 1
+        assert match_paren(s, 3) == 5
+
+    def test_match_paren_ignores_parens_inside_strings(self):
+        # A real footprint name: HRS_U.FL-R-SMT-1(10).
+        s = '(footprint "Lib:HRS_U.FL-R-SMT-1(10)" (layer "F.Cu"))'
+        assert match_paren(s, 0) == len(s) - 1
+
+    def test_match_paren_ignores_an_escaped_quote(self):
+        s = '(property "he said \\"hi (x)\\"" (at 0 0))'
+        assert match_paren(s, 0) == len(s) - 1
+
+    def test_match_paren_returns_minus_one_when_unbalanced(self):
+        assert match_paren("(a (b)", 0) == -1
+
+    def test_iter_child_offsets_yields_direct_children(self):
+        s = '(symbol (lib_id "X") (at 0 0) (property "a" "b" (at 1 1)))'
+        assert [s[i : i + 5] for i in iter_child_offsets(s)] == ["(lib_", "(at 0", "(prop"]
+
+    def test_iter_child_offsets_depth_is_configurable(self):
+        s = "(root (mid (leaf)))"
+        assert [s[i : i + 5] for i in iter_child_offsets(s, depth=3)] == ["(leaf"]
+
+    def test_iter_child_offsets_ignores_indentation(self):
+        """Board files from KiCad indent inconsistently; only nesting counts."""
+        s = '(kicad_pcb\n\t\t\t(footprint "A")\n\t(footprint "B")\n)'
+        assert len(list(iter_child_offsets(s))) == 2
 
 
 class TestIntegerRotationAngle:


### PR DESCRIPTION
## The gap

The server can push a schematic into a board (`sync_schematic_to_board`, the F8 equivalent) but has nothing going the other way.

That direction matters because after a layout pass the **board** is the side that is right. A footprint gets swapped in pcbnew — a 0402 that had to become an 0603, a connector changed for one that fits — and the schematic keeps the old value. Nothing complains, because nothing reads it, until the next ECO run pushes the stale schematic value back onto the board and quietly undoes the layout decision.

Imported projects start out in that state. Anything that came through `import_eagle_project` has schematic-side `Footprint` fields that never matched the placed parts, and today the only fix is to parse the `.kicad_pcb` by hand and patch each field.

## What this adds

`backannotate_footprints` copies the placed footprint into the schematic's `Footprint` field, matching by reference designator.

- Scans every `.kicad_sch` beside the board, so a hierarchical design is handled in one call; `schematicPath` narrows it to one sheet.
- Updates **all units** of a multi-unit symbol, not just the first one found.
- Skips virtual references starting with `#` — power and ground symbols carry no footprint, and writing one to them is wrong.
- Adds the field to instances that lack it (`addMissing`, default true); `references` limits the run to a list; `dryRun` reports the diff without writing.

Two behaviours worth calling out, because both are choices rather than accidents:

**Position and `hide` are inherited from the existing field.** Back-annotating a footprint must not move a field the user placed, and must not reveal one they hid. Only the value changes.

**The `lib_symbols` cache is left alone.** Instance fields override the cache when KiCad loads a sheet, so updating the instance is sufficient and correct. Rewriting the cache is a different operation with different risks, and silently doing both would make this tool much harder to reason about.

## Parsing

Structural, not regex-based, driven by two things found in real files.

Footprint names contain parentheses — `HRS_U.FL-R-SMT-1(10)` is a stock Hirose connector — so counting parens without tracking string state truncates the name mid-value and unbalances the file. And KiCad writes board files whose indentation does not track nesting, so indentation cannot be used as a shortcut for depth.

The s-expression walkers this needed, `match_paren` and `iter_child_offsets`, move into `utils/sexpr_format.py`. They already existed as private copies in `add_symbol_property` and `library_tables`; this replaces both with the shared version rather than adding a third.

## Test plan

24 new tests in `tests/test_backannotate_footprints.py`, plus 8 in `tests/test_sexpr_format.py` for the promoted helpers. They cover the cases where a simpler implementation breaks:

- footprint name containing parens, read from the board and written back intact
- board indentation that does not match nesting
- legacy `(fp_text reference ...)` boards alongside the modern `(property "Reference" ...)` form
- every unit of a multi-unit symbol updated
- `lib_symbols` cache left untouched
- `hide` and `(at ...)` preserved on update
- added field lands inside its own instance, not a neighbour's
- paren balance holds after every write
- second run is a no-op

Verified end to end on a real 71-footprint board outside the test suite: it found two genuine mismatches (`FOG_components:0402S` in the schematic where the board had `FOG_components:0402HF`), `kicad-cli sch upgrade` accepted the result without changes, and a second pass reported nothing to do.

Full suite green: `pytest`, `black`, `isort`, `flake8`, `mypy`, `tsc --noEmit`, `eslint`, `prettier`, `vitest` (70 passed).
