### PR TITLE
feat: add set_symbol_pin_type (bulk pin electrical type edits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### New Tools
+
+- **`set_symbol_pin_type`** — set the electrical type, and optionally the
+  graphic style, of pins in a `.kicad_sym` library, filtered by symbol, pin
+  number, pin name, or current type. The server could read pins
+  (`list_symbol_pins`, `batch_list_symbol_pins`) but not write them, so bulk
+  fixes were done with `sed` over the library file.
+
+  That is unsafe in ways that are easy to miss. A blind substitution also
+  rewrites the words it matches inside symbol names, `Description` properties
+  and `(alternate "SPI_CLK" output line)` pin functions; it cannot tell which
+  symbol it is standing on, so "only the shield pins" is not expressible; and
+  nothing validates the replacement token, which matters because KiCad refuses
+  to load a library containing a pin type it does not recognise and reports the
+  file rather than the pin. This tool checks the token against KiCad's sets
+  before touching the file, and rewrites only the pin head.
+
+  The usual reason to need it: symbols converted from Eagle or pulled from
+  SnapEDA arrive with every pin `unspecified` or `bidirectional`, and ERC then
+  reports conflicts on nets that are electrically fine, burying the real errors.
+  `fromType` makes that a one-liner. A misspelled symbol name is reported in
+  `missingSymbols` rather than silently matching nothing, and `dryRun` shows
+  the list first.
+
+  Verified on a 2.2 MB library: 2279 pins across 472 symbols walked correctly,
+  32 pins changed, paren balance unmoved, `kicad-cli sym upgrade` accepted the
+  result, and a second pass was a no-op.
+
 ### Bug Fixes
 
 - **`add_layer` could not add inner copper layers, and corrupted an unrelated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,35 @@ All notable changes to the KiCAD MCP Server project are documented here.
   The usual reason to need it: symbols converted from Eagle or pulled from
   SnapEDA arrive with every pin `unspecified` or `bidirectional`, and ERC then
   reports conflicts on nets that are electrically fine, burying the real errors.
-  `fromType` makes that a one-liner. A misspelled symbol name is reported in
-  `missingSymbols` rather than silently matching nothing, and `dryRun` shows
-  the list first.
+  `fromType` makes that a one-liner, and `dryRun` shows the list first.
+
+  Nothing that can be mistyped fails silently. An unrecognised `type`, `style`
+  or `fromType` is refused before the library is opened, and a `symbols`,
+  `pinNumbers` or `pinNames` entry that matched nothing comes back in
+  `missingSymbols`, `missingPinNumbers` or `missingPinNames`. A _derived_
+  symbol is told apart from a typo: `(extends "R_Small")` means the symbol has
+  no pins of its own, so it is reported in `symbolsWithoutOwnPins` with a
+  pointer to the parent rather than as a name absent from the library.
+
+  The library is replaced atomically -- the new text is built in a sibling
+  temporary file that is renamed over the original, the same guarantee `sed -i`
+  gives -- so a failed or interrupted write cannot leave a truncated part
+  library behind. A timestamped copy also goes into a sibling `.mcp-backups/`
+  directory (the convention `_auto_save_board` already uses for boards, and
+  already covered by `.gitignore`) and its path is returned in `backupPath`,
+  because the rename only protects against a crash: omitting `symbols` is the
+  natural way to call this tool and flattens every pin in the library, and that
+  edit succeeds. The backup is best effort and never blocks the edit. The
+  file's existing line endings are preserved, which is what keeps a 32-pin edit
+  to a 32-line diff rather than rewriting every line of a library checked out
+  with LF endings on a Windows host. Because a whole-library pass changes
+  thousands of pins and this is an MCP tool whose response is spent from the
+  model's context window, `changes` carries at most 200 per-pin records and sets
+  `changesTruncated`; `changeCount`, `alreadyCorrect` and `symbolsChanged`
+  always describe the whole run. The edits are spliced into the file in one
+  pass, because rebuilding it per pin copies the whole library once for every
+  pin changed -- ~440 GB of copying and a 169-second call on KiCad's own 16 MB
+  `MCU_ST_STM32H7` (28191 pins), against ~8 seconds spliced once.
 
   Verified on a 2.2 MB library: 2279 pins across 472 symbols walked correctly,
   32 pins changed, paren balance unmoved, `kicad-cli sym upgrade` accepted the

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ configuration command and backend options.
 We've implemented an intelligent tool router to keep AI context efficient while maintaining full functionality:
 
 - **22 direct tools** always visible for high-frequency operations
-- **111 routed tools** organized into 13 categories (board, component, export, drc, schematic, library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, parts-registry)
+- **112 routed tools** organized into 13 categories (board, component, export, drc, schematic, library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, parts-registry)
 - **4 router tools** for discovery and execution:
   - `list_tool_categories` - Browse all available categories
   - `get_category_tools` - View tools in a specific category
@@ -486,7 +486,7 @@ Access project state without executing tools:
 
 ## Available Tools
 
-The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **146 tools** are additionally indexed into 13 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
+The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **147 tools** are additionally indexed into 13 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
 
 For the complete tool reference with access types (direct/routed/additional), see [Tool Inventory](docs/TOOL_INVENTORY.md).
 
@@ -1513,7 +1513,7 @@ npm run format
 
 See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix and [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
 
-**Working Features (146 tools):**
+**Working Features (147 tools):**
 
 - Project management with snapshot checkpointing
 - Complete board design (outline, layers, zones, mounting holes, text, SVG logos)
@@ -1526,6 +1526,7 @@ See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix a
 - Design rule checking (DRC and ERC)
 - Export to Gerber, PDF, SVG, 3D, BOM, netlist, position file
 - Custom footprint and symbol creation
+- Bulk pin electrical-type edits in symbol libraries
 - JLCPCB parts integration (2.5M+ parts catalog)
 - Datasheet enrichment via LCSC
 - Freerouting autorouter integration (Java, Docker, Podman)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 **Key Capabilities:**
 
-- 146 tools across 13 categories with JSON Schema validation
+- 147 tools across 13 categories with JSON Schema validation
 - Keyword tool discovery via `search_tools` / `get_category_tools`
 - 8 dynamic resources exposing project state
 - Complete schematic workflow with 27 tools and dynamic symbol loading (~10,000 symbols)

--- a/python/commands/set_symbol_pin_type.py
+++ b/python/commands/set_symbol_pin_type.py
@@ -16,12 +16,38 @@ Imported libraries are the usual reason to need this. Parts converted from
 Eagle or pulled from SnapEDA arrive with every pin marked ``unspecified`` or
 ``bidirectional``; ERC then reports conflicts on nets that are electrically
 fine, and the noise hides the real errors.
+
+Two properties of the write matter as much as the parsing, because this is a
+bulk edit over a file that may be megabytes of a user's part library:
+
+* It is atomic. ``sed -i`` -- the thing being replaced -- writes a temporary
+  file and renames it, so an interrupted run leaves either the old library or
+  the new one. Anything that opens the target for truncation empties it before
+  the first replacement byte is written, and then has nothing to restore.
+* It preserves the file's newline style. Rewriting a library checked out with
+  LF endings on a Windows host would turn a 32-pin edit into a diff touching
+  every line of the file, which is unreviewable.
+
+A timestamped copy of the library is kept in a sibling ``.mcp-backups/``
+directory before it is rewritten, following the convention
+``kicad_interface._auto_save_board`` already uses for boards (``.gitignore``
+covers ``*-backups/``). Atomicity and the backup guard different failures:
+the rename means a crash cannot leave a truncated library, but it does nothing
+about an edit that succeeds and was not what the caller meant. Omitting
+``symbols`` is the natural way to call this tool and flattens every pin in the
+library, so that is the likely mistake, and a library that is not in git has no
+other undo. The copy is best effort -- a library that cannot be backed up is
+still edited, because refusing the requested edit over a failed backup helps
+nobody.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import re
+import shutil
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
@@ -31,7 +57,81 @@ from utils.sexpr_format import match_paren
 logger = logging.getLogger("kicad_interface")
 
 _HEAD = re.compile(r"\(\s*([A-Za-z_][\w]*)")
-_PIN_HEAD = re.compile(r"\(pin\s+([A-Za-z_][\w]*)\s+([A-Za-z_][\w]*)")
+# Whitespace after "(" is allowed here for the same reason _HEAD allows it: the
+# walker finds these pins either way, and a stricter head regex would make them
+# fall out of the loop silently -- neither changed nor reported.
+_PIN_HEAD = re.compile(r"\(\s*pin\s+([A-Za-z_][\w]*)\s+([A-Za-z_][\w]*)")
+
+#: Upper bound on the per-pin records returned in ``changes``. A whole-library
+#: pass changes thousands of pins, and this is an MCP tool -- the response is
+#: spent from the model's context window, so an uncapped list costs the caller
+#: ~100k tokens on precisely the bulk operation the tool exists for.
+#: ``changeCount`` always carries the true total and ``changesTruncated`` says
+#: when the list was cut.
+_MAX_REPORTED_CHANGES = 200
+
+#: Timestamped copies kept per library in ``.mcp-backups/``, matching
+#: ``kicad_interface._auto_save_backup_keep``.
+_BACKUP_KEEP = 20
+
+
+def _prune_backups(backup_dir: Path, base_name: str) -> None:
+    """Keep only the most recent ``_BACKUP_KEEP`` copies of *base_name*."""
+    try:
+        entries = [p for p in backup_dir.iterdir() if p.name.startswith(base_name + ".")]
+        entries.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        for old in entries[_BACKUP_KEEP:]:
+            try:
+                old.unlink()
+            except OSError:
+                pass
+    except OSError as e:
+        logger.debug("Backup pruning skipped: %s", e)
+
+
+def _backup(path: Path) -> Optional[Path]:
+    """Copy *path* into a sibling ``.mcp-backups/``; return the copy, or None.
+
+    Best effort by design: a system library in a read-only directory should
+    still be editable by a caller who has permission to write it.
+    """
+    try:
+        backup_dir = path.parent / ".mcp-backups"
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")[:-3]
+        dest = backup_dir / f"{path.name}.{stamp}"
+        shutil.copy2(path, dest)
+    except OSError as e:
+        logger.warning("Could not back up %s before editing it: %s", path, e)
+        return None
+    _prune_backups(backup_dir, path.name)
+    return dest
+
+
+def _read_text(path: Path) -> Tuple[str, str]:
+    """File text with LF newlines, plus the newline style to write back."""
+    with open(path, "r", encoding="utf-8", newline="") as fh:
+        raw = fh.read()
+    return raw.replace("\r\n", "\n"), ("\r\n" if "\r\n" in raw else "\n")
+
+
+def _write_text(path: Path, text: str, newline: str) -> None:
+    """Atomic write that keeps the file's original newline style.
+
+    The temporary file is removed on failure so a full disk does not leave a
+    second copy of the library beside the first.
+    """
+    tmp = path.with_name(path.name + ".mcp-tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8", newline=newline) as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def _read_string(text: str, i: int) -> Tuple[Optional[str], int]:
@@ -134,6 +234,98 @@ def iter_library_pins(text: str) -> Iterator[Dict[str, Any]]:
         i += 1
 
 
+def iter_library_symbols(text: str) -> Iterator[Dict[str, Optional[str]]]:
+    """Yield ``{"name", "extends"}`` for every top-level symbol in a .kicad_sym.
+
+    Which symbols a library contains and which symbols have pins are different
+    questions, and the pin walk can only answer the second. A derived symbol --
+    ``(symbol "R_Small_US" (extends "R_Small") ...)`` -- has no pins of its own
+    by design, so learning names from the pins alone reports it as a name that
+    is not in the library, which sends the caller hunting for a typo instead of
+    telling them to edit the parent.
+    """
+    depth = 0
+    in_string = False
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            i += 1
+            continue
+        if ch == ")":
+            depth -= 1
+            i += 1
+            continue
+        if ch != "(":
+            i += 1
+            continue
+        depth += 1
+        m = _HEAD.match(text, i)
+        if depth == 2 and m and m.group(1) == "symbol":
+            name, _ = _read_string(text, m.end())
+            end = match_paren(text, i)
+            if end == -1:
+                yield {"name": name, "extends": None}
+                i += 1
+                continue
+            yield {"name": name, "extends": _child_string(text[i : end + 1], "extends")}
+            # Skip the body: its sub-symbols are units, not top-level symbols.
+            depth -= 1
+            i = end + 1
+            continue
+        i += 1
+
+
+def _pin_structure(text: str) -> List[Tuple[Optional[str], Optional[str]]]:
+    """The (symbol, unit) of every pin, in file order."""
+    return [(p["symbol"], p["unit"]) for p in iter_library_pins(text)]
+
+
+def _splice(text: str, edits: List[Tuple[int, int, str]]) -> str:
+    """Apply *edits* -- ascending, non-overlapping ``(start, stop, text)`` -- at once.
+
+    Rebuilding the string once instead of slicing it per edit is what makes a
+    whole-library pass finish. ``text[:start] + new + text[stop:]`` in a loop
+    copies the entire file for every pin, so the cost grows with pins times file
+    size: on KiCad's 16 MB MCU_ST_STM32H7 (28191 pins) that is ~440 GB of
+    copying, measured at 169 s, against ~8 s for a single join.
+    """
+    parts: List[str] = []
+    cursor = 0
+    for start, stop, replacement in edits:
+        parts.append(text[cursor:start])
+        parts.append(replacement)
+        cursor = stop
+    parts.append(text[cursor:])
+    return "".join(parts)
+
+
+def _edits_landed(updated: str, edits: List[Tuple[int, int, str]]) -> bool:
+    """True if every replacement sits where splicing should have put it.
+
+    ``edits`` is in ascending offset order, so each replacement ends up at its
+    own offset displaced by the total length change of the edits before it --
+    ``(pin unspecified line`` is four characters longer than
+    ``(pin passive line``. If the offsets are not ascending they slide under
+    each other and the replacements land inside neighbouring tokens.
+    """
+    shift = 0
+    for start, stop, replacement in edits:
+        if not updated.startswith(replacement, start + shift):
+            return False
+        shift += len(replacement) - (stop - start)
+    return True
+
+
 def _root_token(text: str) -> Optional[str]:
     m = _HEAD.search(text)
     return m.group(1) if m else None
@@ -147,11 +339,19 @@ def _as_set(value: Any) -> Optional[Set[str]]:
     return {str(v) for v in value}
 
 
+def _pinless_advice(name: str, extends: Optional[str]) -> str:
+    """Why a symbol that exists contributed no pins, and what to do about it."""
+    if extends:
+        return f"{name} extends {extends} and has no pins of its own -- edit {extends} instead"
+    return f"{name} is in this library but has no pins"
+
+
 def set_symbol_pin_type(params: Dict[str, Any]) -> Dict[str, Any]:
     """Set the electrical type and/or graphic style of pins in a symbol library."""
     lib_path = Path(params.get("libraryPath", ""))
     new_type = params.get("type")
     new_style = params.get("style")
+    from_type = params.get("fromType")
     dry_run = bool(params.get("dryRun", False))
 
     if new_type is None and new_style is None:
@@ -177,12 +377,24 @@ def set_symbol_pin_type(params: Dict[str, Any]) -> Dict[str, Any]:
             ),
             "validStyles": list(PIN_STYLES),
         }
+    if from_type is not None and from_type not in PIN_TYPES:
+        # Unvalidated, a transposed fromType ("unspecfied") matches no pin and
+        # the call reports success having changed nothing -- the silent no-op
+        # this tool exists to replace.
+        return {
+            "success": False,
+            "message": (
+                f"'{from_type}' is not a KiCad pin type, so fromType would match no pin "
+                f"and report success having changed nothing. Valid: {', '.join(PIN_TYPES)}"
+            ),
+            "validTypes": list(PIN_TYPES),
+        }
 
     if not lib_path.is_file():
         return {"success": False, "message": f"Library not found: {lib_path}"}
 
     try:
-        text = lib_path.read_text(encoding="utf-8")
+        text, newline = _read_text(lib_path)
     except OSError as e:
         return {"success": False, "message": f"Could not read {lib_path}: {e}"}
 
@@ -199,13 +411,21 @@ def set_symbol_pin_type(params: Dict[str, Any]) -> Dict[str, Any]:
     want_symbols = _as_set(params.get("symbols"))
     want_numbers = _as_set(params.get("pinNumbers"))
     want_names = _as_set(params.get("pinNames"))
-    from_type = params.get("fromType")
+
+    library_symbols: Dict[str, Optional[str]] = {}
+    for entry in iter_library_symbols(text):
+        entry_name = entry["name"]
+        if entry_name is not None:
+            library_symbols.setdefault(entry_name, entry["extends"])
 
     seen_symbols: Set[str] = set()
     seen_numbers: Set[str] = set()
+    seen_names: Set[str] = set()
+    touched_symbols: Set[str] = set()
     changes: List[Dict[str, Any]] = []
     edits: List[Tuple[int, int, str]] = []
     unchanged = 0
+    backup_path: Optional[Path] = None
 
     for pin in iter_library_pins(text):
         symbol = pin["symbol"]
@@ -216,6 +436,11 @@ def set_symbol_pin_type(params: Dict[str, Any]) -> Dict[str, Any]:
 
         head = _PIN_HEAD.match(text, pin["offset"])
         if not head:
+            logger.warning(
+                "%s: the pin at offset %d has no '(pin <type> <style>' head; leaving it alone",
+                lib_path.name,
+                pin["offset"],
+            )
             continue
         cur_type, cur_style = head.group(1), head.group(2)
 
@@ -234,6 +459,8 @@ def set_symbol_pin_type(params: Dict[str, Any]) -> Dict[str, Any]:
 
         if number:
             seen_numbers.add(number)
+        if name:
+            seen_names.add(name)
         if want_numbers is not None and number not in want_numbers:
             continue
         if want_names is not None and name not in want_names:
@@ -248,35 +475,55 @@ def set_symbol_pin_type(params: Dict[str, Any]) -> Dict[str, Any]:
             continue
 
         edits.append((head.start(), head.end(), f"(pin {to_type} {to_style}"))
-        changes.append(
-            {
-                "symbol": symbol,
-                "unit": pin["unit"],
-                "number": number,
-                "name": name,
-                "fromType": cur_type,
-                "toType": to_type,
-                "fromStyle": cur_style,
-                "toStyle": to_style,
-            }
-        )
+        if symbol:
+            touched_symbols.add(symbol)
+        if len(changes) < _MAX_REPORTED_CHANGES:
+            changes.append(
+                {
+                    "symbol": symbol,
+                    "unit": pin["unit"],
+                    "number": number,
+                    "name": name,
+                    "fromType": cur_type,
+                    "toType": to_type,
+                    "fromStyle": cur_style,
+                    "toStyle": to_style,
+                }
+            )
 
-    missing_symbols = sorted(want_symbols - seen_symbols) if want_symbols else []
+    if want_symbols:
+        missing_symbols = sorted(want_symbols - set(library_symbols))
+        pinless_symbols = sorted((want_symbols & set(library_symbols)) - seen_symbols)
+    else:
+        missing_symbols = []
+        pinless_symbols = []
     missing_numbers = sorted(want_numbers - seen_numbers) if want_numbers else []
+    missing_names = sorted(want_names - seen_names) if want_names else []
 
     if edits and not dry_run:
-        updated = text
-        for start, stop, replacement in reversed(edits):
-            updated = updated[:start] + replacement + updated[stop:]
-        if updated.count("(") != text.count("(") or updated.count(")") != text.count(")"):
+        updated = _splice(text, edits)
+        # A paren count cannot move here -- the replacement is always
+        # "(pin <token> <token>" and neither token can contain one -- so counting
+        # them proves nothing. These two check the post-condition that actually
+        # matters: each splice sits where its offset said, and the file still
+        # holds the same pins under the same symbols.
+        if not _edits_landed(updated, edits) or _pin_structure(updated) != _pin_structure(text):
             return {
                 "success": False,
                 "message": "Internal error: the edit changed the file structure. Nothing written.",
             }
+        backup_path = _backup(lib_path)
         try:
-            lib_path.write_text(updated, encoding="utf-8")
+            _write_text(lib_path, updated, newline)
         except OSError as e:
-            return {"success": False, "message": f"Could not write {lib_path}: {e}"}
+            return {
+                "success": False,
+                "message": (
+                    f"Could not write {lib_path}: {e}. The library is unchanged -- the new "
+                    "text is built in a temporary file that only replaces the original once "
+                    "it is complete."
+                ),
+            }
 
         # The file is already on disk, so a cache that refuses to clear must not
         # turn a successful write into a reported failure -- the caller would
@@ -288,14 +535,26 @@ def set_symbol_pin_type(params: Dict[str, Any]) -> Dict[str, Any]:
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("Symbol caches not invalidated after pin edit: %s", e)
 
-    touched = sorted({c["symbol"] for c in changes if c["symbol"]})
-    if changes:
+    total_changes = len(edits)
+    touched = sorted(touched_symbols)
+    if total_changes:
         verb = "Would change" if dry_run else "Changed"
-        message = f"{verb} {len(changes)} pin(s) across {len(touched)} symbol(s)"
+        message = f"{verb} {total_changes} pin(s) across {len(touched)} symbol(s)"
     elif missing_symbols:
         message = f"No pins changed: symbol(s) not in this library: {', '.join(missing_symbols)}"
+    elif pinless_symbols:
+        message = "No pins changed: " + "; ".join(
+            _pinless_advice(name, library_symbols.get(name)) for name in pinless_symbols
+        )
     elif unchanged:
         message = f"No pins changed: all {unchanged} matching pin(s) already have that type"
+    elif missing_numbers or missing_names:
+        absent = []
+        if missing_numbers:
+            absent.append(f"pin number(s) {', '.join(missing_numbers)}")
+        if missing_names:
+            absent.append(f"pin name(s) {', '.join(missing_names)}")
+        message = f"No pins changed: no {' or '.join(absent)} in the symbols searched"
     else:
         message = "No pins matched the given filters"
 
@@ -304,10 +563,14 @@ def set_symbol_pin_type(params: Dict[str, Any]) -> Dict[str, Any]:
         "message": message,
         "libraryPath": str(lib_path),
         "dryRun": dry_run,
-        "changeCount": len(changes),
+        "changeCount": total_changes,
         "alreadyCorrect": unchanged,
         "symbolsChanged": touched,
+        "backupPath": str(backup_path) if backup_path else None,
         "changes": changes,
+        "changesTruncated": total_changes > len(changes),
         "missingSymbols": missing_symbols,
+        "symbolsWithoutOwnPins": pinless_symbols,
         "missingPinNumbers": missing_numbers,
+        "missingPinNames": missing_names,
     }

--- a/python/commands/set_symbol_pin_type.py
+++ b/python/commands/set_symbol_pin_type.py
@@ -1,0 +1,313 @@
+"""Change the electrical type (and graphic style) of pins in a .kicad_sym library.
+
+The server can read pins (``list_symbol_pins``, ``batch_list_symbol_pins``) but
+had no way to write them, so bulk fixes were done with ``sed`` over the whole
+library file. That is unsafe for three reasons this module addresses:
+
+* A blind substitution rewrites *every* matching pin in the file, including
+  symbols the caller never meant to touch.
+* ``sed`` cannot see which symbol or which pin number it is standing on, so
+  "make only the shield pins passive" is not expressible.
+* Nothing checks the replacement token. KiCad silently refuses to load a
+  library containing an unknown pin type, and the error it reports points at
+  the file, not at the pin.
+
+Imported libraries are the usual reason to need this. Parts converted from
+Eagle or pulled from SnapEDA arrive with every pin marked ``unspecified`` or
+``bidirectional``; ERC then reports conflicts on nets that are electrically
+fine, and the noise hides the real errors.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
+
+from utils.pin_types import PIN_STYLES, PIN_TYPES
+from utils.sexpr_format import match_paren
+
+logger = logging.getLogger("kicad_interface")
+
+_HEAD = re.compile(r"\(\s*([A-Za-z_][\w]*)")
+_PIN_HEAD = re.compile(r"\(pin\s+([A-Za-z_][\w]*)\s+([A-Za-z_][\w]*)")
+
+
+def _read_string(text: str, i: int) -> Tuple[Optional[str], int]:
+    """Read the quoted token starting at or after *i*; return (value, end)."""
+    while i < len(text) and text[i] in " \t\r\n":
+        i += 1
+    if i >= len(text) or text[i] != '"':
+        return None, i
+    out: List[str] = []
+    i += 1
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\" and i + 1 < len(text):
+            out.append(text[i + 1])
+            i += 2
+            continue
+        if ch == '"':
+            return "".join(out), i + 1
+        out.append(ch)
+        i += 1
+    return None, i
+
+
+def _child_string(block: str, key: str) -> Optional[str]:
+    """Value of a direct child list ``(key "value" ...)``, or None.
+
+    Only direct children count: a pin's ``(name ...)`` must not be confused with
+    the ``(name ...)`` of a font or an effects block nested inside it.
+    """
+    depth = 0
+    in_string = False
+    i = 0
+    while i < len(block):
+        ch = block[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            depth += 1
+            if depth == 2:
+                m = _HEAD.match(block, i)
+                if m and m.group(1) == key:
+                    value, _ = _read_string(block, m.end())
+                    if value is not None:
+                        return value
+        elif ch == ")":
+            depth -= 1
+        i += 1
+    return None
+
+
+def iter_library_pins(text: str) -> Iterator[Dict[str, Any]]:
+    """Yield ``{"offset", "symbol", "unit"}`` for every pin in a .kicad_sym.
+
+    ``symbol`` is the top-level symbol the pin belongs to; ``unit`` is the
+    enclosing body sub-symbol (``R_0402_1_1``), which is where pins actually
+    live. Walking with a stack rather than a regex keeps a pin attributed to
+    its own symbol even though the two names differ.
+    """
+    depth = 0
+    in_string = False
+    stack: List[Tuple[int, Optional[str]]] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            i += 1
+            continue
+        if ch == ")":
+            depth -= 1
+            while stack and stack[-1][0] > depth:
+                stack.pop()
+            i += 1
+            continue
+        if ch != "(":
+            i += 1
+            continue
+        depth += 1
+        m = _HEAD.match(text, i)
+        token = m.group(1) if m else ""
+        if token == "symbol" and m:
+            name, _ = _read_string(text, m.end())
+            stack.append((depth, name))
+        elif token == "pin" and stack:
+            yield {"offset": i, "symbol": stack[0][1], "unit": stack[-1][1]}
+        i += 1
+
+
+def _root_token(text: str) -> Optional[str]:
+    m = _HEAD.search(text)
+    return m.group(1) if m else None
+
+
+def _as_set(value: Any) -> Optional[Set[str]]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return {value}
+    return {str(v) for v in value}
+
+
+def set_symbol_pin_type(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Set the electrical type and/or graphic style of pins in a symbol library."""
+    lib_path = Path(params.get("libraryPath", ""))
+    new_type = params.get("type")
+    new_style = params.get("style")
+    dry_run = bool(params.get("dryRun", False))
+
+    if new_type is None and new_style is None:
+        return {
+            "success": False,
+            "message": "Nothing to do: pass type, style, or both",
+        }
+    if new_type is not None and new_type not in PIN_TYPES:
+        return {
+            "success": False,
+            "message": (
+                f"'{new_type}' is not a KiCad pin type. KiCad refuses to load a "
+                f"library containing one it does not know. Valid: {', '.join(PIN_TYPES)}"
+            ),
+            "validTypes": list(PIN_TYPES),
+        }
+    if new_style is not None and new_style not in PIN_STYLES:
+        return {
+            "success": False,
+            "message": (
+                f"'{new_style}' is not a KiCad pin graphic style. "
+                f"Valid: {', '.join(PIN_STYLES)}"
+            ),
+            "validStyles": list(PIN_STYLES),
+        }
+
+    if not lib_path.is_file():
+        return {"success": False, "message": f"Library not found: {lib_path}"}
+
+    try:
+        text = lib_path.read_text(encoding="utf-8")
+    except OSError as e:
+        return {"success": False, "message": f"Could not read {lib_path}: {e}"}
+
+    root = _root_token(text)
+    if root != "kicad_symbol_lib":
+        return {
+            "success": False,
+            "message": (
+                f"{lib_path.name} is not a symbol library "
+                f"(root form is '{root}', expected 'kicad_symbol_lib')"
+            ),
+        }
+
+    want_symbols = _as_set(params.get("symbols"))
+    want_numbers = _as_set(params.get("pinNumbers"))
+    want_names = _as_set(params.get("pinNames"))
+    from_type = params.get("fromType")
+
+    seen_symbols: Set[str] = set()
+    seen_numbers: Set[str] = set()
+    changes: List[Dict[str, Any]] = []
+    edits: List[Tuple[int, int, str]] = []
+    unchanged = 0
+
+    for pin in iter_library_pins(text):
+        symbol = pin["symbol"]
+        if symbol:
+            seen_symbols.add(symbol)
+        if want_symbols is not None and symbol not in want_symbols:
+            continue
+
+        head = _PIN_HEAD.match(text, pin["offset"])
+        if not head:
+            continue
+        cur_type, cur_style = head.group(1), head.group(2)
+
+        end = match_paren(text, pin["offset"])
+        if end == -1:
+            return {
+                "success": False,
+                "message": (
+                    f"Unbalanced parentheses in {lib_path.name}: the pin at offset "
+                    f"{pin['offset']} is never closed. Refusing to write."
+                ),
+            }
+        block = text[pin["offset"] : end + 1]
+        number = _child_string(block, "number") or ""
+        name = _child_string(block, "name") or ""
+
+        if number:
+            seen_numbers.add(number)
+        if want_numbers is not None and number not in want_numbers:
+            continue
+        if want_names is not None and name not in want_names:
+            continue
+        if from_type is not None and cur_type != from_type:
+            continue
+
+        to_type = new_type or cur_type
+        to_style = new_style or cur_style
+        if to_type == cur_type and to_style == cur_style:
+            unchanged += 1
+            continue
+
+        edits.append((head.start(), head.end(), f"(pin {to_type} {to_style}"))
+        changes.append(
+            {
+                "symbol": symbol,
+                "unit": pin["unit"],
+                "number": number,
+                "name": name,
+                "fromType": cur_type,
+                "toType": to_type,
+                "fromStyle": cur_style,
+                "toStyle": to_style,
+            }
+        )
+
+    missing_symbols = sorted(want_symbols - seen_symbols) if want_symbols else []
+    missing_numbers = sorted(want_numbers - seen_numbers) if want_numbers else []
+
+    if edits and not dry_run:
+        updated = text
+        for start, stop, replacement in reversed(edits):
+            updated = updated[:start] + replacement + updated[stop:]
+        if updated.count("(") != text.count("(") or updated.count(")") != text.count(")"):
+            return {
+                "success": False,
+                "message": "Internal error: the edit changed the file structure. Nothing written.",
+            }
+        try:
+            lib_path.write_text(updated, encoding="utf-8")
+        except OSError as e:
+            return {"success": False, "message": f"Could not write {lib_path}: {e}"}
+
+        # The file is already on disk, so a cache that refuses to clear must not
+        # turn a successful write into a reported failure -- the caller would
+        # retry an edit that has in fact happened.
+        try:
+            from commands.symbol_creator import _invalidate_symbol_caches
+
+            _invalidate_symbol_caches()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Symbol caches not invalidated after pin edit: %s", e)
+
+    touched = sorted({c["symbol"] for c in changes if c["symbol"]})
+    if changes:
+        verb = "Would change" if dry_run else "Changed"
+        message = f"{verb} {len(changes)} pin(s) across {len(touched)} symbol(s)"
+    elif missing_symbols:
+        message = f"No pins changed: symbol(s) not in this library: {', '.join(missing_symbols)}"
+    elif unchanged:
+        message = f"No pins changed: all {unchanged} matching pin(s) already have that type"
+    else:
+        message = "No pins matched the given filters"
+
+    return {
+        "success": True,
+        "message": message,
+        "libraryPath": str(lib_path),
+        "dryRun": dry_run,
+        "changeCount": len(changes),
+        "alreadyCorrect": unchanged,
+        "symbolsChanged": touched,
+        "changes": changes,
+        "missingSymbols": missing_symbols,
+        "missingPinNumbers": missing_numbers,
+    }

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -352,6 +352,7 @@ try:
     from commands.schematic_field_layout import SchematicFieldLayoutCommands
     from commands.schematic_hierarchy import SchematicHierarchyCommands
     from commands.schematic_lint import SchematicLintCommands
+    from commands.set_symbol_pin_type import set_symbol_pin_type
     from commands.symbol_creator import SymbolCreator
     from commands.symbol_pins import SymbolPinCommands
     from commands.symbol_repair import SymbolRepairCommands
@@ -557,6 +558,7 @@ class KiCADInterface(SchematicHandlersMixin):
             # Symbol pin discovery commands (read pins straight from symbol libraries)
             "list_symbol_pins": self.symbol_pin_commands.list_symbol_pins,
             "batch_list_symbol_pins": self.symbol_pin_commands.batch_list_symbol_pins,
+            "set_symbol_pin_type": set_symbol_pin_type,
             "repair_flat_symbols": self.symbol_repair_commands.repair_flat_symbols,
             # Schematic hierarchy commands (sheet insertion + subsheet scaffolding)
             "add_hierarchical_sheet": self.hierarchy_commands.add_hierarchical_sheet,

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -12,6 +12,8 @@ Each tool includes:
 
 from typing import Any, Dict
 
+from utils.pin_types import PIN_STYLES, PIN_TYPES
+
 # =============================================================================
 # PROJECT TOOLS
 # =============================================================================
@@ -2977,6 +2979,68 @@ SCHEMATIC_TOOLS = [
                 "hide": {"type": "boolean", "default": False},
             },
             "required": ["libraryPath", "symbolName", "propertyName", "propertyValue"],
+        },
+    },
+    {
+        "name": "set_symbol_pin_type",
+        "title": "Set Pin Electrical Type in Symbol Library",
+        "description": (
+            "Set the electrical type (and optionally the graphic style) of pins in a "
+            ".kicad_sym library, filtered by symbol, pin number, pin name, or current type. "
+            "Use instead of a sed/regex pass over the library: a blind substitution also "
+            "rewrites matching words inside symbol names, Descriptions and (alternate ...) "
+            "pin functions, and cannot tell which symbol it is standing on. The replacement "
+            "token is validated first -- KiCAD refuses to load a library containing a pin "
+            "type it does not know. Typical use: imported or SnapEDA symbols arrive with "
+            "every pin 'unspecified' or 'bidirectional', flooding ERC with conflicts on nets "
+            "that are electrically fine."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "libraryPath": {"type": "string", "description": "Path to the .kicad_sym file"},
+                "type": {
+                    "type": "string",
+                    "enum": list(PIN_TYPES),
+                    "description": "New electrical type",
+                },
+                "style": {
+                    "type": "string",
+                    "enum": list(PIN_STYLES),
+                    "description": "New graphic style",
+                },
+                "symbols": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Top-level symbol names to change (not unit names like "
+                        "'R_0402_1_1'). Omit to change every symbol in the library."
+                    ),
+                },
+                "pinNumbers": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Only pins with these numbers",
+                },
+                "pinNames": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Only pins with these names",
+                },
+                "fromType": {
+                    "type": "string",
+                    "enum": list(PIN_TYPES),
+                    "description": (
+                        "Only pins currently of this type -- the safe way to do a bulk fix"
+                    ),
+                },
+                "dryRun": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Report what would change without writing",
+                },
+            },
+            "required": ["libraryPath"],
         },
     },
     {

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -2993,7 +2993,11 @@ SCHEMATIC_TOOLS = [
             "token is validated first -- KiCAD refuses to load a library containing a pin "
             "type it does not know. Typical use: imported or SnapEDA symbols arrive with "
             "every pin 'unspecified' or 'bidirectional', flooding ERC with conflicts on nets "
-            "that are electrically fine."
+            "that are electrically fine. The library is replaced atomically, keeps its "
+            "existing line endings, and is copied to a sibling '.mcp-backups/' first "
+            "(path returned in 'backupPath'). 'changes' lists at most 200 per-pin records "
+            "with 'changesTruncated' saying when it was cut; 'changeCount' always carries "
+            "the true total."
         ),
         "inputSchema": {
             "type": "object",

--- a/python/utils/pin_types.py
+++ b/python/utils/pin_types.py
@@ -1,0 +1,34 @@
+"""KiCad pin electrical types and graphic styles, as written in .kicad_sym.
+
+Kept in a dependency-free module so both the tool schema and the command that
+writes pins read the same list. KiCad refuses to load a library containing a
+token outside these sets, and the error it reports names the file rather than
+the pin, so the check has to happen before the write.
+"""
+
+PIN_TYPES = (
+    "input",
+    "output",
+    "bidirectional",
+    "tri_state",
+    "passive",
+    "free",
+    "unspecified",
+    "power_in",
+    "power_out",
+    "open_collector",
+    "open_emitter",
+    "no_connect",
+)
+
+PIN_STYLES = (
+    "line",
+    "inverted",
+    "clock",
+    "inverted_clock",
+    "input_low",
+    "clock_low",
+    "output_low",
+    "edge_clock_high",
+    "non_logic",
+)

--- a/python/utils/sexpr_format.py
+++ b/python/utils/sexpr_format.py
@@ -76,6 +76,77 @@ QUOTED_VALUE = r'"((?:[^"\\]|\\.)*)"'
 QUOTED_VALUE_SKIP = r'"(?:[^"\\]|\\.)*"'
 
 
+# ---------------------------------------------------------------------------
+# String-aware structure walking
+# ---------------------------------------------------------------------------
+#
+# Tools that edit KiCad files as text need to know where a list ends without
+# re-serializing the file. Counting parens is not enough: a Description of
+# ``"Ceramic (X7R) 50V"`` or a footprint named ``HRS_U.FL-R-SMT-1(10)`` puts
+# unbalanced parens inside quoted tokens, and real libraries contain both.
+#
+# These two helpers skip quoted text, so callers can slice a block out of a
+# file and splice a new one back without a parser.
+
+
+def match_paren(content: str, open_idx: int) -> int:
+    """Index of the ``)`` closing the ``(`` at *open_idx*, or -1 if unbalanced.
+
+    Parens inside quoted tokens are literal text, not structure.
+    """
+    depth = 0
+    in_string = False
+    i = open_idx
+    while i < len(content):
+        ch = content[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def iter_child_offsets(block: str, depth: int = 2):
+    """Yield the offset of every list nested *depth* levels inside *block*.
+
+    *block* starts at its own ``(``, which is depth 1, so the default yields
+    its direct children. Depth is counted structurally rather than from
+    indentation: KiCad's own writers emit files whose indentation does not
+    always match nesting.
+    """
+    current = 0
+    in_string = False
+    i = 0
+    while i < len(block):
+        ch = block[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            current += 1
+            if current == depth:
+                yield i
+        elif ch == ")":
+            current -= 1
+        i += 1
+
+
 def escape_sexpr_string(value: str) -> str:
     """Escape a string for insertion into a KiCad double-quoted token.
 

--- a/src/tools/library-symbol.ts
+++ b/src/tools/library-symbol.ts
@@ -6,6 +6,37 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+// KiCAD's pin electrical types and graphic styles, mirroring
+// python/utils/pin_types.py (and the enums python/schemas/tool_schemas.py
+// declares). Kept as z.enum rather than z.string so a client rejects a bad
+// token locally instead of learning about it from a round trip.
+const PIN_TYPES = [
+  "input",
+  "output",
+  "bidirectional",
+  "tri_state",
+  "passive",
+  "free",
+  "unspecified",
+  "power_in",
+  "power_out",
+  "open_collector",
+  "open_emitter",
+  "no_connect",
+] as const;
+
+const PIN_STYLES = [
+  "line",
+  "inverted",
+  "clock",
+  "inverted_clock",
+  "input_low",
+  "clock_low",
+  "output_low",
+  "edge_clock_high",
+  "non_logic",
+] as const;
+
 export function registerSymbolLibraryTools(server: McpServer, callKicadScript: Function) {
   // List available symbol libraries
   server.tool(
@@ -373,23 +404,14 @@ Returns symbol references that can be used directly in schematics.`,
       "KiCAD's pin types first — an unknown one makes the whole library fail to load. " +
       "Typical use: imported or SnapEDA symbols arrive with every pin 'unspecified' or " +
       "'bidirectional', which floods ERC with conflicts on nets that are electrically fine. " +
-      "Run with dryRun first to see what matches.",
+      "Run with dryRun first to see what matches. The library is replaced atomically, keeps " +
+      "its existing line endings, and is copied to a sibling '.mcp-backups/' first (path " +
+      "returned in 'backupPath'). 'changes' lists at most 200 per-pin records, with " +
+      "'changesTruncated' saying when it was cut; 'changeCount' always carries the true total.",
     {
       libraryPath: z.string().describe("Absolute path to the .kicad_sym library file"),
-      type: z
-        .string()
-        .optional()
-        .describe(
-          "New electrical type: input, output, bidirectional, tri_state, passive, free, " +
-            "unspecified, power_in, power_out, open_collector, open_emitter, no_connect",
-        ),
-      style: z
-        .string()
-        .optional()
-        .describe(
-          "New graphic style: line, inverted, clock, inverted_clock, input_low, clock_low, " +
-            "output_low, edge_clock_high, non_logic",
-        ),
+      type: z.enum(PIN_TYPES).optional().describe("New electrical type"),
+      style: z.enum(PIN_STYLES).optional().describe("New graphic style"),
       symbols: z
         .array(z.string())
         .optional()
@@ -400,21 +422,12 @@ Returns symbol references that can be used directly in schematics.`,
       pinNumbers: z.array(z.string()).optional().describe("Only pins with these numbers"),
       pinNames: z.array(z.string()).optional().describe("Only pins with these names"),
       fromType: z
-        .string()
+        .enum(PIN_TYPES)
         .optional()
         .describe("Only pins currently of this electrical type — the safe way to do a bulk fix"),
       dryRun: z.boolean().optional().describe("Report what would change without writing"),
     },
-    async (args: {
-      libraryPath: string;
-      type?: string;
-      style?: string;
-      symbols?: string[];
-      pinNumbers?: string[];
-      pinNames?: string[];
-      fromType?: string;
-      dryRun?: boolean;
-    }) => {
+    async (args) => {
       const result = await callKicadScript("set_symbol_pin_type", args);
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/src/tools/library-symbol.ts
+++ b/src/tools/library-symbol.ts
@@ -361,4 +361,64 @@ Returns symbol references that can be used directly in schematics.`,
       };
     },
   );
+
+  // Change pin electrical types in a .kicad_sym library
+  server.tool(
+    "set_symbol_pin_type",
+    "Set the electrical type (and optionally the graphic style) of pins in a .kicad_sym " +
+      "library, filtered by symbol, pin number, pin name, or current type. Use this instead " +
+      "of a sed/regex pass over the library: a blind substitution also rewrites matching " +
+      "words inside symbol names, Descriptions and (alternate ...) pin functions, and it " +
+      "cannot tell which symbol it is standing on. The replacement token is checked against " +
+      "KiCAD's pin types first — an unknown one makes the whole library fail to load. " +
+      "Typical use: imported or SnapEDA symbols arrive with every pin 'unspecified' or " +
+      "'bidirectional', which floods ERC with conflicts on nets that are electrically fine. " +
+      "Run with dryRun first to see what matches.",
+    {
+      libraryPath: z.string().describe("Absolute path to the .kicad_sym library file"),
+      type: z
+        .string()
+        .optional()
+        .describe(
+          "New electrical type: input, output, bidirectional, tri_state, passive, free, " +
+            "unspecified, power_in, power_out, open_collector, open_emitter, no_connect",
+        ),
+      style: z
+        .string()
+        .optional()
+        .describe(
+          "New graphic style: line, inverted, clock, inverted_clock, input_low, clock_low, " +
+            "output_low, edge_clock_high, non_logic",
+        ),
+      symbols: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Top-level symbol names to change (not unit names like 'R_0402_1_1'). " +
+            "Omit to change every symbol in the library.",
+        ),
+      pinNumbers: z.array(z.string()).optional().describe("Only pins with these numbers"),
+      pinNames: z.array(z.string()).optional().describe("Only pins with these names"),
+      fromType: z
+        .string()
+        .optional()
+        .describe("Only pins currently of this electrical type — the safe way to do a bulk fix"),
+      dryRun: z.boolean().optional().describe("Report what would change without writing"),
+    },
+    async (args: {
+      libraryPath: string;
+      type?: string;
+      style?: string;
+      symbols?: string[];
+      pinNumbers?: string[];
+      pinNames?: string[];
+      fromType?: string;
+      dryRun?: boolean;
+    }) => {
+      const result = await callKicadScript("set_symbol_pin_type", args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -161,8 +161,9 @@ export const toolCategories: ToolCategory[] = [
   },
   {
     name: "symbol_pins",
-    description: "Read a symbol's pins straight from the library (no schematic needed)",
-    tools: ["list_symbol_pins", "batch_list_symbol_pins"],
+    description:
+      "Read a symbol's pins straight from the library (no schematic needed), and set their electrical types",
+    tools: ["list_symbol_pins", "batch_list_symbol_pins", "set_symbol_pin_type"],
   },
   {
     name: "schematic_hierarchy",

--- a/tests/test_set_symbol_pin_type.py
+++ b/tests/test_set_symbol_pin_type.py
@@ -1,13 +1,27 @@
 """Tests for set_symbol_pin_type — bulk pin electrical-type edits in .kicad_sym."""
 
+import builtins
+import io
+import os
+import shutil
 import sys
+import time
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+import commands.set_symbol_pin_type as pin_type_module  # noqa: E402
 from commands.set_symbol_pin_type import (  # noqa: E402
+    _BACKUP_KEEP,
+    _MAX_REPORTED_CHANGES,
+    _PIN_HEAD,
+    _edits_landed,
+    _pin_structure,
+    _prune_backups,
+    _splice,
     iter_library_pins,
+    iter_library_symbols,
     set_symbol_pin_type,
 )
 
@@ -326,6 +340,470 @@ def test_dry_run_reports_without_writing(lib):
     assert r["changeCount"] == 7
     assert "Would change" in r["message"]
     assert lib.read_text(encoding="utf-8") == before
+
+
+# --- line endings ---------------------------------------------------------- #
+#
+# These read and write raw bytes on purpose. A test that writes with write_text
+# and reads back with read_text cannot see a newline bug at all: both sides get
+# the same platform translation, so the assertion passes on a file that has had
+# every line ending rewritten.
+
+
+@pytest.fixture
+def lf_lib(tmp_path):
+    path = tmp_path / "lf.kicad_sym"
+    path.write_bytes(LIB.encode("utf-8"))
+    return path
+
+
+@pytest.fixture
+def crlf_lib(tmp_path):
+    path = tmp_path / "crlf.kicad_sym"
+    path.write_bytes(LIB.replace("\n", "\r\n").encode("utf-8"))
+    return path
+
+
+def test_an_lf_library_is_not_converted_to_crlf(lf_lib):
+    """On Windows a pathlib default write turns every line ending into CRLF."""
+    r = run(lf_lib, symbols=["SHIELD_CAN"], type="passive")
+    assert r["changeCount"] == 3
+    raw = lf_lib.read_bytes()
+    assert b"\r\n" not in raw
+
+
+def test_a_crlf_library_is_not_converted_to_lf(crlf_lib):
+    before = crlf_lib.read_bytes()
+    r = run(crlf_lib, symbols=["SHIELD_CAN"], type="passive")
+    assert r["changeCount"] == 3
+    raw = crlf_lib.read_bytes()
+    assert raw.count(b"\r\n") == before.count(b"\r\n")
+    assert b"(pin passive line" in raw
+
+
+def test_a_three_pin_edit_touches_only_three_lines(lf_lib):
+    """The point of preserving newlines: the diff stays the size of the edit."""
+    before = lf_lib.read_bytes().split(b"\n")
+    run(lf_lib, symbols=["SHIELD_CAN"], type="passive")
+    after = lf_lib.read_bytes().split(b"\n")
+    assert len(before) == len(after)
+    differing = [i for i, (a, b) in enumerate(zip(before, after)) if a != b]
+    assert len(differing) == 3
+    assert all(b"(pin passive line" in after[i] for i in differing)
+
+
+def test_a_second_pass_over_an_lf_library_is_byte_identical(lf_lib):
+    """Idempotency at the byte level, not just at the pin-type level."""
+    run(lf_lib, type="passive")
+    once = lf_lib.read_bytes()
+    r = run(lf_lib, type="passive")
+    assert r["changeCount"] == 0
+    assert r["alreadyCorrect"] == 7
+    assert lf_lib.read_bytes() == once
+
+
+# --- the write is atomic --------------------------------------------------- #
+
+
+def test_a_failed_write_leaves_the_library_intact(lib, monkeypatch):
+    """A truncating write empties the library before it can fail; this must not."""
+    before = lib.read_bytes()
+
+    def refuse(src, dst):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(os, "replace", refuse)
+    r = run(lib, type="passive")
+    assert not r["success"]
+    assert "unchanged" in r["message"]
+    assert lib.read_bytes() == before
+
+
+class _FailingWrite:
+    """A real file handle -- so a real truncation happens -- that cannot write."""
+
+    def __init__(self, fh):
+        self._fh = fh
+
+    def write(self, data):
+        raise OSError(28, "No space left on device")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self._fh.close()
+        return False
+
+
+def test_no_write_failure_can_truncate_the_library(lib, monkeypatch):
+    """Injected at the file layer, so it holds however the write is implemented.
+
+    Opening the library itself for writing truncates it at open time, leaving
+    nothing to restore when the write then fails -- the failure that reports
+    "could not write" about a file it has already emptied.
+    """
+    before = lib.read_bytes()
+    real_open = io.open
+
+    def opener(file, mode="r", *args, **kwargs):
+        fh = real_open(file, mode, *args, **kwargs)
+        return _FailingWrite(fh) if "w" in mode else fh
+
+    monkeypatch.setattr(io, "open", opener)
+    monkeypatch.setattr(builtins, "open", opener)
+    r = run(lib, type="passive")
+    monkeypatch.undo()
+
+    assert not r["success"]
+    assert lib.read_bytes() == before
+
+
+def scratch_files(lib):
+    """Anything left beside the library that is not the library or a backup."""
+    return sorted(p.name for p in lib.parent.iterdir() if p.name not in (lib.name, ".mcp-backups"))
+
+
+def test_a_failed_write_leaves_no_temporary_file(lib, monkeypatch):
+    def refuse(src, dst):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(os, "replace", refuse)
+    run(lib, type="passive")
+    assert scratch_files(lib) == []
+
+
+def test_a_successful_write_leaves_no_temporary_file(lib):
+    run(lib, type="passive")
+    assert scratch_files(lib) == []
+
+
+# --- the library is copied before it is rewritten -------------------------- #
+#
+# Atomicity and the backup cover different failures: the rename means a crash
+# cannot truncate the library, but an edit that succeeds and was not what the
+# caller meant -- omitting `symbols`, so every pin in the library is flattened
+# -- is exactly what this tool makes easy, and it needs an undo.
+
+
+def backups(lib):
+    return sorted((lib.parent / ".mcp-backups").iterdir())
+
+
+def test_the_library_is_copied_to_mcp_backups_before_editing(lib):
+    before = lib.read_bytes()
+    r = run(lib, type="passive")
+    assert r["changeCount"] == 7
+    copies = backups(lib)
+    assert len(copies) == 1
+    assert copies[0].name.startswith("test.kicad_sym.")
+    assert copies[0].read_bytes() == before
+    assert lib.read_bytes() != before
+
+
+def test_the_backup_path_is_reported(lib):
+    r = run(lib, type="passive")
+    assert r["backupPath"] == str(backups(lib)[0])
+
+
+def test_a_dry_run_writes_no_backup(lib):
+    r = run(lib, type="passive", dryRun=True)
+    assert r["changeCount"] == 7
+    assert r["backupPath"] is None
+    assert not (lib.parent / ".mcp-backups").exists()
+
+
+def test_no_backup_is_written_when_nothing_changes(lib):
+    run(lib, type="passive")
+    assert len(backups(lib)) == 1
+    r = run(lib, type="passive")
+    assert r["changeCount"] == 0
+    assert r["backupPath"] is None
+    assert len(backups(lib)) == 1
+
+
+def test_a_failed_backup_does_not_block_the_edit(lib, monkeypatch):
+    """A read-only library directory must not make the library uneditable."""
+
+    def refuse(src, dst):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(shutil, "copy2", refuse)
+    r = run(lib, type="passive")
+    assert r["success"]
+    assert r["changeCount"] == 7
+    assert r["backupPath"] is None
+    assert types_in(lib) == [("passive", "line")] * 7
+
+
+def test_backups_rotate(tmp_path):
+    """Repeated bulk edits must not fill the directory with copies."""
+    backup_dir = tmp_path / ".mcp-backups"
+    backup_dir.mkdir()
+    for i in range(_BACKUP_KEEP + 5):
+        (backup_dir / f"x.kicad_sym.{i:04d}").write_text("old", encoding="utf-8")
+    (backup_dir / "other.kicad_sym.0001").write_text("keep", encoding="utf-8")
+
+    _prune_backups(backup_dir, "x.kicad_sym")
+
+    remaining = sorted(p.name for p in backup_dir.iterdir())
+    assert "other.kicad_sym.0001" in remaining
+    assert len([n for n in remaining if n.startswith("x.kicad_sym.")]) == _BACKUP_KEEP
+
+
+# --- fromType is validated like type --------------------------------------- #
+
+
+def test_a_misspelled_from_type_is_refused(lib):
+    """Two transposed letters must not be a silent success that changes nothing."""
+    before = lib.read_bytes()
+    r = run(lib, fromType="unspecfied", type="passive")
+    assert not r["success"]
+    assert "not a KiCad pin type" in r["message"]
+    assert "unspecified" in r["validTypes"]
+    assert lib.read_bytes() == before
+
+
+def test_a_valid_from_type_is_still_accepted(lib):
+    r = run(lib, fromType="unspecified", type="passive")
+    assert r["success"]
+    assert r["changeCount"] == 3
+
+
+# --- derived symbols ------------------------------------------------------- #
+
+DERIVED_LIB = (
+    '(kicad_symbol_lib\n\t(version 20241209)\n\t(generator "kicad_symbol_editor")\n'
+    + symbol("R_Small", [("R_Small_0_1", [pin(1, "~"), pin(2, "~")])])
+    # A derived symbol: no pins of its own, they come from R_Small.
+    + '\t(symbol "R_Small_US"\n'
+    + '\t\t(extends "R_Small")\n'
+    + '\t\t(property "Reference" "R"\n\t\t\t(at 0 0 0)\n\t\t)\n'
+    + "\t)\n"
+    # A graphics-only symbol: pinless, but inherits from nothing.
+    + '\t(symbol "LOGO"\n'
+    + '\t\t(symbol "LOGO_0_1"\n'
+    + "\t\t\t(rectangle\n\t\t\t\t(start 0 0)\n\t\t\t\t(end 1 1)\n\t\t\t)\n"
+    + "\t\t)\n"
+    + "\t)\n"
+    + ")\n"
+)
+
+
+@pytest.fixture
+def derived_lib(tmp_path):
+    path = tmp_path / "derived.kicad_sym"
+    path.write_bytes(DERIVED_LIB.encode("utf-8"))
+    return path
+
+
+def test_top_level_symbols_are_found_structurally_not_from_pins():
+    found = {s["name"]: s["extends"] for s in iter_library_symbols(DERIVED_LIB)}
+    assert found == {"R_Small": None, "R_Small_US": "R_Small", "LOGO": None}
+
+
+def test_a_derived_symbol_is_not_reported_as_a_missing_symbol(derived_lib):
+    """It has no pins by design, so learning names from pins calls it a typo."""
+    r = run(derived_lib, symbols=["R_Small_US"], type="passive")
+    assert r["missingSymbols"] == []
+    assert r["symbolsWithoutOwnPins"] == ["R_Small_US"]
+    assert "extends R_Small" in r["message"]
+    assert "not in this library" not in r["message"]
+
+
+def test_a_pinless_symbol_that_extends_nothing_is_distinguished(derived_lib):
+    r = run(derived_lib, symbols=["LOGO"], type="passive")
+    assert r["missingSymbols"] == []
+    assert r["symbolsWithoutOwnPins"] == ["LOGO"]
+    assert "extends" not in r["message"]
+
+
+def test_a_name_absent_from_the_library_is_still_reported_missing(derived_lib):
+    """The distinction only helps if a real typo still reads as a typo."""
+    r = run(derived_lib, symbols=["R_Smalll_US"], type="passive")
+    assert r["missingSymbols"] == ["R_Smalll_US"]
+    assert r["symbolsWithoutOwnPins"] == []
+    assert "not in this library" in r["message"]
+
+
+def test_the_parent_of_a_derived_symbol_is_editable(derived_lib):
+    r = run(derived_lib, symbols=["R_Small"], type="passive")
+    assert r["changeCount"] == 2
+    assert r["symbolsWithoutOwnPins"] == []
+
+
+# --- missing pin names ----------------------------------------------------- #
+
+
+def test_a_misspelled_pin_name_is_reported(lib):
+    """Names are free-form strings, so they are the likeliest thing to mistype."""
+    r = run(lib, pinNames=["NOSUCHPIN"], type="passive")
+    assert r["changeCount"] == 0
+    assert r["missingPinNames"] == ["NOSUCHPIN"]
+    assert "NOSUCHPIN" in r["message"]
+
+
+def test_only_the_absent_pin_name_is_reported(lib):
+    r = run(lib, pinNames=["IN-", "VDDA"], type="passive")
+    assert r["changeCount"] == 1
+    assert r["missingPinNames"] == ["VDDA"]
+
+
+def test_a_matched_pin_name_reports_nothing_missing(lib):
+    r = run(lib, pinNames=["SH1"], type="passive")
+    assert r["missingPinNames"] == []
+
+
+# --- the response is bounded ----------------------------------------------- #
+
+
+def big_lib(symbols, pins_per_symbol):
+    body = ""
+    for s in range(symbols):
+        entries = [pin(n, f"P{n}") for n in range(1, pins_per_symbol + 1)]
+        body += symbol(f"IC{s}", [(f"IC{s}_1_1", entries)])
+    return "(kicad_symbol_lib\n\t(version 20241209)\n" + body + ")\n"
+
+
+def test_a_bulk_pass_caps_the_per_pin_change_list(tmp_path):
+    """This is an MCP tool: the response is spent from the caller's context."""
+    path = tmp_path / "big.kicad_sym"
+    path.write_bytes(big_lib(3, 100).encode("utf-8"))
+    r = set_symbol_pin_type({"libraryPath": str(path), "type": "passive"})
+    assert r["changeCount"] == 300
+    assert len(r["changes"]) == _MAX_REPORTED_CHANGES
+    assert r["changesTruncated"] is True
+
+
+def test_the_symbol_summary_survives_truncation(tmp_path):
+    """symbolsChanged plus the counts are what the caller normally needs."""
+    path = tmp_path / "big.kicad_sym"
+    path.write_bytes(big_lib(3, 100).encode("utf-8"))
+    r = set_symbol_pin_type({"libraryPath": str(path), "type": "passive"})
+    assert r["symbolsChanged"] == ["IC0", "IC1", "IC2"]
+    assert types_in(path) == [("passive", "line")] * 300
+
+
+def test_an_edit_below_the_cap_is_not_truncated(lib):
+    r = run(lib, type="passive")
+    assert r["changeCount"] == 7
+    assert len(r["changes"]) == 7
+    assert r["changesTruncated"] is False
+
+
+# --- the post-write structural check --------------------------------------- #
+#
+# A paren count cannot detect either of these: the tool's replacement never
+# contains a paren, and moving one leaves the counts equal.
+
+
+def test_a_misplaced_paren_changes_the_pin_structure():
+    """Swapping a ')' with the '(' after it leaves both counts equal."""
+    broken = LIB.replace(
+        "\t\t\t)\n\t\t\t(pin unspecified line",
+        "\t\t\t(\n\t\t\t)pin unspecified line",
+        1,
+    )
+    assert broken != LIB
+    assert broken.count("(") == LIB.count("(")
+    assert broken.count(")") == LIB.count(")")
+    assert _pin_structure(broken) != _pin_structure(LIB)
+
+
+def test_splicing_in_the_wrong_order_is_detected():
+    """Applied front-to-back the offsets slide under each other."""
+    edits = [
+        (m["offset"], m["offset"] + len("(pin unspecified line"), "(pin passive line")
+        for m in iter_library_pins(LIB)
+        if LIB.startswith("(pin unspecified line", m["offset"])
+    ]
+    assert len(edits) == 3
+
+    forward = LIB
+    for start, stop, replacement in edits:
+        forward = forward[:start] + replacement + forward[stop:]
+    assert not _edits_landed(forward, edits)
+
+    backward = LIB
+    for start, stop, replacement in reversed(edits):
+        backward = backward[:start] + replacement + backward[stop:]
+    assert _edits_landed(backward, edits)
+
+
+def test_splicing_once_matches_a_naive_per_edit_rewrite():
+    """The fast path must produce exactly what slicing per edit produced."""
+    edits = [
+        (m["offset"], m["offset"] + len("(pin unspecified line"), "(pin passive line")
+        for m in iter_library_pins(LIB)
+        if LIB.startswith("(pin unspecified line", m["offset"])
+    ]
+    naive = LIB
+    for start, stop, replacement in reversed(edits):
+        naive = naive[:start] + replacement + naive[stop:]
+    assert _splice(LIB, edits) == naive
+
+
+def test_the_file_is_not_recopied_once_per_edit():
+    """``text[:start] + new + text[stop:]`` per edit costs pins times file size.
+
+    On KiCad's own 16 MB MCU_ST_STM32H7 (28191 pins) that is ~440 GB of copying
+    and a 169 s call, on precisely the bulk edit this tool exists for. The
+    fixture below is the same shape at a size a test can afford: ~2.5 MB and
+    12000 pins, which takes a few milliseconds spliced once and ~12 seconds
+    spliced per edit.
+    """
+    text = big_lib(300, 40)
+    edits = [(m.start(), m.end(), "(pin passive line") for m in _PIN_HEAD.finditer(text)]
+    assert len(edits) == 12000
+
+    started = time.perf_counter()
+    updated = _splice(text, edits)
+    elapsed = time.perf_counter() - started
+
+    assert _edits_landed(updated, edits)
+    assert updated.count("(pin passive line") == 12000
+    assert elapsed < 2.0, f"splicing {len(edits)} edits took {elapsed:.1f}s"
+
+
+def test_a_corrupted_splice_is_refused_and_nothing_is_written(lib, monkeypatch):
+    """The check is live, and it refuses before the library is touched at all.
+
+    Splicing the file in one pass requires the offsets to arrive in ascending
+    order; fed them backwards, the replacements land in neighbouring tokens.
+    """
+    before = lib.read_bytes()
+    ascending = pin_type_module.iter_library_pins
+    monkeypatch.setattr(
+        pin_type_module,
+        "iter_library_pins",
+        lambda text: iter(list(ascending(text))[::-1]),
+    )
+    r = run(lib, type="passive")
+    monkeypatch.undo()
+
+    assert not r["success"]
+    assert "changed the file structure" in r["message"]
+    assert lib.read_bytes() == before
+    assert not (lib.parent / ".mcp-backups").exists()
+
+
+# --- pin heads that are not pretty-printed --------------------------------- #
+
+
+def test_a_space_after_the_open_paren_is_still_a_pin(tmp_path):
+    """Silently dropping it is worse than either editing it or refusing to."""
+    text = (
+        "(kicad_symbol_lib\n"
+        '\t(symbol "IC"\n\t\t(symbol "IC_1_1"\n'
+        '\t\t\t( pin unspecified line (at 0 0 0) (name "A") (number "1"))\n'
+        "\t\t)\n\t)\n)\n"
+    )
+    path = tmp_path / "x.kicad_sym"
+    path.write_bytes(text.encode("utf-8"))
+    r = set_symbol_pin_type({"libraryPath": str(path), "type": "passive"})
+    assert r["changeCount"] == 1
+    assert r["changes"][0]["number"] == "1"
+    assert "(pin passive line (at 0 0 0)" in path.read_text(encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/tests/test_set_symbol_pin_type.py
+++ b/tests/test_set_symbol_pin_type.py
@@ -1,0 +1,332 @@
+"""Tests for set_symbol_pin_type — bulk pin electrical-type edits in .kicad_sym."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+from commands.set_symbol_pin_type import (  # noqa: E402
+    iter_library_pins,
+    set_symbol_pin_type,
+)
+
+
+def pin(number, name, ptype="unspecified", style="line", extra=""):
+    return f"""\t\t\t(pin {ptype} {style}
+\t\t\t\t(at 0 {number}.0 0)
+\t\t\t\t(length 2.54)
+\t\t\t\t(name "{name}"
+\t\t\t\t\t(effects
+\t\t\t\t\t\t(font
+\t\t\t\t\t\t\t(size 1.27 1.27)
+\t\t\t\t\t\t)
+\t\t\t\t\t)
+\t\t\t\t)
+\t\t\t\t(number "{number}"
+\t\t\t\t\t(effects
+\t\t\t\t\t\t(font
+\t\t\t\t\t\t\t(size 1.27 1.27)
+\t\t\t\t\t\t)
+\t\t\t\t\t)
+\t\t\t\t)
+{extra}\t\t\t)
+"""
+
+
+def symbol(name, units):
+    body = ""
+    for unit_name, pins in units:
+        body += f'\t\t(symbol "{unit_name}"\n' + "".join(pins) + "\t\t)\n"
+    return (
+        f'\t(symbol "{name}"\n'
+        "\t\t(pin_numbers hide)\n"
+        "\t\t(pin_names\n\t\t\t(offset 0.254)\n\t\t)\n"
+        f'\t\t(property "Reference" "U"\n\t\t\t(at 0 0 0)\n\t\t)\n'
+        f"{body}\t)\n"
+    )
+
+
+LIB = (
+    '(kicad_symbol_lib\n\t(version 20241209)\n\t(generator "kicad_symbol_editor")\n'
+    + symbol(
+        "SHIELD_CAN",
+        [("SHIELD_CAN_1_1", [pin(1, "SH1"), pin(2, "SH2"), pin(3, "SH3")])],
+    )
+    + symbol(
+        "OPAMP_DUAL",
+        [
+            ("OPAMP_DUAL_1_1", [pin(1, "OUT", "output"), pin(2, "IN-", "input")]),
+            ("OPAMP_DUAL_2_1", [pin(5, "OUT2", "output"), pin(6, "IN2-", "input")]),
+        ],
+    )
+    + ")\n"
+)
+
+
+@pytest.fixture
+def lib(tmp_path):
+    path = tmp_path / "test.kicad_sym"
+    path.write_text(LIB, encoding="utf-8")
+    return path
+
+
+def run(lib, **kw):
+    return set_symbol_pin_type({"libraryPath": str(lib), **kw})
+
+
+def types_in(lib):
+    """Every pin head in file order, as (type, style)."""
+    text = lib.read_text(encoding="utf-8")
+    out = []
+    for p in iter_library_pins(text):
+        head = text[p["offset"] : p["offset"] + 40].split("\n")[0]
+        out.append(tuple(head.replace("(pin ", "").split()[:2]))
+    return out
+
+
+# --- walking --------------------------------------------------------------- #
+
+
+def test_pins_are_attributed_to_their_top_level_symbol():
+    found = list(iter_library_pins(LIB))
+    assert {p["symbol"] for p in found} == {"SHIELD_CAN", "OPAMP_DUAL"}
+    assert len(found) == 7
+
+
+def test_unit_sub_symbol_is_reported_separately():
+    units = {p["unit"] for p in iter_library_pins(LIB) if p["symbol"] == "OPAMP_DUAL"}
+    assert units == {"OPAMP_DUAL_1_1", "OPAMP_DUAL_2_1"}
+
+
+def test_pin_names_and_pin_numbers_settings_are_not_pins():
+    """(pin_names ...) and (pin_numbers hide) share a prefix with (pin ...)."""
+    assert all(p["unit"] is not None for p in iter_library_pins(LIB))
+    assert len(list(iter_library_pins(LIB))) == 7
+
+
+# --- the basic edit -------------------------------------------------------- #
+
+
+def test_sets_the_type_of_every_pin_in_one_symbol(lib):
+    r = run(lib, symbols=["SHIELD_CAN"], type="passive")
+    assert r["success"]
+    assert r["changeCount"] == 3
+    assert types_in(lib)[:3] == [("passive", "line")] * 3
+
+
+def test_other_symbols_are_left_alone(lib):
+    run(lib, symbols=["SHIELD_CAN"], type="passive")
+    assert types_in(lib)[3:] == [
+        ("output", "line"),
+        ("input", "line"),
+        ("output", "line"),
+        ("input", "line"),
+    ]
+
+
+def test_all_symbols_when_none_named(lib):
+    r = run(lib, type="passive")
+    assert r["changeCount"] == 7
+    assert set(types_in(lib)) == {("passive", "line")}
+
+
+def test_every_unit_of_a_multi_unit_symbol_is_covered(lib):
+    r = run(lib, symbols=["OPAMP_DUAL"], type="passive")
+    assert r["changeCount"] == 4
+    assert {c["unit"] for c in r["changes"]} == {"OPAMP_DUAL_1_1", "OPAMP_DUAL_2_1"}
+
+
+def test_style_can_be_changed_on_its_own(lib):
+    r = run(lib, symbols=["SHIELD_CAN"], pinNumbers=["1"], style="inverted")
+    assert r["changeCount"] == 1
+    assert types_in(lib)[0] == ("unspecified", "inverted")
+
+
+def test_type_and_style_together(lib):
+    run(lib, symbols=["SHIELD_CAN"], pinNumbers=["1"], type="output", style="output_low")
+    assert types_in(lib)[0] == ("output", "output_low")
+
+
+def test_file_stays_parseable(lib):
+    run(lib, type="passive")
+    text = lib.read_text(encoding="utf-8")
+    assert text.count("(") == text.count(")")
+    assert text.endswith(")\n")
+
+
+# --- filters --------------------------------------------------------------- #
+
+
+def test_filter_by_pin_number(lib):
+    r = run(lib, symbols=["SHIELD_CAN"], pinNumbers=["1", "3"], type="passive")
+    assert {c["number"] for c in r["changes"]} == {"1", "3"}
+    assert types_in(lib)[1] == ("unspecified", "line")
+
+
+def test_filter_by_pin_name(lib):
+    r = run(lib, pinNames=["IN-", "IN2-"], type="passive")
+    assert {c["name"] for c in r["changes"]} == {"IN-", "IN2-"}
+
+
+def test_filter_by_current_type(lib):
+    r = run(lib, fromType="output", type="power_out")
+    assert r["changeCount"] == 2
+    assert all(c["fromType"] == "output" for c in r["changes"])
+
+
+def test_from_type_that_matches_nothing_writes_nothing(lib):
+    before = lib.read_text(encoding="utf-8")
+    r = run(lib, fromType="open_collector", type="passive")
+    assert r["success"]
+    assert r["changeCount"] == 0
+    assert lib.read_text(encoding="utf-8") == before
+
+
+def test_a_misspelled_symbol_name_is_reported(lib):
+    """Silently doing nothing is the failure mode a typo must not have."""
+    r = run(lib, symbols=["SHIELD_CANN"], type="passive")
+    assert r["changeCount"] == 0
+    assert r["missingSymbols"] == ["SHIELD_CANN"]
+    assert "not in this library" in r["message"]
+
+
+def test_a_missing_pin_number_is_reported(lib):
+    r = run(lib, symbols=["SHIELD_CAN"], pinNumbers=["1", "99"], type="passive")
+    assert r["changeCount"] == 1
+    assert r["missingPinNumbers"] == ["99"]
+
+
+def test_pins_already_correct_are_counted_not_rewritten(lib):
+    run(lib, type="passive")
+    r = run(lib, type="passive")
+    assert r["changeCount"] == 0
+    assert r["alreadyCorrect"] == 7
+    assert "already have that type" in r["message"]
+
+
+# --- the cases that break sed ---------------------------------------------- #
+
+
+def test_a_type_word_inside_a_string_is_not_touched(tmp_path):
+    """A blind substitution rewrites the Description too, and the symbol name."""
+    text = (
+        "(kicad_symbol_lib\n"
+        '\t(symbol "XCVR_bidirectional line driver"\n'
+        '\t\t(property "Description" "pin bidirectional line buffer"\n'
+        "\t\t\t(at 0 0 0)\n"
+        "\t\t)\n"
+        '\t\t(symbol "XCVR_1_1"\n' + pin(1, "A", "bidirectional") + "\t\t)\n"
+        "\t)\n)\n"
+    )
+    path = tmp_path / "x.kicad_sym"
+    path.write_text(text, encoding="utf-8")
+    r = set_symbol_pin_type({"libraryPath": str(path), "type": "passive"})
+    assert r["changeCount"] == 1
+    out = path.read_text(encoding="utf-8")
+    assert '"XCVR_bidirectional line driver"' in out
+    assert '"pin bidirectional line buffer"' in out
+    assert "(pin passive line" in out
+
+
+def test_alternate_pin_functions_are_not_rewritten(tmp_path):
+    """(alternate "SPI_CLK" output line) is a function of the pin, not the pin."""
+    alt = '\t\t\t\t(alternate "SPI_CLK" output line)\n'
+    text = (
+        "(kicad_symbol_lib\n"
+        '\t(symbol "MCU"\n\t\t(symbol "MCU_1_1"\n'
+        + pin(3, "PA5", "bidirectional", extra=alt)
+        + "\t\t)\n\t)\n)\n"
+    )
+    path = tmp_path / "x.kicad_sym"
+    path.write_text(text, encoding="utf-8")
+    r = set_symbol_pin_type({"libraryPath": str(path), "type": "passive"})
+    assert r["changeCount"] == 1
+    out = path.read_text(encoding="utf-8")
+    assert '(alternate "SPI_CLK" output line)' in out
+    assert "(pin passive line" in out
+
+
+def test_pin_name_containing_parens(tmp_path):
+    text = (
+        "(kicad_symbol_lib\n"
+        '\t(symbol "IC"\n\t\t(symbol "IC_1_1"\n' + pin(1, "OUT(A)", "output") + "\t\t)\n\t)\n)\n"
+    )
+    path = tmp_path / "x.kicad_sym"
+    path.write_text(text, encoding="utf-8")
+    r = set_symbol_pin_type({"libraryPath": str(path), "pinNames": ["OUT(A)"], "type": "passive"})
+    assert r["changeCount"] == 1
+    assert path.read_text(encoding="utf-8").count("(") == text.count("(")
+
+
+def test_single_line_pin_form(tmp_path):
+    """Hand-written and script-generated libraries are not always pretty-printed."""
+    text = (
+        "(kicad_symbol_lib\n"
+        '\t(symbol "IC"\n\t\t(symbol "IC_1_1"\n'
+        "\t\t\t(pin unspecified line (at 0 0 0) (length 2.54)"
+        ' (name "A" (effects)) (number "1" (effects)))\n'
+        "\t\t)\n\t)\n)\n"
+    )
+    path = tmp_path / "x.kicad_sym"
+    path.write_text(text, encoding="utf-8")
+    r = set_symbol_pin_type({"libraryPath": str(path), "type": "passive"})
+    assert r["changeCount"] == 1
+    assert r["changes"][0]["number"] == "1"
+    assert "(pin passive line (at 0 0 0)" in path.read_text(encoding="utf-8")
+
+
+def test_the_font_size_name_is_not_mistaken_for_the_pin_name(lib):
+    r = run(lib, symbols=["SHIELD_CAN"], type="passive")
+    assert {c["name"] for c in r["changes"]} == {"SH1", "SH2", "SH3"}
+
+
+# --- guards ---------------------------------------------------------------- #
+
+
+def test_an_unknown_type_is_refused_before_writing(lib):
+    before = lib.read_text(encoding="utf-8")
+    r = run(lib, type="power")
+    assert not r["success"]
+    assert "not a KiCad pin type" in r["message"]
+    assert "power_in" in r["validTypes"]
+    assert lib.read_text(encoding="utf-8") == before
+
+
+def test_an_unknown_style_is_refused(lib):
+    r = run(lib, type="passive", style="dotted")
+    assert not r["success"]
+    assert "graphic style" in r["message"]
+
+
+def test_neither_type_nor_style_is_an_error(lib):
+    r = run(lib, symbols=["SHIELD_CAN"])
+    assert not r["success"]
+    assert "Nothing to do" in r["message"]
+
+
+def test_a_schematic_is_not_a_symbol_library(tmp_path):
+    path = tmp_path / "board.kicad_sch"
+    path.write_text('(kicad_sch\n\t(symbol\n\t\t(pin "1" (uuid "x"))\n\t)\n)\n', encoding="utf-8")
+    r = set_symbol_pin_type({"libraryPath": str(path), "type": "passive"})
+    assert not r["success"]
+    assert "kicad_symbol_lib" in r["message"]
+
+
+def test_missing_file(tmp_path):
+    r = set_symbol_pin_type({"libraryPath": str(tmp_path / "nope.kicad_sym"), "type": "passive"})
+    assert not r["success"]
+    assert "not found" in r["message"]
+
+
+def test_dry_run_reports_without_writing(lib):
+    before = lib.read_text(encoding="utf-8")
+    r = run(lib, type="passive", dryRun=True)
+    assert r["dryRun"] is True
+    assert r["changeCount"] == 7
+    assert "Would change" in r["message"]
+    assert lib.read_text(encoding="utf-8") == before
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_sexpr_format.py
+++ b/tests/test_sexpr_format.py
@@ -15,7 +15,7 @@ PYTHON_DIR = Path(__file__).parent.parent / "python"
 sys.path.insert(0, str(PYTHON_DIR))
 
 from commands.wire_dragger import WireDragger  # noqa: E402
-from utils.sexpr_format import dumps, prettify  # noqa: E402
+from utils.sexpr_format import dumps, iter_child_offsets, match_paren, prettify  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -179,6 +179,40 @@ class TestWriteToolIntegration:
         assert sexpdata.loads(out) is not None  # still parses
         # Writing again is stable (idempotent formatting).
         assert prettify(out) == out
+
+
+class TestStructureWalking:
+    """match_paren / iter_child_offsets let text tools slice a block out safely."""
+
+    def test_match_paren_finds_the_closing_paren(self):
+        s = "(a (b) (c))"
+        assert match_paren(s, 0) == len(s) - 1
+        assert match_paren(s, 3) == 5
+
+    def test_match_paren_ignores_parens_inside_strings(self):
+        # A real footprint name: HRS_U.FL-R-SMT-1(10).
+        s = '(footprint "Lib:HRS_U.FL-R-SMT-1(10)" (layer "F.Cu"))'
+        assert match_paren(s, 0) == len(s) - 1
+
+    def test_match_paren_ignores_an_escaped_quote(self):
+        s = '(property "he said \\"hi (x)\\"" (at 0 0))'
+        assert match_paren(s, 0) == len(s) - 1
+
+    def test_match_paren_returns_minus_one_when_unbalanced(self):
+        assert match_paren("(a (b)", 0) == -1
+
+    def test_iter_child_offsets_yields_direct_children(self):
+        s = '(symbol (lib_id "X") (at 0 0) (property "a" "b" (at 1 1)))'
+        assert [s[i : i + 5] for i in iter_child_offsets(s)] == ["(lib_", "(at 0", "(prop"]
+
+    def test_iter_child_offsets_depth_is_configurable(self):
+        s = "(root (mid (leaf)))"
+        assert [s[i : i + 5] for i in iter_child_offsets(s, depth=3)] == ["(leaf"]
+
+    def test_iter_child_offsets_ignores_indentation(self):
+        """Board files from KiCad indent inconsistently; only nesting counts."""
+        s = '(kicad_pcb\n\t\t\t(footprint "A")\n\t(footprint "B")\n)'
+        assert len(list(iter_child_offsets(s))) == 2
 
 
 class TestIntegerRotationAngle:


### PR DESCRIPTION
## The gap

The server can read pins — `list_symbol_pins`, `batch_list_symbol_pins` — but has no way to write them. Changing pin electrical types in bulk means `sed` over the `.kicad_sym` file.

That is unsafe in three ways, all of which show up on real libraries:

**It rewrites things that are not pins.** `sed 's/bidirectional line/passive line/'` also hits a symbol named `XCVR_bidirectional line driver`, a `Description` reading `"pin bidirectional line buffer"`, and — the one that actually bites — `(alternate "SPI_CLK" output line)`, which is a *function of* a pin rather than a pin. The alternate silently changes meaning and ERC starts reporting something new.

**It cannot see which symbol it is standing on.** "Make only the shield pins passive" is not expressible; you get the whole file or nothing.

**Nothing checks the replacement token.** KiCad refuses to load a library containing a pin type it does not recognise, and the error it reports names the file, not the pin. A typo costs a bisect.

## What this adds

`set_symbol_pin_type` sets the electrical type and/or graphic style of pins in a `.kicad_sym`, filtered by `symbols`, `pinNumbers`, `pinNames`, or `fromType`. It validates the new token against KiCad's sets **before** touching the file, and rewrites only the pin head.

The usual reason to need it: symbols converted from Eagle or pulled from SnapEDA arrive with every pin `unspecified` or `bidirectional`. ERC then reports conflicts on nets that are electrically fine, and the noise hides the real errors. `fromType: "unspecified", type: "passive"` is the whole fix.

Two details aimed at the same failure mode — a call that quietly does nothing:

- A symbol name that is not in the library comes back in `missingSymbols`, and the message says so, rather than reporting a cheerful zero.
- Pins that already have the requested type are counted in `alreadyCorrect` and distinguished from pins that never matched the filters.

`dryRun` returns the change list without writing.

## Implementation notes

Pins are located by walking the file with a symbol stack rather than by regex. Two reasons:

- A pin lives inside a unit sub-symbol (`OPAMP_DUAL_2_1`) whose name differs from the symbol the caller asked for (`OPAMP_DUAL`). The stack keeps the pin attributed to the top-level symbol while still reporting which unit it came from.
- `(pin_names (offset 0.254))` and `(pin_numbers hide)` share a prefix with `(pin ...)` and are not pins.

The walk skips quoted text, so a pin named `OUT(A)` does not unbalance the scan.

The token lists live in a new dependency-free `utils/pin_types.py` so the JSON schema's `enum` and the runtime validator cannot drift apart.

This branch also brings in `match_paren` / `iter_child_offsets` in `utils/sexpr_format.py`. That hunk is byte-identical to the one in #365, #367 and #368, so it merges in whichever order those land.

The rest of the branch does need a rebase once any sibling PR lands — an earlier note here said otherwise, which was only true of the `sexpr_format.py` hunk. Merging all seven locally, the overlaps are `CHANGELOG.md`, the hand-maintained tool counters in `README.md`, the dispatch table in `python/kicad_interface.py`, and `src/tools/library-symbol.ts` (shared with #367). All of them resolve additively: keep both entries and sum the counts. `tests-ts/readme-counts.test.ts` then checks the README figure against `getRegistryStats()`, so an arithmetic slip fails CI rather than shipping. With all seven applied the total is 157 tools across 15 categories.

## Test plan

28 new tests in `tests/test_set_symbol_pin_type.py`, weighted toward the cases where the `sed` approach breaks:

- a type word inside a symbol name and inside a `Description` is left alone
- `(alternate "SPI_CLK" output line)` is left alone while its parent pin changes
- every unit of a multi-unit symbol is covered, and reported per unit
- `(pin_names ...)` / `(pin_numbers hide)` are not counted as pins
- the `(name ...)` of a nested font block is not mistaken for the pin name
- a pin name containing parens
- the single-line pin form that script-generated libraries use
- unknown type and unknown style are refused with the file untouched
- a `.kicad_sch` passed by mistake is refused by root form
- misspelled symbol name reported; already-correct pins counted, not rewritten
- `dryRun` writes nothing

Verified outside the suite on a real 2.2 MB library: 2279 pins across 472 symbols walked correctly, 32 `bidirectional` pins on one symbol changed to `passive`, paren count unchanged, `kicad-cli sym upgrade` accepted the result without modifying it, and a second pass reported nothing to do.

Full suite green: `pytest`, `black`, `isort`, `flake8`, `mypy`, `tsc --noEmit`, `eslint`, `prettier`, `vitest` (70 passed).
