### PR TITLE
feat: add find_duplicate_symbols (the same part stored twice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### New Tools
+
+- **`find_duplicate_symbols`** — group symbols in a `.kicad_sym` that are the
+  same part stored twice under different names. Libraries collect these the
+  moment more than one source feeds them: an Eagle import lands a part the
+  curated library already had, a SnapEDA download arrives under the vendor's
+  naming, someone re-adds a part because search did not find the existing name.
+  KiCad reports nothing, because the names differ — which is also why grepping
+  for the name does not find it.
+
+  Matches on manufacturer part number, distributor part number, Value +
+  Footprint, an identical drawn body, or near-identical names. The MPN match
+  normalises property names first, because a real library holds that field as
+  `MPN`, `MP`, `MANUFACTURER PART NUMBER` and `PART NUMBER` depending on which
+  importer wrote it, and a plain group-by therefore finds nothing. Each group
+  reports which strategy and which property produced it.
+
+  `schematicPaths` counts instances per symbol across the project's sheets,
+  which turns the report into a decision: the duplicate nothing places is the
+  one to retire. `suggestedKeep` names it and says why.
+
+  `graphics` is off by default. Verified against a 489-symbol library: matching
+  on the drawn body alone put 78 different resistor values in one group, because
+  every resistor shares one drawing. It stays available for hunting a custom
+  part copied under a new name, and is documented as evidence rather than
+  verdict. With the defaults the same library reported 86 real groups covering
+  116 redundant symbols, 69 of which no schematic places — including five
+  symbols for one TI transceiver, of which one is in use.
+
 ### Bug Fixes
 
 - **`add_layer` could not add inner copper layers, and corrupted an unrelated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,23 +15,41 @@ All notable changes to the KiCAD MCP Server project are documented here.
   for the name does not find it.
 
   Matches on manufacturer part number, distributor part number, Value +
-  Footprint, an identical drawn body, or near-identical names. The MPN match
-  normalises property names first, because a real library holds that field as
-  `MPN`, `MP`, `MANUFACTURER PART NUMBER` and `PART NUMBER` depending on which
-  importer wrote it, and a plain group-by therefore finds nothing. Each group
-  reports which strategy and which property produced it.
+  Footprint, an identical drawn body, or names differing only in separators. The
+  MPN match normalises property names first, because a real library holds that
+  field as `MPN`, `MP`, `MANUFACTURER PART NUMBER` and `PART NUMBER` depending on
+  which importer wrote it, and a plain group-by therefore finds nothing. A value
+  that only marks a field as unfilled — `N/A`, `TBD`, `-`, KiCad's `~` — is never
+  a key, since grouping on one collects every part the importer knew nothing
+  about. Each group reports which strategy and which property produced it, and
+  groups are merged by connected component, so no symbol is reported twice and
+  the redundant-symbol count cannot exceed what the library holds.
 
   `schematicPaths` counts instances per symbol across the project's sheets,
   which turns the report into a decision: the duplicate nothing places is the
-  one to retire. `suggestedKeep` names it and says why.
+  one to retire. `suggestedKeep` names it and says why. Counting is attributed
+  to _this_ library by lib_id nickname — resolved from the file name and from
+  the `sym-lib-table` beside each scanned sheet, overridable with
+  `libraryNicknames` — because a bare `R` or `LED` collides with `Device:` and
+  `power:` constantly, and crediting another library's placements here
+  recommends keeping the copy nothing uses. A sub-sheet instantiated four times
+  counts four times, autosave sheets and backup/history folders are skipped
+  because they duplicate sheets already being counted, and a `schematicPaths`
+  entry that does not exist is reported in `missingPaths` instead of leaving the
+  report to claim that nothing is used.
 
   `graphics` is off by default. Verified against a 489-symbol library: matching
-  on the drawn body alone put 78 different resistor values in one group, because
-  every resistor shares one drawing. It stays available for hunting a custom
-  part copied under a new name, and is documented as evidence rather than
-  verdict. With the defaults the same library reported 86 real groups covering
-  116 redundant symbols, 69 of which no schematic places — including five
-  symbols for one TI transceiver, of which one is in use.
+  on the drawn body alone put 78 resistor symbols spanning 53 distinct values
+  into one group, because every resistor shares one drawing. It stays available
+  for hunting a custom part copied under a new name, and is documented as
+  evidence rather than verdict. With the defaults, and 20 sheets of the same
+  project scanned, that library reports 78 groups covering 107 redundant
+  symbols, 61 of which no schematic places — including five symbols for one TI
+  transceiver, of which one is in use. Nickname attribution changed the advice
+  for three of those groups: each recommended keeping a symbol this library
+  never places, because a same-named symbol in an Eagle-import library was being
+  counted towards it, and for one of them the symbol it proposed to retire had
+  the only two real placements.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 **Key Capabilities:**
 
-- 146 tools across 13 categories with JSON Schema validation
+- 147 tools across 13 categories with JSON Schema validation
 - Keyword tool discovery via `search_tools` / `get_category_tools`
 - 8 dynamic resources exposing project state
 - Complete schematic workflow with 27 tools and dynamic symbol loading (~10,000 symbols)

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ configuration command and backend options.
 We've implemented an intelligent tool router to keep AI context efficient while maintaining full functionality:
 
 - **22 direct tools** always visible for high-frequency operations
-- **111 routed tools** organized into 13 categories (board, component, export, drc, schematic, library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, parts-registry)
+- **112 routed tools** organized into 13 categories (board, component, export, drc, schematic, library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, parts-registry)
 - **4 router tools** for discovery and execution:
   - `list_tool_categories` - Browse all available categories
   - `get_category_tools` - View tools in a specific category
@@ -486,7 +486,7 @@ Access project state without executing tools:
 
 ## Available Tools
 
-The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **146 tools** are additionally indexed into 13 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
+The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **147 tools** are additionally indexed into 13 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
 
 For the complete tool reference with access types (direct/routed/additional), see [Tool Inventory](docs/TOOL_INVENTORY.md).
 
@@ -1513,7 +1513,7 @@ npm run format
 
 See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix and [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
 
-**Working Features (146 tools):**
+**Working Features (147 tools):**
 
 - Project management with snapshot checkpointing
 - Complete board design (outline, layers, zones, mounting holes, text, SVG logos)
@@ -1526,6 +1526,7 @@ See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix a
 - Design rule checking (DRC and ERC)
 - Export to Gerber, PDF, SVG, 3D, BOM, netlist, position file
 - Custom footprint and symbol creation
+- Duplicate-symbol detection across libraries, with schematic usage counts
 - JLCPCB parts integration (2.5M+ parts catalog)
 - Datasheet enrichment via LCSC
 - Freerouting autorouter integration (Java, Docker, Podman)

--- a/python/commands/find_duplicate_symbols.py
+++ b/python/commands/find_duplicate_symbols.py
@@ -7,7 +7,7 @@ because search did not find the existing name. Nothing in KiCad reports this,
 because the names differ -- which is exactly why grepping for the name does
 not find it either.
 
-Four ways to notice the same part twice, each catching what the others miss:
+Five ways to notice the same part twice, each catching what the others miss:
 
 ``mpn``
     Same manufacturer part number. The strongest signal, and the one that has
@@ -30,8 +30,25 @@ Four ways to notice the same part twice, each catching what the others miss:
     hunting a copied IC, and read it as evidence rather than as a verdict.
     Symbols that ``extends`` another are excluded: sharing a body is the point.
 
+``name``
+    Names that differ only in separators: ``R_10K``, ``R-10K``, ``R 10K``. The
+    weakest signal -- it finds the copy someone made by retyping a name, and
+    little else -- so it is off by default. The decimal point is deliberately
+    NOT collapsed: stripping it makes ``C_1.0uF_0805`` and ``C_10uF_0805``, or
+    ``R_1.5K`` and ``R_15K``, the same key.
+
+Whichever strategy produced a key, a value that only means "this field was not
+filled in" cannot be one: an importer with nothing to write puts ``N/A``,
+``TBD`` or ``-`` in the field, and KiCad's own empty marker is ``~``. Those are
+rejected, because grouping on them is the failure ``graphics`` has on passives
+-- one huge group of unrelated parts -- happening under the defaults.
+
 Usage counts from the project's schematics turn the report into a decision:
-the duplicate that nothing instantiates is the one to retire.
+the duplicate that nothing instantiates is the one to retire. Two things make
+those counts mean what they say. Placements are attributed by library and not
+by bare symbol name, so this library's ``R`` does not inherit the fifty
+placements of ``Device:R``; and a sub-sheet instantiated four times counts
+four times, as KiCad's own netlist has it.
 """
 
 from __future__ import annotations
@@ -40,10 +57,15 @@ import hashlib
 import logging
 import re
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Sequence, Set, Tuple
 
 from utils.duplicate_strategies import DEFAULT_DUPLICATE_STRATEGIES, DUPLICATE_STRATEGIES
-from utils.sexpr_format import iter_child_offsets, match_paren
+from utils.sexpr_format import (
+    QUOTED_VALUE,
+    iter_child_offsets,
+    match_paren,
+    unescape_sexpr_string,
+)
 
 logger = logging.getLogger("kicad_interface")
 
@@ -75,13 +97,45 @@ SUPPLIER_KEYS = (
 )
 
 _HEAD = re.compile(r"\(\s*([A-Za-z_][\w]*)")
-_LIB_ID = re.compile(r'\(lib_id\s+"((?:[^"\\]|\\.)*)"')
+_LIB_ID = re.compile(r"\(lib_id\s+" + QUOTED_VALUE)
 _WHITESPACE = re.compile(r"\s+")
+
+# Values that say "this field was not filled in" rather than naming anything.
+# Eagle and Altium importers and hand entry write these into MPN and Value
+# fields; ``~`` is KiCad's own empty-field marker.
+PLACEHOLDER_VALUES = frozenset({"", "~", "-", "--", "N/A", "NA", "NONE", "TBD", "?", "X"})
+
+# eeschema writes ``_autosave-<sheet>.kicad_sch`` beside the real sheet while a
+# project is open and leaves it there after a crash; KiCad's backup archives
+# unpack into ``<project>-backups``; editors keep their own copies in dot
+# directories (the library this was developed against has 15 sheets under
+# ``.history`` beside 20 real ones). Each is a complete copy of a sheet that is
+# already being scanned, so counting them multiplies every usage count.
+_AUTOSAVE_PREFIX = "_autosave-"
+
+# A hierarchy of N sheets can in principle have exponentially many instance
+# paths. Real designs have a handful; this only stops a pathological or
+# malformed one from walking forever.
+_MAX_SHEET_WALK = 100_000
+
+_TABLE_NAME = re.compile(r"\(\s*name\s+" + QUOTED_VALUE + r"\s*\)")
+_TABLE_URI = re.compile(r"\(\s*uri\s+" + QUOTED_VALUE + r"\s*\)")
 
 
 def _norm_key(name: str) -> str:
     """Collapse a property name so MANUFACTURER PART NUMBER == Manufacturer_Part-Number."""
     return re.sub(r"[\s_\-.#]+", "", name).upper()
+
+
+def _is_placeholder(value: str) -> bool:
+    """True if *value* only means the field was left blank.
+
+    Grouping on a placeholder is what makes ``graphics`` useless on passives --
+    one enormous group of unrelated parts -- except that it happens under the
+    default strategies, where it cannot be opted out of. Six parts with nothing
+    in common but ``(property "MPN" "N/A")`` are not the same part.
+    """
+    return value.strip().upper() in PLACEHOLDER_VALUES
 
 
 def _read_string(text: str, i: int) -> Tuple[Optional[str], int]:
@@ -181,59 +235,304 @@ def read_library_symbols(text: str) -> List[Dict[str, Any]]:
 
 
 def _first_property(symbol: Dict[str, Any], keys: Sequence[str]) -> Tuple[str, str]:
-    """Return (value, property name) for the first of *keys* that is filled."""
+    """Return (value, property name) for the first of *keys* holding a real value.
+
+    A field filled in with a placeholder is skipped rather than returned, so a
+    symbol whose ``MPN`` is ``N/A`` and whose ``PART NUMBER`` is a real part
+    number matches on the real one.
+    """
     for key in keys:
         value = symbol["normalized"].get(key, "").strip()
-        if value:
-            original = next(
-                (k for k in symbol["properties"] if _norm_key(k) == key),
-                key,
-            )
-            return value, original
+        if _is_placeholder(value):
+            continue
+        original = next(
+            (k for k in symbol["properties"] if _norm_key(k) == key),
+            key,
+        )
+        return value, original
     return "", ""
 
 
-def _iter_schematics(paths: Iterable[str]) -> List[Path]:
-    """Expand a mix of .kicad_sch files and directories into sheet paths."""
-    sheets: List[Path] = []
-    for raw in paths:
-        path = Path(raw)
-        if path.is_dir():
-            sheets.extend(sorted(path.rglob("*.kicad_sch")))
-        elif path.is_file():
-            sheets.append(path)
-    seen: Set[Path] = set()
-    unique = []
-    for sheet in sheets:
-        resolved = sheet.resolve()
-        if resolved not in seen:
-            seen.add(resolved)
-            unique.append(sheet)
-    return unique
+def _read_sheet_references(text: str) -> List[str]:
+    """The Sheetfile of every ``(sheet ...)`` block, once per instantiation.
 
-
-def count_symbol_usage(sheets: Sequence[Path]) -> Dict[str, Dict[str, int]]:
-    """Count symbol instances per symbol name, per sheet.
-
-    The library nickname in a lib_id is ignored: the same library is registered
-    under different nicknames in different projects, and the question being
-    asked is which symbol is in use, not which table entry pointed at it.
+    Repeats are the point: a four-channel design has four ``(sheet ...)``
+    blocks naming one file, and that file's contents exist four times.
     """
-    usage: Dict[str, Dict[str, int]] = {}
+    root = _HEAD.search(text)
+    if not root:
+        return []
+    refs: List[str] = []
+    for off in iter_child_offsets(text[root.start() :]):
+        off += root.start()
+        head = _HEAD.match(text, off)
+        if not head or head.group(1) != "sheet":
+            continue
+        end = match_paren(text, off)
+        if end == -1:
+            continue
+        block = text[off : end + 1]
+        for child in iter_child_offsets(block):
+            child_head = _HEAD.match(block, child)
+            if not child_head or child_head.group(1) != "property":
+                continue
+            key, after = _read_string(block, child_head.end())
+            # KiCad 7 wrote "Sheetfile", 8+ writes "Sheet file"; _norm_key
+            # makes them the same lookup.
+            if key and _norm_key(key) == "SHEETFILE":
+                value, _ = _read_string(block, after)
+                if value:
+                    refs.append(value)
+                break
+    return refs
+
+
+def _sheet_instance_counts(texts: Dict[Path, str]) -> Dict[Path, int]:
+    """How many times each scanned sheet file is instantiated in the hierarchy.
+
+    A sheet file reused by four ``(sheet ...)`` blocks holds four of every part
+    drawn on it, which is what KiCad's netlist and BOM report. Counting sheet
+    files instead of instances undercounts every part on a reused sheet.
+
+    A file no other scanned sheet references is a root and counts once, so a
+    flat design and an unrelated pile of sheets both come out as 1 each --
+    exactly the previous behaviour.
+    """
+    children: Dict[Path, List[Path]] = {}
+    referenced: Set[Path] = set()
+    for path, text in texts.items():
+        kids: List[Path] = []
+        for ref in _read_sheet_references(text):
+            try:
+                target = (path.parent / ref).resolve()
+            except OSError:
+                continue
+            if target in texts:
+                kids.append(target)
+                referenced.add(target)
+        children[path] = kids
+
+    counts: Dict[Path, int] = dict.fromkeys(texts, 0)
+    stack = [(path, frozenset()) for path in texts if path not in referenced]
+    steps = 0
+    while stack:
+        path, on_path = stack.pop()
+        if path in on_path:  # a sheet cycle; KiCad rejects these, files can hold them
+            continue
+        steps += 1
+        if steps > _MAX_SHEET_WALK:
+            logger.warning(
+                "Sheet hierarchy has more than %d instance paths; usage counts "
+                "fall back to one per sheet file",
+                _MAX_SHEET_WALK,
+            )
+            return dict.fromkeys(texts, 1)
+        counts[path] += 1
+        deeper = on_path | {path}
+        stack.extend((kid, deeper) for kid in children[path])
+    # A sheet reachable only through a cycle would otherwise count zero times.
+    return {path: max(count, 1) for path, count in counts.items()}
+
+
+def _nicknames_from_table(table: Path, lib_path: Path) -> Set[str]:
+    """Nicknames in one ``sym-lib-table`` whose uri is *lib_path*."""
+    try:
+        text = table.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.warning("Could not read %s: %s", table, e)
+        return set()
+    root = _HEAD.search(text)
+    if not root:
+        return set()
+    found: Set[str] = set()
+    for off in iter_child_offsets(text[root.start() :]):
+        off += root.start()
+        head = _HEAD.match(text, off)
+        if not head or head.group(1) != "lib":
+            continue
+        end = match_paren(text, off)
+        if end == -1:
+            continue
+        block = text[off : end + 1]
+        name = _TABLE_NAME.search(block)
+        uri = _TABLE_URI.search(block)
+        if not name or not uri:
+            continue
+        # ${KIPRJMOD} is the directory holding the table. Any other variable
+        # points somewhere this code cannot resolve (a stock library path), and
+        # an unresolved one must not be compared as a literal.
+        expanded = unescape_sexpr_string(uri.group(1)).replace("${KIPRJMOD}", str(table.parent))
+        if "${" in expanded or "$(" in expanded:
+            continue
+        try:
+            if Path(expanded).resolve() == lib_path:
+                found.add(unescape_sexpr_string(name.group(1)))
+        except OSError:
+            continue
+    return found
+
+
+def resolve_library_nicknames(
+    lib_path: Path,
+    sheets: Sequence[Path],
+    override: Any = None,
+) -> Set[str]:
+    """The nicknames under which *lib_path* may legitimately appear in a lib_id.
+
+    The nickname is whatever ``sym-lib-table`` chose to call the library, which
+    is not always the file name -- so the table beside each scanned sheet is
+    read and every entry resolving to this file contributes its name. The file
+    stem is accepted too, because it is what KiCad proposes when a library is
+    added and therefore what most tables say.
+
+    *override* wins outright when given: it is the escape hatch for a library
+    registered under a name no scanned project's table mentions.
+    """
+    if isinstance(override, str):
+        override = [override]
+    chosen = {n.strip() for n in (override or ()) if isinstance(n, str) and n.strip()}
+    if chosen:
+        return chosen
+
+    chosen.add(lib_path.stem)
+    try:
+        target = lib_path.resolve()
+    except OSError:
+        return chosen
+    for directory in dict.fromkeys(sheet.parent for sheet in sheets):
+        table = directory / "sym-lib-table"
+        if table.is_file():
+            chosen |= _nicknames_from_table(table, target)
+    return chosen
+
+
+class ScanResult(NamedTuple):
+    """Sheets to scan, what to call them in the report, and what did not exist."""
+
+    sheets: List[Path]
+    labels: Dict[Path, str]
+    missing: List[str]
+
+
+def _iter_schematics(paths: Iterable[str]) -> ScanResult:
+    """Expand a mix of .kicad_sch files and directories into sheets to scan.
+
+    Autosave sheets and backup locations are skipped during directory expansion,
+    since they duplicate sheets already in the list. A path named explicitly is
+    always honoured -- naming one is a deliberate act.
+
+    Inputs that resolve to nothing are collected rather than dropped: a typo in
+    a directory name used to produce an empty scan and a report that confidently
+    said every symbol was unused.
+    """
+    sheets: List[Path] = []
+    labels: Dict[Path, str] = {}
+    missing: List[str] = []
+    seen: Set[Path] = set()
+
+    def add(sheet: Path, label: str) -> None:
+        try:
+            resolved = sheet.resolve()
+        except OSError as e:
+            logger.warning("Could not resolve %s: %s", sheet, e)
+            return
+        if resolved in seen:
+            return
+        seen.add(resolved)
+        sheets.append(resolved)
+        labels[resolved] = label
+
+    for raw in paths:
+        path = Path(str(raw))
+        if path.is_dir():
+            for sheet in sorted(path.rglob("*.kicad_sch")):
+                if sheet.name.startswith(_AUTOSAVE_PREFIX):
+                    continue
+                relative = sheet.relative_to(path)
+                if any(
+                    part.startswith(".") or part.endswith("-backups")
+                    for part in relative.parts[:-1]
+                ):
+                    continue
+                # Labelled by path below the scanned root, not by basename:
+                # a project with analog/power.kicad_sch and
+                # digital/power.kicad_sch has two different sheets.
+                add(sheet, relative.as_posix())
+        elif path.is_file():
+            add(path, path.name)
+        else:
+            missing.append(str(path))
+    return ScanResult(sheets, labels, missing)
+
+
+class SymbolUsage(NamedTuple):
+    """Instance counts per symbol, and the evidence for how they were attributed."""
+
+    counts: Dict[str, Dict[str, int]]
+    nicknames_seen: List[str]
+    sheet_instances: Dict[str, int]
+
+
+def count_symbol_usage(
+    sheets: Sequence[Path],
+    nicknames: Optional[Iterable[str]] = None,
+    labels: Optional[Dict[Path, str]] = None,
+) -> SymbolUsage:
+    """Count placed instances of one library's symbols, per sheet.
+
+    A lib_id names the library it came from, and that half cannot be discarded.
+    Bare names collide with the stock libraries constantly -- ``R``, ``C``,
+    ``D``, ``LED``, ``GND`` -- so crediting the fifty placements of ``Device:R``
+    to this library's ``R`` reports the symbol nothing references as the popular
+    one, and then recommends retiring the only copy anything actually places.
+
+    Only nicknames in *nicknames* are counted; pass nothing to count every
+    nickname, which is name-only matching and cannot distinguish libraries. The
+    nicknames actually encountered come back in the result, so a library
+    registered under a name the caller did not expect is visible rather than
+    silently reported as unused.
+
+    A lib_id with no nickname at all is counted by name: that is all the
+    information the file carries about it.
+
+    Instances of a sub-sheet are counted per instantiation, so a sheet file used
+    by four ``(sheet ...)`` blocks contributes four of every part on it.
+    """
+    accepted = {n.strip().upper() for n in (nicknames or ()) if n and n.strip()}
+    labels = labels or {}
+
+    texts: Dict[Path, str] = {}
     for sheet in sheets:
         try:
-            text = sheet.read_text(encoding="utf-8")
+            texts[sheet] = sheet.read_text(encoding="utf-8")
         except OSError as e:
             logger.warning("Could not read %s: %s", sheet, e)
-            continue
+    instances = _sheet_instance_counts(texts)
+
+    usage: Dict[str, Dict[str, int]] = {}
+    seen: Set[str] = set()
+    for sheet, text in texts.items():
+        label = labels.get(sheet, sheet.name)
+        weight = instances.get(sheet, 1)
         # Only placed instances carry (lib_id ...); the lib_symbols cache keys
         # its entries by the id itself, so counting lib_id counts placements.
         for m in _LIB_ID.finditer(text):
-            lib_id = m.group(1)
-            symbol_name = lib_id.split(":", 1)[1] if ":" in lib_id else lib_id
-            usage.setdefault(symbol_name, {})
-            usage[symbol_name][sheet.name] = usage[symbol_name].get(sheet.name, 0) + 1
-    return usage
+            lib_id = unescape_sexpr_string(m.group(1))
+            nickname, separator, symbol_name = lib_id.partition(":")
+            if not separator:  # no nickname at all; the id is the symbol name
+                nickname, symbol_name = "", nickname
+            if nickname:
+                seen.add(nickname)
+                if accepted and nickname.upper() not in accepted:
+                    continue
+            per_sheet = usage.setdefault(symbol_name, {})
+            per_sheet[label] = per_sheet.get(label, 0) + weight
+
+    return SymbolUsage(
+        usage,
+        sorted(seen),
+        {labels.get(path, path.name): count for path, count in instances.items() if count > 1},
+    )
 
 
 def _group_key(symbol: Dict[str, Any], strategy: str, ignore_case: bool) -> Tuple[str, str]:
@@ -245,13 +544,15 @@ def _group_key(symbol: Dict[str, Any], strategy: str, ignore_case: bool) -> Tupl
     elif strategy == "value_footprint":
         value_field = symbol["normalized"].get("VALUE", "").strip()
         footprint = symbol["normalized"].get("FOOTPRINT", "").strip()
-        if not value_field or not footprint:
+        if _is_placeholder(value_field) or _is_placeholder(footprint):
             return "", ""
         value, source = f"{value_field} @ {footprint}", "Value + Footprint"
     elif strategy == "graphics":
         value, source = symbol["fingerprint"], "body"
     elif strategy == "name":
-        value = re.sub(r"[\s_\-.]+", "", symbol["name"])
+        # Separators are noise; the decimal point is not. Collapsing it makes
+        # C_1.0uF_0805 and C_10uF_0805 -- and R_1.5K and R_15K -- one key.
+        value = re.sub(r"[\s_\-]+", "", symbol["name"])
         source = "name"
     else:
         return "", ""
@@ -280,15 +581,27 @@ def _suggest_keep(members: List[Dict[str, Any]]) -> Tuple[str, str]:
         reason = f"only one in use ({best['usageCount']} instance(s))"
     elif best["usageCount"] > 0:
         reason = f"most used ({best['usageCount']} instance(s))"
-    elif any(m["usageCount"] for m in members):
-        reason = "most used"
     else:
+        # best is the maximum by usageCount, so zero here means every member is
+        # unused and the field-completeness tie-break is what decided it.
         reason = "none are used; most complete fields"
     return best["name"], reason
 
 
 def find_duplicate_symbols(params: Dict[str, Any]) -> Dict[str, Any]:
-    """Group symbols in a library that look like the same part stored twice."""
+    """Group symbols in a library that look like the same part stored twice.
+
+    Each group is one connected set of symbols with every strategy that linked
+    any of them attached as evidence, so no symbol appears in two groups and
+    ``duplicateSymbolCount`` never exceeds ``symbolCount - groupCount``.
+
+    ``usageCount`` counts placements of THIS library's symbols only, decided by
+    the lib_id nickname (see :func:`count_symbol_usage`), and counts a reused
+    sub-sheet once per instantiation. ``libraryNicknames`` and ``nicknamesSeen``
+    in the result show how that attribution was made; ``missingPaths`` lists any
+    ``schematicPaths`` entry that does not exist, so an empty scan is never
+    mistaken for an unused library.
+    """
     lib_path = Path(params.get("libraryPath", ""))
     requested = params.get("matchBy") or list(DEFAULT_STRATEGIES)
     if isinstance(requested, str):
@@ -302,7 +615,15 @@ def find_duplicate_symbols(params: Dict[str, Any]) -> Dict[str, Any]:
         }
 
     ignore_case = bool(params.get("ignoreCase", True))
-    min_group_size = max(2, int(params.get("minGroupSize", 2)))
+    try:
+        min_group_size = max(2, int(params.get("minGroupSize", 2)))
+    except (TypeError, ValueError):
+        return {
+            "success": False,
+            "message": (
+                "minGroupSize must be a whole number, got " f"{params.get('minGroupSize')!r}"
+            ),
+        }
 
     if not lib_path.is_file():
         return {"success": False, "message": f"Library not found: {lib_path}"}
@@ -331,12 +652,13 @@ def find_duplicate_symbols(params: Dict[str, Any]) -> Dict[str, Any]:
             "groups": [],
         }
 
-    sheets = _iter_schematics(params.get("schematicPaths") or [])
-    usage = count_symbol_usage(sheets)
+    requested_paths = params.get("schematicPaths") or []
+    if isinstance(requested_paths, str):
+        requested_paths = [requested_paths]
+    scan = _iter_schematics(requested_paths)
+    nicknames = resolve_library_nicknames(lib_path, scan.sheets, params.get("libraryNicknames"))
+    usage = count_symbol_usage(scan.sheets, nicknames, scan.labels)
 
-    # A pair of symbols usually trips more than one strategy. Group by the set
-    # of members so the report has one entry per real duplicate, listing the
-    # evidence, instead of the same pair three times.
     buckets: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
     for strategy in requested:
         by_key: Dict[str, List[Dict[str, Any]]] = {}
@@ -348,18 +670,41 @@ def find_duplicate_symbols(params: Dict[str, Any]) -> Dict[str, Any]:
             if len(group) >= min_group_size:
                 buckets[(strategy, key)] = group
 
-    merged: Dict[frozenset, Dict[str, Any]] = {}
+    # A pair of symbols usually trips more than one strategy, and the member
+    # sets need not nest neatly: A and B can share an MPN while A, B and C share
+    # a Value and a Footprint. Merging on the exact member set made {A,B} and
+    # {A,B,C} two separate groups -- so a caller iterating groups handled A and
+    # B twice, and three of three symbols were called redundant. Merging by
+    # connected component gives the one entry per real duplicate the report
+    # promises, and makes the redundant count right by construction.
+    parent: Dict[str, str] = {}
+
+    def find(name: str) -> str:
+        parent.setdefault(name, name)
+        while parent[name] != name:
+            parent[name] = parent[parent[name]]
+            name = parent[name]
+        return name
+
+    for group in buckets.values():
+        root_name = find(group[0]["name"])
+        for symbol in group[1:]:
+            other = find(symbol["name"])
+            if other != root_name:
+                parent[other] = root_name
+
+    merged: Dict[str, Dict[str, Any]] = {}
     for (strategy, key), group in buckets.items():
-        names = frozenset(s["name"] for s in group)
-        entry = merged.setdefault(names, {"symbols": group, "evidence": []})
+        entry = merged.setdefault(find(group[0]["name"]), {"symbols": {}, "evidence": []})
+        entry["symbols"].update({s["name"]: s for s in group})
         source = _group_key(group[0], strategy, ignore_case)[1]
         entry["evidence"].append({"strategy": strategy, "key": key, "from": source})
 
     groups: List[Dict[str, Any]] = []
     for entry in merged.values():
         members: List[Dict[str, Any]] = []
-        for symbol in sorted(entry["symbols"], key=lambda s: s["name"]):
-            sheets_used = usage.get(symbol["name"], {})
+        for symbol in sorted(entry["symbols"].values(), key=lambda s: s["name"]):
+            sheets_used = usage.counts.get(symbol["name"], {})
             mpn, mpn_from = _first_property(symbol, MPN_KEYS)
             members.append(
                 {
@@ -380,7 +725,7 @@ def find_duplicate_symbols(params: Dict[str, Any]) -> Dict[str, Any]:
         groups.append(
             {
                 "size": len(members),
-                "evidence": sorted(entry["evidence"], key=lambda e: e["strategy"]),
+                "evidence": sorted(entry["evidence"], key=lambda e: (e["strategy"], e["key"])),
                 "matchedBy": sorted({e["strategy"] for e in entry["evidence"]}),
                 "members": members,
                 "suggestedKeep": keep,
@@ -399,18 +744,42 @@ def find_duplicate_symbols(params: Dict[str, Any]) -> Dict[str, Any]:
             f"{len(groups)} duplicate group(s) covering {duplicate_count} "
             f"redundant symbol(s) out of {len(symbols)}"
         )
-        if sheets:
+        if scan.sheets:
             retirable = sum(len(g["unusedMembers"]) for g in groups)
-            message += f"; {retirable} unused across {len(sheets)} sheet(s)"
+            message += f"; {retirable} unused across {len(scan.sheets)} sheet(s)"
+        elif requested_paths:
+            # Saying "pass schematicPaths" to someone who did is how a typo'd
+            # directory became a report claiming every symbol was retirable.
+            message += (
+                f"; none of the {len(requested_paths)} schematicPaths given exist, so "
+                "no usage could be counted and no symbol should be retired on the "
+                "strength of this report"
+            )
         else:
             message += "; pass schematicPaths to see which ones are actually used"
+
+    if scan.sheets and not usage.counts and usage.nicknames_seen:
+        # Every placement named some other library. Either this library is
+        # registered under a nickname no scanned sym-lib-table mentions, or the
+        # sheets genuinely belong to another project -- both of which would
+        # otherwise read as "nothing here is used".
+        message += (
+            f"; nothing in the scanned sheets references {'/'.join(sorted(nicknames))}, "
+            f"so no usage was attributed to this library (nicknames seen: "
+            f"{', '.join(usage.nicknames_seen)}) -- pass libraryNicknames if it is "
+            "registered under a different name"
+        )
 
     return {
         "success": True,
         "message": message,
         "libraryPath": str(lib_path),
         "symbolCount": len(symbols),
-        "sheetsScanned": [s.name for s in sheets],
+        "sheetsScanned": [scan.labels.get(s, s.name) for s in scan.sheets],
+        "missingPaths": scan.missing,
+        "libraryNicknames": sorted(nicknames),
+        "nicknamesSeen": usage.nicknames_seen,
+        "sheetInstances": usage.sheet_instances,
         "matchBy": list(requested),
         "groupCount": len(groups),
         "duplicateSymbolCount": duplicate_count,

--- a/python/commands/find_duplicate_symbols.py
+++ b/python/commands/find_duplicate_symbols.py
@@ -1,0 +1,418 @@
+"""Find symbols that are the same part stored twice in a .kicad_sym library.
+
+Libraries accumulate duplicates the moment more than one source feeds them:
+an Eagle import lands the same resistor the curated library already had, a
+SnapEDA download arrives under the vendor's naming, someone re-adds a part
+because search did not find the existing name. Nothing in KiCad reports this,
+because the names differ -- which is exactly why grepping for the name does
+not find it either.
+
+Four ways to notice the same part twice, each catching what the others miss:
+
+``mpn``
+    Same manufacturer part number. The strongest signal, and the one that has
+    to work across inconsistent property naming: a real library holds the same
+    field as ``MPN``, ``MP``, ``MANUFACTURER PART NUMBER`` and ``PART NUMBER``
+    depending on which importer wrote it, so a plain group-by finds nothing.
+
+``supplier``
+    Same distributor part number, for parts that never got an MPN field.
+
+``value_footprint``
+    Same Value on the same Footprint. Catches the passives that make up most
+    of a library, where there is no MPN to compare.
+
+``graphics``
+    Byte-identical body: same pins in the same places, same drawing. Catches a
+    custom part copied under a new name whatever its fields say -- but every
+    resistor in a library shares one body, so on passives it groups the whole
+    family and means nothing. Off by default for that reason; ask for it when
+    hunting a copied IC, and read it as evidence rather than as a verdict.
+    Symbols that ``extends`` another are excluded: sharing a body is the point.
+
+Usage counts from the project's schematics turn the report into a decision:
+the duplicate that nothing instantiates is the one to retire.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+from utils.duplicate_strategies import DEFAULT_DUPLICATE_STRATEGIES, DUPLICATE_STRATEGIES
+from utils.sexpr_format import iter_child_offsets, match_paren
+
+logger = logging.getLogger("kicad_interface")
+
+STRATEGIES = DUPLICATE_STRATEGIES
+DEFAULT_STRATEGIES = DEFAULT_DUPLICATE_STRATEGIES
+
+# Property names that hold a manufacturer part number, best first. Compared
+# after _norm_key, so spacing and punctuation do not matter.
+MPN_KEYS = (
+    "MPN",
+    "MANUFACTURERPARTNUMBER",
+    "MFRPARTNUMBER",
+    "MFGPARTNUMBER",
+    "MANUFACTURERPARTNO",
+    "MP",
+    "PARTNUMBER",
+)
+
+SUPPLIER_KEYS = (
+    "DIGIKEY",
+    "DIGIKEYPARTNUMBER",
+    "DIGIKEYPN",
+    "SUPPLIERPARTNUMBER1",
+    "SUPPLIERPARTNUMBER",
+    "LCSC",
+    "LCSCPARTNUMBER",
+    "MOUSER",
+    "MOUSERPARTNUMBER",
+)
+
+_HEAD = re.compile(r"\(\s*([A-Za-z_][\w]*)")
+_LIB_ID = re.compile(r'\(lib_id\s+"((?:[^"\\]|\\.)*)"')
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _norm_key(name: str) -> str:
+    """Collapse a property name so MANUFACTURER PART NUMBER == Manufacturer_Part-Number."""
+    return re.sub(r"[\s_\-.#]+", "", name).upper()
+
+
+def _read_string(text: str, i: int) -> Tuple[Optional[str], int]:
+    """Read the quoted token at or after *i*; return (value, index after it)."""
+    while i < len(text) and text[i] in " \t\r\n":
+        i += 1
+    if i >= len(text) or text[i] != '"':
+        return None, i
+    out: List[str] = []
+    i += 1
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\" and i + 1 < len(text):
+            out.append(text[i + 1])
+            i += 2
+            continue
+        if ch == '"':
+            return "".join(out), i + 1
+        out.append(ch)
+        i += 1
+    return None, i
+
+
+def _fingerprint(block: str, symbol_name: str) -> str:
+    """Hash of a symbol's drawn body, blind to its name and to formatting.
+
+    Unit sub-symbols are named after their parent (``R_0402_1_1``), so the same
+    body copied under a new name hashes differently unless the parent name is
+    stripped first. Whitespace is collapsed because a hand-edited library and
+    one written by the symbol editor differ in indentation and nothing else.
+    """
+    parts: List[str] = []
+    for off in iter_child_offsets(block):
+        head = _HEAD.match(block, off)
+        if not head or head.group(1) != "symbol":
+            continue
+        end = match_paren(block, off)
+        if end == -1:
+            continue
+        unit = block[off : end + 1]
+        name, _ = _read_string(block, head.end())
+        if name and name.startswith(symbol_name):
+            unit = unit.replace(f'"{name}"', f'"{name[len(symbol_name):]}"', 1)
+        parts.append(_WHITESPACE.sub(" ", unit).strip())
+    if not parts:
+        return ""
+    return hashlib.sha1("\n".join(sorted(parts)).encode("utf-8")).hexdigest()[:16]
+
+
+def read_library_symbols(text: str) -> List[Dict[str, Any]]:
+    """Parse a .kicad_sym into one record per top-level symbol."""
+    root = _HEAD.search(text)
+    if not root:
+        return []
+    lib_start = root.start()
+    symbols: List[Dict[str, Any]] = []
+
+    for off in iter_child_offsets(text[lib_start:]):
+        off += lib_start
+        head = _HEAD.match(text, off)
+        if not head or head.group(1) != "symbol":
+            continue
+        end = match_paren(text, off)
+        if end == -1:
+            continue
+        block = text[off : end + 1]
+        name, _ = _read_string(text, head.end())
+        if not name:
+            continue
+
+        properties: Dict[str, str] = {}
+        extends: Optional[str] = None
+        for child in iter_child_offsets(block):
+            child_head = _HEAD.match(block, child)
+            if not child_head:
+                continue
+            token = child_head.group(1)
+            if token == "property":
+                key, after = _read_string(block, child_head.end())
+                value, _ = _read_string(block, after)
+                if key is not None:
+                    properties[key] = value or ""
+            elif token == "extends":
+                extends, _ = _read_string(block, child_head.end())
+
+        symbols.append(
+            {
+                "name": name,
+                "properties": properties,
+                "normalized": {_norm_key(k): v for k, v in properties.items()},
+                "extends": extends,
+                "pinCount": len(re.findall(r"\(pin\s+[A-Za-z_]", block)),
+                "fingerprint": "" if extends else _fingerprint(block, name),
+            }
+        )
+    return symbols
+
+
+def _first_property(symbol: Dict[str, Any], keys: Sequence[str]) -> Tuple[str, str]:
+    """Return (value, property name) for the first of *keys* that is filled."""
+    for key in keys:
+        value = symbol["normalized"].get(key, "").strip()
+        if value:
+            original = next(
+                (k for k in symbol["properties"] if _norm_key(k) == key),
+                key,
+            )
+            return value, original
+    return "", ""
+
+
+def _iter_schematics(paths: Iterable[str]) -> List[Path]:
+    """Expand a mix of .kicad_sch files and directories into sheet paths."""
+    sheets: List[Path] = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            sheets.extend(sorted(path.rglob("*.kicad_sch")))
+        elif path.is_file():
+            sheets.append(path)
+    seen: Set[Path] = set()
+    unique = []
+    for sheet in sheets:
+        resolved = sheet.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            unique.append(sheet)
+    return unique
+
+
+def count_symbol_usage(sheets: Sequence[Path]) -> Dict[str, Dict[str, int]]:
+    """Count symbol instances per symbol name, per sheet.
+
+    The library nickname in a lib_id is ignored: the same library is registered
+    under different nicknames in different projects, and the question being
+    asked is which symbol is in use, not which table entry pointed at it.
+    """
+    usage: Dict[str, Dict[str, int]] = {}
+    for sheet in sheets:
+        try:
+            text = sheet.read_text(encoding="utf-8")
+        except OSError as e:
+            logger.warning("Could not read %s: %s", sheet, e)
+            continue
+        # Only placed instances carry (lib_id ...); the lib_symbols cache keys
+        # its entries by the id itself, so counting lib_id counts placements.
+        for m in _LIB_ID.finditer(text):
+            lib_id = m.group(1)
+            symbol_name = lib_id.split(":", 1)[1] if ":" in lib_id else lib_id
+            usage.setdefault(symbol_name, {})
+            usage[symbol_name][sheet.name] = usage[symbol_name].get(sheet.name, 0) + 1
+    return usage
+
+
+def _group_key(symbol: Dict[str, Any], strategy: str, ignore_case: bool) -> Tuple[str, str]:
+    """Return (key, provenance) for one symbol under one strategy; '' means skip."""
+    if strategy == "mpn":
+        value, source = _first_property(symbol, MPN_KEYS)
+    elif strategy == "supplier":
+        value, source = _first_property(symbol, SUPPLIER_KEYS)
+    elif strategy == "value_footprint":
+        value_field = symbol["normalized"].get("VALUE", "").strip()
+        footprint = symbol["normalized"].get("FOOTPRINT", "").strip()
+        if not value_field or not footprint:
+            return "", ""
+        value, source = f"{value_field} @ {footprint}", "Value + Footprint"
+    elif strategy == "graphics":
+        value, source = symbol["fingerprint"], "body"
+    elif strategy == "name":
+        value = re.sub(r"[\s_\-.]+", "", symbol["name"])
+        source = "name"
+    else:
+        return "", ""
+
+    if not value:
+        return "", ""
+    if ignore_case and strategy != "graphics":
+        value = value.upper()
+    return value, source
+
+
+def _suggest_keep(members: List[Dict[str, Any]]) -> Tuple[str, str]:
+    """Pick the member to keep, and say why. Deterministic on ties."""
+    best = max(
+        members,
+        key=lambda m: (
+            m["usageCount"],
+            sum(1 for f in ("mpn", "datasheet", "description") if m.get(f)),
+            -len(m["name"]),
+            [-ord(c) for c in m["name"]],
+        ),
+    )
+    if best["usageCount"] > 0 and all(
+        m["usageCount"] == 0 for m in members if m["name"] != best["name"]
+    ):
+        reason = f"only one in use ({best['usageCount']} instance(s))"
+    elif best["usageCount"] > 0:
+        reason = f"most used ({best['usageCount']} instance(s))"
+    elif any(m["usageCount"] for m in members):
+        reason = "most used"
+    else:
+        reason = "none are used; most complete fields"
+    return best["name"], reason
+
+
+def find_duplicate_symbols(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Group symbols in a library that look like the same part stored twice."""
+    lib_path = Path(params.get("libraryPath", ""))
+    requested = params.get("matchBy") or list(DEFAULT_STRATEGIES)
+    if isinstance(requested, str):
+        requested = [requested]
+    unknown = [s for s in requested if s not in STRATEGIES]
+    if unknown:
+        return {
+            "success": False,
+            "message": f"Unknown matchBy value(s): {', '.join(unknown)}",
+            "validStrategies": list(STRATEGIES),
+        }
+
+    ignore_case = bool(params.get("ignoreCase", True))
+    min_group_size = max(2, int(params.get("minGroupSize", 2)))
+
+    if not lib_path.is_file():
+        return {"success": False, "message": f"Library not found: {lib_path}"}
+    try:
+        text = lib_path.read_text(encoding="utf-8")
+    except OSError as e:
+        return {"success": False, "message": f"Could not read {lib_path}: {e}"}
+
+    root = _HEAD.search(text)
+    if not root or root.group(1) != "kicad_symbol_lib":
+        found = root.group(1) if root else "nothing"
+        return {
+            "success": False,
+            "message": (
+                f"{lib_path.name} is not a symbol library "
+                f"(root form is '{found}', expected 'kicad_symbol_lib')"
+            ),
+        }
+
+    symbols = read_library_symbols(text)
+    if not symbols:
+        return {
+            "success": True,
+            "message": f"{lib_path.name} contains no symbols",
+            "symbolCount": 0,
+            "groups": [],
+        }
+
+    sheets = _iter_schematics(params.get("schematicPaths") or [])
+    usage = count_symbol_usage(sheets)
+
+    # A pair of symbols usually trips more than one strategy. Group by the set
+    # of members so the report has one entry per real duplicate, listing the
+    # evidence, instead of the same pair three times.
+    buckets: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    for strategy in requested:
+        by_key: Dict[str, List[Dict[str, Any]]] = {}
+        for symbol in symbols:
+            key, _ = _group_key(symbol, strategy, ignore_case)
+            if key:
+                by_key.setdefault(key, []).append(symbol)
+        for key, group in by_key.items():
+            if len(group) >= min_group_size:
+                buckets[(strategy, key)] = group
+
+    merged: Dict[frozenset, Dict[str, Any]] = {}
+    for (strategy, key), group in buckets.items():
+        names = frozenset(s["name"] for s in group)
+        entry = merged.setdefault(names, {"symbols": group, "evidence": []})
+        source = _group_key(group[0], strategy, ignore_case)[1]
+        entry["evidence"].append({"strategy": strategy, "key": key, "from": source})
+
+    groups: List[Dict[str, Any]] = []
+    for entry in merged.values():
+        members: List[Dict[str, Any]] = []
+        for symbol in sorted(entry["symbols"], key=lambda s: s["name"]):
+            sheets_used = usage.get(symbol["name"], {})
+            mpn, mpn_from = _first_property(symbol, MPN_KEYS)
+            members.append(
+                {
+                    "name": symbol["name"],
+                    "value": symbol["properties"].get("Value", ""),
+                    "footprint": symbol["properties"].get("Footprint", ""),
+                    "datasheet": symbol["properties"].get("Datasheet", ""),
+                    "description": symbol["properties"].get("Description", ""),
+                    "mpn": mpn,
+                    "mpnProperty": mpn_from,
+                    "extends": symbol["extends"],
+                    "pinCount": symbol["pinCount"],
+                    "usageCount": sum(sheets_used.values()),
+                    "usedIn": sorted(sheets_used),
+                }
+            )
+        keep, reason = _suggest_keep(members)
+        groups.append(
+            {
+                "size": len(members),
+                "evidence": sorted(entry["evidence"], key=lambda e: e["strategy"]),
+                "matchedBy": sorted({e["strategy"] for e in entry["evidence"]}),
+                "members": members,
+                "suggestedKeep": keep,
+                "keepReason": reason,
+                "unusedMembers": [m["name"] for m in members if m["usageCount"] == 0],
+            }
+        )
+
+    groups.sort(key=lambda g: (-g["size"], g["members"][0]["name"]))
+    duplicate_count = sum(g["size"] - 1 for g in groups)
+
+    if not groups:
+        message = f"No duplicates found among {len(symbols)} symbol(s)"
+    else:
+        message = (
+            f"{len(groups)} duplicate group(s) covering {duplicate_count} "
+            f"redundant symbol(s) out of {len(symbols)}"
+        )
+        if sheets:
+            retirable = sum(len(g["unusedMembers"]) for g in groups)
+            message += f"; {retirable} unused across {len(sheets)} sheet(s)"
+        else:
+            message += "; pass schematicPaths to see which ones are actually used"
+
+    return {
+        "success": True,
+        "message": message,
+        "libraryPath": str(lib_path),
+        "symbolCount": len(symbols),
+        "sheetsScanned": [s.name for s in sheets],
+        "matchBy": list(requested),
+        "groupCount": len(groups),
+        "duplicateSymbolCount": duplicate_count,
+        "groups": groups,
+    }

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -331,6 +331,7 @@ try:
     from commands.design_rules import DesignRuleCommands
     from commands.eagle import EagleCommands
     from commands.export import ExportCommands
+    from commands.find_duplicate_symbols import find_duplicate_symbols
     from commands.footprint import FootprintCreator
     from commands.freerouting import FreeroutingCommands
     from commands.hierarchical_place import HierarchicalPlaceCommands
@@ -557,6 +558,7 @@ class KiCADInterface(SchematicHandlersMixin):
             # Symbol pin discovery commands (read pins straight from symbol libraries)
             "list_symbol_pins": self.symbol_pin_commands.list_symbol_pins,
             "batch_list_symbol_pins": self.symbol_pin_commands.batch_list_symbol_pins,
+            "find_duplicate_symbols": find_duplicate_symbols,
             "repair_flat_symbols": self.symbol_repair_commands.repair_flat_symbols,
             # Schematic hierarchy commands (sheet insertion + subsheet scaffolding)
             "add_hierarchical_sheet": self.hierarchy_commands.add_hierarchical_sheet,

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -3007,7 +3007,10 @@ SCHEMATIC_TOOLS = [
                     "description": (
                         "How to decide two symbols are the same part. 'graphics' is off by "
                         "default: every resistor in a library shares one body, so on "
-                        "passives it groups the whole family."
+                        "passives it groups the whole family. 'name' is off by default "
+                        "because matching names that differ only in separators is the "
+                        "weakest signal here. Values that only mark a field as unfilled "
+                        "(N/A, TBD, -, ~) are never used as a key."
                     ),
                 },
                 "schematicPaths": {
@@ -3015,7 +3018,24 @@ SCHEMATIC_TOOLS = [
                     "items": {"type": "string"},
                     "description": (
                         ".kicad_sch files or directories to scan for usage counts. "
-                        "Directories are searched recursively."
+                        "Directories are searched recursively, skipping autosave sheets "
+                        "and backup/history folders, which are copies of sheets already "
+                        "being counted. Only placements of THIS library are counted (see "
+                        "libraryNicknames), and a sub-sheet instantiated more than once "
+                        "counts once per instantiation. Paths that do not exist come back "
+                        "in missingPaths rather than being silently ignored."
+                    ),
+                },
+                "libraryNicknames": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "The nickname(s) this library is registered under in a lib_id, if "
+                        "the file stem and the sym-lib-table entries beside the scanned "
+                        "sheets do not cover it. Placements naming another library are not "
+                        "counted: a bare 'R' here is not Device:R. The result reports the "
+                        "nicknames used (libraryNicknames) and the ones actually found in "
+                        "the sheets (nicknamesSeen)."
                     ),
                 },
                 "minGroupSize": {

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -12,6 +12,8 @@ Each tool includes:
 
 from typing import Any, Dict
 
+from utils.duplicate_strategies import DEFAULT_DUPLICATE_STRATEGIES, DUPLICATE_STRATEGIES
+
 # =============================================================================
 # PROJECT TOOLS
 # =============================================================================
@@ -2977,6 +2979,57 @@ SCHEMATIC_TOOLS = [
                 "hide": {"type": "boolean", "default": False},
             },
             "required": ["libraryPath", "symbolName", "propertyName", "propertyValue"],
+        },
+    },
+    {
+        "name": "find_duplicate_symbols",
+        "title": "Find Duplicate Symbols in a Library",
+        "description": (
+            "Group symbols in a .kicad_sym that are the same part stored twice under "
+            "different names -- the residue of Eagle imports, SnapEDA downloads and parts "
+            "re-added because search did not find the existing name. KiCad reports nothing "
+            "here, because the names differ, which is also why grepping does not find it. "
+            "Matches on manufacturer part number (tolerating the inconsistent property "
+            "naming real libraries have: MPN, MP, 'MANUFACTURER PART NUMBER', 'PART "
+            "NUMBER'), on distributor part number, on Value+Footprint, on an identical "
+            "drawn body, or on near-identical names. Pass schematicPaths to count how many "
+            "instances each duplicate actually has, which turns the report into a decision: "
+            "the one nothing places is the one to retire."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "libraryPath": {"type": "string", "description": "Path to the .kicad_sym file"},
+                "matchBy": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": list(DUPLICATE_STRATEGIES)},
+                    "default": list(DEFAULT_DUPLICATE_STRATEGIES),
+                    "description": (
+                        "How to decide two symbols are the same part. 'graphics' is off by "
+                        "default: every resistor in a library shares one body, so on "
+                        "passives it groups the whole family."
+                    ),
+                },
+                "schematicPaths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        ".kicad_sch files or directories to scan for usage counts. "
+                        "Directories are searched recursively."
+                    ),
+                },
+                "minGroupSize": {
+                    "type": "integer",
+                    "default": 2,
+                    "description": "Only report groups with at least this many symbols",
+                },
+                "ignoreCase": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Compare part numbers and values case-insensitively",
+                },
+            },
+            "required": ["libraryPath"],
         },
     },
     {

--- a/python/utils/duplicate_strategies.py
+++ b/python/utils/duplicate_strategies.py
@@ -1,0 +1,14 @@
+"""Ways find_duplicate_symbols can decide two symbols are the same part.
+
+Dependency-free so the tool schema and the command share one list instead of
+drifting apart.
+
+``graphics`` is deliberately absent from the defaults: every resistor in a
+library is drawn with the same body, so on passives it groups the whole family
+and reports nothing useful. It earns its keep when hunting a custom part that
+was copied under a new name.
+"""
+
+DUPLICATE_STRATEGIES = ("mpn", "supplier", "value_footprint", "graphics", "name")
+
+DEFAULT_DUPLICATE_STRATEGIES = ("mpn", "value_footprint")

--- a/python/utils/duplicate_strategies.py
+++ b/python/utils/duplicate_strategies.py
@@ -7,6 +7,16 @@ drifting apart.
 library is drawn with the same body, so on passives it groups the whole family
 and reports nothing useful. It earns its keep when hunting a custom part that
 was copied under a new name.
+
+``name`` is absent for the opposite reason -- it is the weakest signal, not the
+loudest. It collapses the separators between the parts of a name, so ``R_10K``
+and ``R-10K`` match, and finds little beyond a part re-added by retyping its
+name. The decimal point is NOT collapsed: doing so makes ``C_1.0uF_0805`` and
+``C_10uF_0805`` the same key.
+
+Whatever the strategy, a key has to be a value and not a marker meaning the
+field was left blank -- ``N/A``, ``TBD``, ``-``, KiCad's ``~``. Grouping on one
+of those puts every part an importer could not fill in into a single group.
 """
 
 DUPLICATE_STRATEGIES = ("mpn", "supplier", "value_footprint", "graphics", "name")

--- a/python/utils/sexpr_format.py
+++ b/python/utils/sexpr_format.py
@@ -76,6 +76,77 @@ QUOTED_VALUE = r'"((?:[^"\\]|\\.)*)"'
 QUOTED_VALUE_SKIP = r'"(?:[^"\\]|\\.)*"'
 
 
+# ---------------------------------------------------------------------------
+# String-aware structure walking
+# ---------------------------------------------------------------------------
+#
+# Tools that edit KiCad files as text need to know where a list ends without
+# re-serializing the file. Counting parens is not enough: a Description of
+# ``"Ceramic (X7R) 50V"`` or a footprint named ``HRS_U.FL-R-SMT-1(10)`` puts
+# unbalanced parens inside quoted tokens, and real libraries contain both.
+#
+# These two helpers skip quoted text, so callers can slice a block out of a
+# file and splice a new one back without a parser.
+
+
+def match_paren(content: str, open_idx: int) -> int:
+    """Index of the ``)`` closing the ``(`` at *open_idx*, or -1 if unbalanced.
+
+    Parens inside quoted tokens are literal text, not structure.
+    """
+    depth = 0
+    in_string = False
+    i = open_idx
+    while i < len(content):
+        ch = content[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def iter_child_offsets(block: str, depth: int = 2):
+    """Yield the offset of every list nested *depth* levels inside *block*.
+
+    *block* starts at its own ``(``, which is depth 1, so the default yields
+    its direct children. Depth is counted structurally rather than from
+    indentation: KiCad's own writers emit files whose indentation does not
+    always match nesting.
+    """
+    current = 0
+    in_string = False
+    i = 0
+    while i < len(block):
+        ch = block[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "(":
+            current += 1
+            if current == depth:
+                yield i
+        elif ch == ")":
+            current -= 1
+        i += 1
+
+
 def escape_sexpr_string(value: str) -> str:
     """Escape a string for insertion into a KiCad double-quoted token.
 

--- a/src/tools/library-symbol.ts
+++ b/src/tools/library-symbol.ts
@@ -387,7 +387,20 @@ Returns symbol references that can be used directly in schematics.`,
       schematicPaths: z
         .array(z.string())
         .optional()
-        .describe(".kicad_sch files or directories to scan for usage counts (recursive)"),
+        .describe(
+          ".kicad_sch files or directories to scan for usage counts (recursive, skipping " +
+            "autosave sheets and backup/history folders). Only placements of this library " +
+            "count, and a sub-sheet instantiated more than once counts once per instantiation.",
+        ),
+      libraryNicknames: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "The nickname(s) this library is registered under in a lib_id, if the file stem " +
+            "and the sym-lib-table entries beside the scanned sheets do not cover it. A " +
+            "bare 'R' in this library is not Device:R, so placements naming another " +
+            "library are not counted towards it.",
+        ),
       minGroupSize: z
         .number()
         .optional()
@@ -401,6 +414,7 @@ Returns symbol references that can be used directly in schematics.`,
       libraryPath: string;
       matchBy?: string[];
       schematicPaths?: string[];
+      libraryNicknames?: string[];
       minGroupSize?: number;
       ignoreCase?: boolean;
     }) => {

--- a/src/tools/library-symbol.ts
+++ b/src/tools/library-symbol.ts
@@ -361,4 +361,53 @@ Returns symbol references that can be used directly in schematics.`,
       };
     },
   );
+
+  // Find the same part stored twice under different names
+  server.tool(
+    "find_duplicate_symbols",
+    "Group symbols in a .kicad_sym that are the same part stored twice under different " +
+      "names — the residue of Eagle imports, SnapEDA downloads, and parts re-added because " +
+      "search did not find the existing name. KiCAD reports nothing here because the names " +
+      "differ, which is also why grepping does not find it. Matches on manufacturer part " +
+      "number (tolerating the inconsistent property naming real libraries have: MPN, MP, " +
+      "'MANUFACTURER PART NUMBER', 'PART NUMBER'), on distributor part number, on " +
+      "Value+Footprint, on an identical drawn body, or on near-identical names. Pass " +
+      "schematicPaths to count how many instances each duplicate actually has — that turns " +
+      "the report into a decision, because the one nothing places is the one to retire.",
+    {
+      libraryPath: z.string().describe("Absolute path to the .kicad_sym library file"),
+      matchBy: z
+        .array(z.enum(["mpn", "supplier", "value_footprint", "graphics", "name"]))
+        .optional()
+        .describe(
+          "How to decide two symbols are the same part (default: mpn, value_footprint). " +
+            "'graphics' is off by default: every resistor in a library shares one body, so " +
+            "on passives it groups the whole family.",
+        ),
+      schematicPaths: z
+        .array(z.string())
+        .optional()
+        .describe(".kicad_sch files or directories to scan for usage counts (recursive)"),
+      minGroupSize: z
+        .number()
+        .optional()
+        .describe("Only report groups with at least this many symbols (default 2)"),
+      ignoreCase: z
+        .boolean()
+        .optional()
+        .describe("Compare part numbers and values case-insensitively (default true)"),
+    },
+    async (args: {
+      libraryPath: string;
+      matchBy?: string[];
+      schematicPaths?: string[];
+      minGroupSize?: number;
+      ignoreCase?: boolean;
+    }) => {
+      const result = await callKicadScript("find_duplicate_symbols", args);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -157,6 +157,7 @@ export const toolCategories: ToolCategory[] = [
       // symbol-library category yet -- see #345, which tracks giving the
       // ~13 unregistered symbol tools a proper home.
       "repair_flat_symbols",
+      "find_duplicate_symbols",
     ],
   },
   {

--- a/tests/test_find_duplicate_symbols.py
+++ b/tests/test_find_duplicate_symbols.py
@@ -10,6 +10,7 @@ from commands.find_duplicate_symbols import (  # noqa: E402
     count_symbol_usage,
     find_duplicate_symbols,
     read_library_symbols,
+    resolve_library_nicknames,
 )
 
 
@@ -87,6 +88,34 @@ SCH = (
     '\t(symbol\n\t\t(lib_id "OtherNick:LED_RED")\n\t\t(at 30 10 0)\n\t)\n'
     ")\n"
 )
+
+
+def placements(*lib_ids):
+    """A schematic placing each lib_id once, in order."""
+    out = "(kicad_sch\n"
+    for i, lib_id in enumerate(lib_ids):
+        out += f'\t(symbol\n\t\t(lib_id "{lib_id}")\n\t\t(at {i} 10 0)\n\t)\n'
+    return out + ")\n"
+
+
+def sheet_block(name, file_name):
+    return (
+        "\t(sheet\n\t\t(at 0 0)\n"
+        f'\t\t(property "Sheetname" "{name}")\n'
+        f'\t\t(property "Sheetfile" "{file_name}")\n\t)\n'
+    )
+
+
+def sheets_sch(*blocks):
+    return "(kicad_sch\n" + "".join(blocks) + ")\n"
+
+
+def sym_lib_table(nickname, uri):
+    return (
+        "(sym_lib_table\n\t(version 7)\n"
+        f'\t(lib (name "{nickname}")(type "KiCad")(uri "{uri}")(options "")(descr ""))\n'
+        ")\n"
+    )
 
 
 @pytest.fixture
@@ -190,7 +219,8 @@ def test_graphics_match_finds_a_copy_with_different_fields(lib):
 
 def test_graphics_is_off_by_default(lib):
     """Every resistor in a library shares one body; on a real library graphics
-    alone grouped 78 different values together. It has to be asked for."""
+    alone put 78 resistor symbols, spanning 53 distinct values, in one group.
+    It has to be asked for."""
     r = run(lib)
     assert all("LED_RED" not in [m["name"] for m in g["members"]] for g in r["groups"])
     assert r["matchBy"] == ["mpn", "value_footprint"]
@@ -215,6 +245,154 @@ def test_strategies_agreeing_produce_one_group_not_three(lib):
     assert matching[0]["matchedBy"] == ["graphics", "mpn", "value_footprint"]
 
 
+# --- placeholder values ---------------------------------------------------- #
+
+
+def test_a_placeholder_mpn_does_not_group_unrelated_parts(tmp_path):
+    """N/A is what an importer writes for a part with no MPN, not an MPN.
+
+    Six parts sharing nothing but that marker were reported as one group of six
+    under the default strategies -- the failure graphics has on passives,
+    happening where it cannot be turned off.
+    """
+    path = tmp_path / "Imported.kicad_sym"
+    path.write_text(
+        "(kicad_symbol_lib\n"
+        + "".join(
+            sym(f"PART_{i}", {"Value": f"V{i}", "Footprint": f"FP_{i}", "MPN": "N/A"}, unit_x=i)
+            for i in range(6)
+        )
+        + ")\n",
+        encoding="utf-8",
+    )
+    r = find_duplicate_symbols({"libraryPath": str(path)})
+    assert r["groupCount"] == 0
+    assert r["duplicateSymbolCount"] == 0
+
+
+@pytest.mark.parametrize("marker", ["~", "-", "--", "N/A", "n/a", "NA", "None", "TBD", "?", "X"])
+def test_every_known_placeholder_is_rejected_as_an_mpn(tmp_path, marker):
+    path = tmp_path / f"Lib{abs(hash(marker))}.kicad_sym"
+    path.write_text(
+        "(kicad_symbol_lib\n"
+        + sym("A", {"Value": "1", "Footprint": "f:1", "MPN": marker}, unit_x=1)
+        + sym("B", {"Value": "2", "Footprint": "f:2", "MPN": marker}, unit_x=2)
+        + ")\n",
+        encoding="utf-8",
+    )
+    assert find_duplicate_symbols({"libraryPath": str(path), "matchBy": ["mpn"]})["groupCount"] == 0
+
+
+def test_kicads_empty_field_marker_is_not_a_value_footprint_key(tmp_path):
+    """~ is how KiCad spells an empty field."""
+    path = tmp_path / "Tilde.kicad_sym"
+    path.write_text(
+        "(kicad_symbol_lib\n"
+        + "".join(sym(f"U_{i}", {"Value": "~", "Footprint": "~"}, unit_x=i) for i in range(4))
+        + ")\n",
+        encoding="utf-8",
+    )
+    r = find_duplicate_symbols({"libraryPath": str(path), "matchBy": ["value_footprint"]})
+    assert r["groupCount"] == 0
+
+
+def test_a_real_part_number_wins_over_a_placeholder_in_another_spelling(tmp_path):
+    """MPN is N/A but PART NUMBER is real, so the real one decides the match."""
+    path = tmp_path / "Mixed.kicad_sym"
+    path.write_text(
+        "(kicad_symbol_lib\n"
+        + sym("A", {"Value": "1", "Footprint": "f:1", "MPN": "N/A", "PART NUMBER": "REAL-1"})
+        + sym("B", {"Value": "2", "Footprint": "f:2", "MPN": "REAL-1"}, unit_x=2)
+        + ")\n",
+        encoding="utf-8",
+    )
+    r = find_duplicate_symbols({"libraryPath": str(path), "matchBy": ["mpn"]})
+    assert r["groupCount"] == 1
+    assert r["groups"][0]["evidence"][0]["key"] == "REAL-1"
+    member = next(m for m in r["groups"][0]["members"] if m["name"] == "A")
+    assert member["mpn"] == "REAL-1"
+    assert member["mpnProperty"] == "PART NUMBER"
+
+
+# --- overlapping groups ---------------------------------------------------- #
+
+
+def test_overlapping_groups_merge_into_one_component(tmp_path):
+    """A and B share an MPN; A, B and C share Value + Footprint.
+
+    Merging on the exact member set made those two separate groups, so A and B
+    were reported twice and three of three symbols were called redundant.
+    """
+    path = tmp_path / "Overlap.kicad_sym"
+    path.write_text(
+        "(kicad_symbol_lib\n"
+        + sym("A", {"Value": "10K", "Footprint": "R0402", "MPN": "SHARED"})
+        + sym("B", {"Value": "10K", "Footprint": "R0402", "MPN": "SHARED"})
+        + sym("C", {"Value": "10K", "Footprint": "R0402", "MPN": "OTHER-C"})
+        + ")\n",
+        encoding="utf-8",
+    )
+    r = find_duplicate_symbols({"libraryPath": str(path)})
+    assert r["groupCount"] == 1
+    assert r["duplicateSymbolCount"] == 2
+    group = r["groups"][0]
+    assert [m["name"] for m in group["members"]] == ["A", "B", "C"]
+    assert group["matchedBy"] == ["mpn", "value_footprint"]
+    assert [e["key"] for e in group["evidence"]] == ["SHARED", "10K @ R0402"]
+
+
+def test_no_symbol_appears_in_two_groups(tmp_path):
+    """A caller iterating groups must not process the same symbol twice."""
+    path = tmp_path / "Chain.kicad_sym"
+    path.write_text(
+        "(kicad_symbol_lib\n"
+        + sym("A", {"Value": "1u", "Footprint": "C0402", "MPN": "M-AB"})
+        + sym("B", {"Value": "1u", "Footprint": "C0402", "MPN": "M-AB"})
+        + sym("C", {"Value": "1u", "Footprint": "C0402", "MPN": "M-CD"})
+        + sym("D", {"Value": "1u", "Footprint": "C0402", "MPN": "M-CD"})
+        + ")\n",
+        encoding="utf-8",
+    )
+    r = find_duplicate_symbols({"libraryPath": str(path)})
+    seen = [m["name"] for g in r["groups"] for m in g["members"]]
+    assert sorted(seen) == ["A", "B", "C", "D"]
+    assert r["duplicateSymbolCount"] <= r["symbolCount"] - r["groupCount"]
+
+
+# --- the name strategy ----------------------------------------------------- #
+
+
+def test_the_name_strategy_matches_across_separators(tmp_path):
+    path = tmp_path / "Names.kicad_sym"
+    path.write_text(
+        "(kicad_symbol_lib\n"
+        + sym("R_10K_0402", {"Value": "10K"})
+        + sym("R-10K-0402", {"Value": "10K"}, unit_x=2)
+        + ")\n",
+        encoding="utf-8",
+    )
+    r = find_duplicate_symbols({"libraryPath": str(path), "matchBy": ["name"]})
+    assert r["groupCount"] == 1
+    assert r["groups"][0]["evidence"][0]["from"] == "name"
+
+
+def test_the_name_strategy_keeps_the_decimal_point(tmp_path):
+    """Stripping it made C_1.0uF_0805 and C_10uF_0805 -- and R_1.5K and R_15K -- one key."""
+    path = tmp_path / "Decimals.kicad_sym"
+    path.write_text(
+        "(kicad_symbol_lib\n"
+        + sym("C_1.0uF_0805", {"Value": "1.0uF"}, unit_x=1)
+        + sym("C_10uF_0805", {"Value": "10uF"}, unit_x=2)
+        + sym("R_1.5K", {"Value": "1.5K"}, unit_x=3)
+        + sym("R_15K", {"Value": "15K"}, unit_x=4)
+        + ")\n",
+        encoding="utf-8",
+    )
+    assert (
+        find_duplicate_symbols({"libraryPath": str(path), "matchBy": ["name"]})["groupCount"] == 0
+    )
+
+
 def test_evidence_records_which_property_supplied_the_key(lib):
     g = group_named(run(lib, matchBy=["mpn"]), "R_0402_10K")
     assert g["evidence"][0]["from"] == "MPN"
@@ -233,15 +411,109 @@ def test_member_reports_which_property_its_mpn_came_from(lib):
 def test_usage_counts_instances_not_cache_entries(tmp_path):
     sheet = tmp_path / "board.kicad_sch"
     sheet.write_text(SCH, encoding="utf-8")
-    usage = count_symbol_usage([sheet])
-    assert usage["R_0402_10K"] == {"board.kicad_sch": 2}
+    usage = count_symbol_usage([sheet], ["FOG"])
+    assert usage.counts["R_0402_10K"] == {"board.kicad_sch": 2}
 
 
-def test_usage_ignores_the_library_nickname(tmp_path):
-    """The same library is registered under different nicknames per project."""
+def test_another_librarys_placements_are_not_counted_as_this_librarys(tmp_path):
+    """OtherNick:LED_RED is not FOG's LED_RED, however alike the names are."""
     sheet = tmp_path / "board.kicad_sch"
     sheet.write_text(SCH, encoding="utf-8")
-    assert count_symbol_usage([sheet])["LED_RED"] == {"board.kicad_sch": 1}
+    usage = count_symbol_usage([sheet], ["FOG"])
+    assert "LED_RED" not in usage.counts
+    assert usage.nicknames_seen == ["FOG", "OtherNick"]
+
+
+def test_a_stock_library_does_not_make_an_unused_symbol_look_popular(tmp_path):
+    """Bare one-letter names collide with Device:/Switch:/power: constantly.
+
+    Crediting Device:R's 50 placements to this library's R recommended keeping
+    the symbol nothing references and retiring the only one actually placed.
+    """
+    path = tmp_path / "MyLib.kicad_sym"
+    path.write_text(
+        "(kicad_symbol_lib\n"
+        + sym("R", {"Value": "10K", "Footprint": "R_0402", "MPN": "RC0402-10K"})
+        + sym("R_10K_0402", {"Value": "10K", "Footprint": "R_0402", "MPN": "RC0402-10K"})
+        + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "board.kicad_sch").write_text(
+        placements(*(["Device:R"] * 50 + ["MyLib:R_10K_0402"] * 3)), encoding="utf-8"
+    )
+    g = run(path, schematicPaths=[str(tmp_path)])["groups"][0]
+    by_name = {m["name"]: m for m in g["members"]}
+    assert by_name["R"]["usageCount"] == 0
+    assert by_name["R_10K_0402"]["usageCount"] == 3
+    assert g["suggestedKeep"] == "R_10K_0402"
+    assert g["unusedMembers"] == ["R"]
+
+
+def test_a_lib_id_with_no_nickname_is_counted_by_name(tmp_path):
+    """A bare id names no library, so its name is all there is to go on."""
+    sheet = tmp_path / "board.kicad_sch"
+    sheet.write_text(placements("R_0402_10K", "R_0402_10K"), encoding="utf-8")
+    usage = count_symbol_usage([sheet], ["FOG"])
+    assert usage.counts["R_0402_10K"] == {"board.kicad_sch": 2}
+    assert usage.nicknames_seen == []
+
+
+def test_the_nickname_is_taken_from_sym_lib_table(tmp_path):
+    """sym-lib-table decides the nickname, and it need not be the file name."""
+    lib_path = tmp_path / "FOG_components.kicad_sym"
+    lib_path.write_text(LIB, encoding="utf-8")
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "sym-lib-table").write_text(
+        sym_lib_table("FOGSYM", "${KIPRJMOD}/../FOG_components.kicad_sym"), encoding="utf-8"
+    )
+    (project / "board.kicad_sch").write_text(
+        placements("FOGSYM:R_0402_10K", "FOGSYM:R_0402_10K"), encoding="utf-8"
+    )
+    r = run(lib_path, schematicPaths=[str(project)])
+    assert sorted(r["libraryNicknames"]) == ["FOGSYM", "FOG_components"]
+    used = next(m for m in group_named(r, "R_0402_10K")["members"] if m["name"] == "R_0402_10K")
+    assert used["usageCount"] == 2
+
+
+def test_a_sym_lib_table_entry_for_another_library_is_not_adopted(tmp_path):
+    lib_path = tmp_path / "FOG.kicad_sym"
+    lib_path.write_text(LIB, encoding="utf-8")
+    (tmp_path / "sym-lib-table").write_text(
+        sym_lib_table("Elsewhere", "${KIPRJMOD}/other.kicad_sym"), encoding="utf-8"
+    )
+    (tmp_path / "board.kicad_sch").write_text(SCH, encoding="utf-8")
+    assert run(lib_path, schematicPaths=[str(tmp_path)])["libraryNicknames"] == ["FOG"]
+
+
+def test_library_nicknames_can_be_given_explicitly(tmp_path):
+    """The escape hatch for a library no scanned project's table registers."""
+    lib_path = tmp_path / "FOG.kicad_sym"
+    lib_path.write_text(LIB, encoding="utf-8")
+    (tmp_path / "board.kicad_sch").write_text(
+        placements("Renamed:R_0402_10K", "Renamed:R_0402_10K"), encoding="utf-8"
+    )
+    r = run(lib_path, schematicPaths=[str(tmp_path)], libraryNicknames=["Renamed"])
+    assert r["libraryNicknames"] == ["Renamed"]
+    used = next(m for m in group_named(r, "R_0402_10K")["members"] if m["name"] == "R_0402_10K")
+    assert used["usageCount"] == 2
+
+
+def test_a_nickname_mismatch_is_said_out_loud(tmp_path):
+    """Attributing nothing must not read the same as "nothing is used"."""
+    lib_path = tmp_path / "FOG.kicad_sym"
+    lib_path.write_text(LIB, encoding="utf-8")
+    (tmp_path / "board.kicad_sch").write_text(
+        placements("Renamed:R_0402_10K", "Renamed:RES-10K-0402"), encoding="utf-8"
+    )
+    r = run(lib_path, schematicPaths=[str(tmp_path)])
+    assert r["nicknamesSeen"] == ["Renamed"]
+    assert "no usage was attributed to this library" in r["message"]
+    assert "libraryNicknames" in r["message"]
+
+
+def test_resolve_library_nicknames_defaults_to_the_file_stem(tmp_path):
+    assert resolve_library_nicknames(tmp_path / "FOG.kicad_sym", []) == {"FOG"}
 
 
 def test_usage_is_attached_to_members(project, lib):
@@ -259,6 +531,115 @@ def test_a_directory_of_sheets_is_expanded(project, lib):
     )
     r = run(lib, schematicPaths=[str(project)])
     assert sorted(r["sheetsScanned"]) == ["board.kicad_sch", "sub.kicad_sch"]
+
+
+def test_an_autosave_sheet_is_not_counted(project, lib):
+    """eeschema writes _autosave-<sheet> while the project is open; it is a copy
+    of a sheet already being scanned, so counting it doubles every number."""
+    (project / "_autosave-board.kicad_sch").write_text(SCH, encoding="utf-8")
+    r = run(lib, schematicPaths=[str(project)])
+    assert r["sheetsScanned"] == ["board.kicad_sch"]
+    used = next(m for m in group_named(r, "R_0402_10K")["members"] if m["name"] == "R_0402_10K")
+    assert used["usageCount"] == 2
+
+
+def test_backup_and_history_directories_are_not_scanned(project, lib):
+    for folder in ("proj-backups", ".history"):
+        (project / folder).mkdir()
+        (project / folder / "board.kicad_sch").write_text(SCH, encoding="utf-8")
+    r = run(lib, schematicPaths=[str(project)])
+    assert r["sheetsScanned"] == ["board.kicad_sch"]
+    used = next(m for m in group_named(r, "R_0402_10K")["members"] if m["name"] == "R_0402_10K")
+    assert used["usageCount"] == 2
+
+
+def test_an_explicitly_named_autosave_sheet_is_still_read(tmp_path, lib):
+    """Skipping them is for directory expansion; naming one is deliberate."""
+    autosave = tmp_path / "_autosave-board.kicad_sch"
+    autosave.write_text(SCH, encoding="utf-8")
+    r = run(lib, schematicPaths=[str(autosave)])
+    assert r["sheetsScanned"] == ["_autosave-board.kicad_sch"]
+
+
+def test_a_sheet_instantiated_four_times_counts_four_times(tmp_path, lib):
+    """A four-channel design built from one reused sheet file has four of every
+    part on it, which is what KiCad's own netlist and BOM report."""
+    (tmp_path / "root.kicad_sch").write_text(
+        sheets_sch(*(sheet_block(f"channel{i + 1}", "channel.kicad_sch") for i in range(4))),
+        encoding="utf-8",
+    )
+    (tmp_path / "channel.kicad_sch").write_text(placements("FOG:R_0402_10K"), encoding="utf-8")
+    r = run(lib, schematicPaths=[str(tmp_path)])
+    used = next(m for m in group_named(r, "R_0402_10K")["members"] if m["name"] == "R_0402_10K")
+    assert used["usageCount"] == 4
+    assert r["sheetInstances"] == {"channel.kicad_sch": 4}
+
+
+def test_a_flat_design_counts_each_sheet_once(project, lib):
+    r = run(lib, schematicPaths=[str(project)])
+    assert r["sheetInstances"] == {}
+    used = next(m for m in group_named(r, "R_0402_10K")["members"] if m["name"] == "R_0402_10K")
+    assert used["usageCount"] == 2
+
+
+def test_nested_sheet_instances_multiply(tmp_path, lib):
+    """Two boards, each with three of the same channel: six instances."""
+    (tmp_path / "root.kicad_sch").write_text(
+        sheets_sch(*(sheet_block(f"board{i + 1}", "board.kicad_sch") for i in range(2))),
+        encoding="utf-8",
+    )
+    (tmp_path / "board.kicad_sch").write_text(
+        sheets_sch(*(sheet_block(f"ch{i + 1}", "channel.kicad_sch") for i in range(3))),
+        encoding="utf-8",
+    )
+    (tmp_path / "channel.kicad_sch").write_text(placements("FOG:R_0402_10K"), encoding="utf-8")
+    r = run(lib, schematicPaths=[str(tmp_path)])
+    used = next(m for m in group_named(r, "R_0402_10K")["members"] if m["name"] == "R_0402_10K")
+    assert used["usageCount"] == 6
+
+
+def test_a_sheet_cycle_does_not_hang(tmp_path, lib):
+    """KiCad rejects a recursive hierarchy; a file on disk can still hold one."""
+    (tmp_path / "a.kicad_sch").write_text(
+        sheets_sch(sheet_block("b", "b.kicad_sch")) + placements("FOG:R_0402_10K"),
+        encoding="utf-8",
+    )
+    (tmp_path / "b.kicad_sch").write_text(
+        sheets_sch(sheet_block("a", "a.kicad_sch")), encoding="utf-8"
+    )
+    r = run(lib, schematicPaths=[str(tmp_path)])
+    used = next(m for m in group_named(r, "R_0402_10K")["members"] if m["name"] == "R_0402_10K")
+    assert used["usageCount"] >= 1
+
+
+def test_used_in_distinguishes_sheets_with_the_same_basename(tmp_path, lib):
+    for folder in ("analog", "digital"):
+        (tmp_path / folder).mkdir()
+        (tmp_path / folder / "power.kicad_sch").write_text(
+            placements("FOG:R_0402_10K"), encoding="utf-8"
+        )
+    r = run(lib, schematicPaths=[str(tmp_path)])
+    used = next(m for m in group_named(r, "R_0402_10K")["members"] if m["name"] == "R_0402_10K")
+    assert used["usedIn"] == ["analog/power.kicad_sch", "digital/power.kicad_sch"]
+    assert used["usageCount"] == 2
+
+
+def test_an_escaped_quote_in_a_lib_id_still_matches(tmp_path):
+    r"""A library symbol name is read unescaped, so the lib_id must be too."""
+    path = tmp_path / "Odd.kicad_sym"
+    path.write_text(
+        "(kicad_symbol_lib\n"
+        + sym('R_2\\"_LONG', {"Value": "10K", "Footprint": "f:1", "MPN": "M-1"})
+        + sym("R_ALT", {"Value": "10K", "Footprint": "f:1", "MPN": "M-1"}, unit_x=2)
+        + ")\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "board.kicad_sch").write_text(
+        '(kicad_sch\n\t(symbol\n\t\t(lib_id "Odd:R_2\\"_LONG")\n\t)\n)\n', encoding="utf-8"
+    )
+    r = find_duplicate_symbols({"libraryPath": str(path), "schematicPaths": [str(tmp_path)]})
+    used = next(m for m in r["groups"][0]["members"] if m["name"] == 'R_2"_LONG')
+    assert used["usageCount"] == 1
 
 
 def test_the_used_symbol_is_the_one_suggested(project, lib):
@@ -288,6 +669,14 @@ def test_the_message_counts_retirable_symbols(project, lib):
 
 def test_min_group_size(lib):
     assert run(lib, matchBy=["mpn"], minGroupSize=3)["groupCount"] == 0
+
+
+@pytest.mark.parametrize("bad", ["abc", None, [2]])
+def test_a_non_numeric_min_group_size_is_refused(lib, bad):
+    """The TS layer types it as a number; the Python dispatch is reachable directly."""
+    r = run(lib, minGroupSize=bad)
+    assert not r["success"]
+    assert "minGroupSize" in r["message"]
 
 
 def test_unknown_strategy_is_refused(lib):
@@ -337,6 +726,20 @@ def test_a_missing_sheet_path_does_not_abort_the_scan(lib, project):
     r = run(lib, schematicPaths=[str(project), str(project / "ghost.kicad_sch")])
     assert r["success"]
     assert r["sheetsScanned"] == ["board.kicad_sch"]
+    assert r["missingPaths"] == [str(project / "ghost.kicad_sch")]
+
+
+def test_a_schematic_path_that_resolves_to_nothing_is_not_read_as_unused(lib, tmp_path):
+    """A typo'd directory used to produce an empty scan and a confident report
+    that every member of every group could be retired."""
+    typo = tmp_path / "schematiks"
+    r = run(lib, schematicPaths=[str(typo)])
+    assert r["success"]
+    assert r["sheetsScanned"] == []
+    assert r["missingPaths"] == [str(typo)]
+    assert "pass schematicPaths" not in r["message"]
+    assert "none of the 1 schematicPaths given exist" in r["message"]
+    assert "no symbol should be retired" in r["message"]
 
 
 if __name__ == "__main__":

--- a/tests/test_find_duplicate_symbols.py
+++ b/tests/test_find_duplicate_symbols.py
@@ -1,0 +1,343 @@
+"""Tests for find_duplicate_symbols — the same part stored twice in a library."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+from commands.find_duplicate_symbols import (  # noqa: E402
+    count_symbol_usage,
+    find_duplicate_symbols,
+    read_library_symbols,
+)
+
+
+def prop(name, value):
+    return f'\t\t(property "{name}" "{value}"\n\t\t\t(at 0 0 0)\n\t\t)\n'
+
+
+def body(unit_name, x=0):
+    return (
+        f'\t\t(symbol "{unit_name}"\n'
+        f"\t\t\t(rectangle\n\t\t\t\t(start {x} 1)\n\t\t\t\t(end 2 -1)\n\t\t\t)\n"
+        "\t\t\t(pin passive line\n\t\t\t\t(at -3 0 0)\n\t\t\t\t(length 1)\n"
+        '\t\t\t\t(name "~")\n\t\t\t\t(number "1")\n\t\t\t)\n'
+        "\t\t\t(pin passive line\n\t\t\t\t(at 3 0 180)\n\t\t\t\t(length 1)\n"
+        '\t\t\t\t(name "~")\n\t\t\t\t(number "2")\n\t\t\t)\n'
+        "\t\t)\n"
+    )
+
+
+def sym(name, props, unit_x=0, extends=None):
+    out = f'\t(symbol "{name}"\n'
+    if extends:
+        out += f'\t\t(extends "{extends}")\n'
+    for k, v in props.items():
+        out += prop(k, v)
+    if not extends:
+        out += body(f"{name}_1_1", unit_x)
+    return out + "\t)\n"
+
+
+LIB = (
+    "(kicad_symbol_lib\n\t(version 20241209)\n"
+    # Same part, two names, MPN written under two different property names.
+    + sym(
+        "R_0402_10K",
+        {
+            "Reference": "R",
+            "Value": "10K",
+            "Footprint": "FOG:0402",
+            "MPN": "RC0402FR-0710KL",
+            "Datasheet": "http://x",
+            "Description": "10K 1%",
+        },
+    )
+    + sym(
+        "RES-10K-0402",
+        {
+            "Reference": "R",
+            "Value": "10k",
+            "Footprint": "FOG:0402",
+            "MANUFACTURER PART NUMBER": "rc0402fr-0710kl",
+        },
+    )
+    # Same body copied under a new name, no MPN anywhere.
+    + sym("LED_RED", {"Reference": "D", "Value": "RED", "Footprint": "FOG:0603"}, unit_x=5)
+    + sym("LED_ROT", {"Reference": "D", "Value": "ROT", "Footprint": "FOG:0603"}, unit_x=5)
+    # Alone in every dimension.
+    + sym(
+        "CONN_USB",
+        {"Reference": "J", "Value": "USB", "Footprint": "FOG:USB", "MPN": "USB4085"},
+        unit_x=9,
+    )
+    # A derived symbol: shares the base's body on purpose.
+    + sym("R_0402_10K_ALT", {"Reference": "R", "Value": "10K"}, extends="R_0402_10K")
+    + ")\n"
+)
+
+SCH = (
+    "(kicad_sch\n"
+    "\t(lib_symbols\n"
+    '\t\t(symbol "FOG:R_0402_10K"\n\t\t\t(property "Value" "10K"\n\t\t\t)\n\t\t)\n'
+    "\t)\n"
+    '\t(symbol\n\t\t(lib_id "FOG:R_0402_10K")\n\t\t(at 10 10 0)\n\t)\n'
+    '\t(symbol\n\t\t(lib_id "FOG:R_0402_10K")\n\t\t(at 20 10 0)\n\t)\n'
+    '\t(symbol\n\t\t(lib_id "OtherNick:LED_RED")\n\t\t(at 30 10 0)\n\t)\n'
+    ")\n"
+)
+
+
+@pytest.fixture
+def lib(tmp_path):
+    path = tmp_path / "FOG.kicad_sym"
+    path.write_text(LIB, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def project(tmp_path, lib):
+    (tmp_path / "board.kicad_sch").write_text(SCH, encoding="utf-8")
+    return tmp_path
+
+
+def run(lib, **kw):
+    return find_duplicate_symbols({"libraryPath": str(lib), **kw})
+
+
+def group_named(result, name):
+    for g in result["groups"]:
+        if name in [m["name"] for m in g["members"]]:
+            return g
+    return None
+
+
+# --- reading --------------------------------------------------------------- #
+
+
+def test_reads_every_top_level_symbol():
+    names = [s["name"] for s in read_library_symbols(LIB)]
+    assert names == [
+        "R_0402_10K",
+        "RES-10K-0402",
+        "LED_RED",
+        "LED_ROT",
+        "CONN_USB",
+        "R_0402_10K_ALT",
+    ]
+
+
+def test_unit_sub_symbols_are_not_top_level_symbols():
+    assert all("_1_1" not in s["name"] for s in read_library_symbols(LIB))
+
+
+def test_property_names_are_normalized_for_lookup():
+    by_name = {s["name"]: s for s in read_library_symbols(LIB)}
+    assert by_name["RES-10K-0402"]["normalized"]["MANUFACTURERPARTNUMBER"] == "rc0402fr-0710kl"
+
+
+def test_extends_is_recorded_and_has_no_fingerprint():
+    by_name = {s["name"]: s for s in read_library_symbols(LIB)}
+    assert by_name["R_0402_10K_ALT"]["extends"] == "R_0402_10K"
+    assert by_name["R_0402_10K_ALT"]["fingerprint"] == ""
+
+
+def test_identical_bodies_under_different_names_hash_the_same():
+    by_name = {s["name"]: s for s in read_library_symbols(LIB)}
+    assert by_name["LED_RED"]["fingerprint"] == by_name["LED_ROT"]["fingerprint"]
+    assert by_name["LED_RED"]["fingerprint"] != by_name["CONN_USB"]["fingerprint"]
+
+
+def test_indentation_does_not_change_the_fingerprint():
+    by_name = {s["name"]: s for s in read_library_symbols(LIB)}
+    reindented = {s["name"]: s for s in read_library_symbols(LIB.replace("\t", "  "))}
+    assert reindented["LED_RED"]["fingerprint"] == by_name["LED_RED"]["fingerprint"]
+
+
+# --- matching -------------------------------------------------------------- #
+
+
+def test_mpn_match_survives_inconsistent_property_names(lib):
+    """The same field is MPN in one symbol and MANUFACTURER PART NUMBER in the other."""
+    r = run(lib, matchBy=["mpn"])
+    g = group_named(r, "R_0402_10K")
+    assert sorted(m["name"] for m in g["members"]) == ["RES-10K-0402", "R_0402_10K"]
+    assert "mpn" in g["matchedBy"]
+
+
+def test_mpn_match_is_case_insensitive_by_default(lib):
+    assert run(lib, matchBy=["mpn"])["groupCount"] == 1
+    assert run(lib, matchBy=["mpn"], ignoreCase=False)["groupCount"] == 0
+
+
+def test_value_footprint_match(lib):
+    g = group_named(run(lib, matchBy=["value_footprint"]), "R_0402_10K")
+    assert sorted(m["name"] for m in g["members"]) == ["RES-10K-0402", "R_0402_10K"]
+
+
+def test_value_footprint_ignores_symbols_missing_either_field(lib):
+    """R_0402_10K_ALT has a Value but no Footprint, so it cannot be compared."""
+    r = run(lib, matchBy=["value_footprint"])
+    assert all("R_0402_10K_ALT" not in [m["name"] for m in g["members"]] for g in r["groups"])
+
+
+def test_graphics_match_finds_a_copy_with_different_fields(lib):
+    """LED_RED and LED_ROT share no field values; only the body gives them away."""
+    g = group_named(run(lib, matchBy=["graphics"]), "LED_RED")
+    assert sorted(m["name"] for m in g["members"]) == ["LED_RED", "LED_ROT"]
+
+
+def test_graphics_is_off_by_default(lib):
+    """Every resistor in a library shares one body; on a real library graphics
+    alone grouped 78 different values together. It has to be asked for."""
+    r = run(lib)
+    assert all("LED_RED" not in [m["name"] for m in g["members"]] for g in r["groups"])
+    assert r["matchBy"] == ["mpn", "value_footprint"]
+
+
+def test_a_derived_symbol_is_not_a_graphics_duplicate(lib):
+    """extends exists to share a body; reporting it would be noise."""
+    r = run(lib, matchBy=["graphics"])
+    assert all("R_0402_10K_ALT" not in [m["name"] for m in g["members"]] for g in r["groups"])
+
+
+def test_a_unique_symbol_is_not_reported(lib):
+    r = run(lib)
+    assert all("CONN_USB" not in [m["name"] for m in g["members"]] for g in r["groups"])
+
+
+def test_strategies_agreeing_produce_one_group_not_three(lib):
+    """R_0402_10K and RES-10K-0402 match on mpn, value_footprint and graphics."""
+    r = run(lib, matchBy=["mpn", "value_footprint", "graphics"])
+    matching = [g for g in r["groups"] if "R_0402_10K" in [m["name"] for m in g["members"]]]
+    assert len(matching) == 1
+    assert matching[0]["matchedBy"] == ["graphics", "mpn", "value_footprint"]
+
+
+def test_evidence_records_which_property_supplied_the_key(lib):
+    g = group_named(run(lib, matchBy=["mpn"]), "R_0402_10K")
+    assert g["evidence"][0]["from"] == "MPN"
+    assert g["evidence"][0]["key"] == "RC0402FR-0710KL"
+
+
+def test_member_reports_which_property_its_mpn_came_from(lib):
+    g = group_named(run(lib, matchBy=["mpn"]), "RES-10K-0402")
+    member = next(m for m in g["members"] if m["name"] == "RES-10K-0402")
+    assert member["mpnProperty"] == "MANUFACTURER PART NUMBER"
+
+
+# --- usage ----------------------------------------------------------------- #
+
+
+def test_usage_counts_instances_not_cache_entries(tmp_path):
+    sheet = tmp_path / "board.kicad_sch"
+    sheet.write_text(SCH, encoding="utf-8")
+    usage = count_symbol_usage([sheet])
+    assert usage["R_0402_10K"] == {"board.kicad_sch": 2}
+
+
+def test_usage_ignores_the_library_nickname(tmp_path):
+    """The same library is registered under different nicknames per project."""
+    sheet = tmp_path / "board.kicad_sch"
+    sheet.write_text(SCH, encoding="utf-8")
+    assert count_symbol_usage([sheet])["LED_RED"] == {"board.kicad_sch": 1}
+
+
+def test_usage_is_attached_to_members(project, lib):
+    g = group_named(run(lib, schematicPaths=[str(project)]), "R_0402_10K")
+    used = next(m for m in g["members"] if m["name"] == "R_0402_10K")
+    unused = next(m for m in g["members"] if m["name"] == "RES-10K-0402")
+    assert used["usageCount"] == 2
+    assert used["usedIn"] == ["board.kicad_sch"]
+    assert unused["usageCount"] == 0
+
+
+def test_a_directory_of_sheets_is_expanded(project, lib):
+    (project / "sub.kicad_sch").write_text(
+        '(kicad_sch\n\t(symbol\n\t\t(lib_id "FOG:RES-10K-0402")\n\t)\n)\n', encoding="utf-8"
+    )
+    r = run(lib, schematicPaths=[str(project)])
+    assert sorted(r["sheetsScanned"]) == ["board.kicad_sch", "sub.kicad_sch"]
+
+
+def test_the_used_symbol_is_the_one_suggested(project, lib):
+    g = group_named(run(lib, schematicPaths=[str(project)]), "R_0402_10K")
+    assert g["suggestedKeep"] == "R_0402_10K"
+    assert "only one in use" in g["keepReason"]
+    assert g["unusedMembers"] == ["RES-10K-0402"]
+
+
+def test_without_schematics_the_richer_symbol_is_suggested(lib):
+    """No usage data, so fall back to the one carrying a datasheet and description."""
+    g = group_named(run(lib, matchBy=["mpn"]), "R_0402_10K")
+    assert g["suggestedKeep"] == "R_0402_10K"
+    assert "none are used" in g["keepReason"]
+
+
+def test_the_message_says_when_usage_data_is_missing(lib):
+    assert "pass schematicPaths" in run(lib)["message"]
+
+
+def test_the_message_counts_retirable_symbols(project, lib):
+    assert "unused across 1 sheet(s)" in run(lib, schematicPaths=[str(project)])["message"]
+
+
+# --- options and errors ---------------------------------------------------- #
+
+
+def test_min_group_size(lib):
+    assert run(lib, matchBy=["mpn"], minGroupSize=3)["groupCount"] == 0
+
+
+def test_unknown_strategy_is_refused(lib):
+    r = run(lib, matchBy=["vibes"])
+    assert not r["success"]
+    assert "vibes" in r["message"]
+    assert "graphics" in r["validStrategies"]
+
+
+def test_a_schematic_is_not_a_symbol_library(tmp_path):
+    path = tmp_path / "board.kicad_sch"
+    path.write_text(SCH, encoding="utf-8")
+    r = find_duplicate_symbols({"libraryPath": str(path)})
+    assert not r["success"]
+    assert "kicad_symbol_lib" in r["message"]
+
+
+def test_missing_library(tmp_path):
+    r = find_duplicate_symbols({"libraryPath": str(tmp_path / "nope.kicad_sym")})
+    assert not r["success"]
+
+
+def test_empty_library(tmp_path):
+    path = tmp_path / "empty.kicad_sym"
+    path.write_text("(kicad_symbol_lib\n\t(version 20241209)\n)\n", encoding="utf-8")
+    r = find_duplicate_symbols({"libraryPath": str(path)})
+    assert r["success"]
+    assert r["symbolCount"] == 0
+
+
+def test_a_library_with_no_duplicates(tmp_path):
+    path = tmp_path / "clean.kicad_sym"
+    path.write_text(
+        "(kicad_symbol_lib\n"
+        + sym("A", {"Value": "1", "Footprint": "f:1", "MPN": "AA"}, unit_x=1)
+        + sym("B", {"Value": "2", "Footprint": "f:2", "MPN": "BB"}, unit_x=2)
+        + ")\n",
+        encoding="utf-8",
+    )
+    r = find_duplicate_symbols({"libraryPath": str(path)})
+    assert r["success"]
+    assert r["groupCount"] == 0
+    assert "No duplicates" in r["message"]
+
+
+def test_a_missing_sheet_path_does_not_abort_the_scan(lib, project):
+    r = run(lib, schematicPaths=[str(project), str(project / "ghost.kicad_sch")])
+    assert r["success"]
+    assert r["sheetsScanned"] == ["board.kicad_sch"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_sexpr_format.py
+++ b/tests/test_sexpr_format.py
@@ -15,7 +15,7 @@ PYTHON_DIR = Path(__file__).parent.parent / "python"
 sys.path.insert(0, str(PYTHON_DIR))
 
 from commands.wire_dragger import WireDragger  # noqa: E402
-from utils.sexpr_format import dumps, prettify  # noqa: E402
+from utils.sexpr_format import dumps, iter_child_offsets, match_paren, prettify  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -179,6 +179,40 @@ class TestWriteToolIntegration:
         assert sexpdata.loads(out) is not None  # still parses
         # Writing again is stable (idempotent formatting).
         assert prettify(out) == out
+
+
+class TestStructureWalking:
+    """match_paren / iter_child_offsets let text tools slice a block out safely."""
+
+    def test_match_paren_finds_the_closing_paren(self):
+        s = "(a (b) (c))"
+        assert match_paren(s, 0) == len(s) - 1
+        assert match_paren(s, 3) == 5
+
+    def test_match_paren_ignores_parens_inside_strings(self):
+        # A real footprint name: HRS_U.FL-R-SMT-1(10).
+        s = '(footprint "Lib:HRS_U.FL-R-SMT-1(10)" (layer "F.Cu"))'
+        assert match_paren(s, 0) == len(s) - 1
+
+    def test_match_paren_ignores_an_escaped_quote(self):
+        s = '(property "he said \\"hi (x)\\"" (at 0 0))'
+        assert match_paren(s, 0) == len(s) - 1
+
+    def test_match_paren_returns_minus_one_when_unbalanced(self):
+        assert match_paren("(a (b)", 0) == -1
+
+    def test_iter_child_offsets_yields_direct_children(self):
+        s = '(symbol (lib_id "X") (at 0 0) (property "a" "b" (at 1 1)))'
+        assert [s[i : i + 5] for i in iter_child_offsets(s)] == ["(lib_", "(at 0", "(prop"]
+
+    def test_iter_child_offsets_depth_is_configurable(self):
+        s = "(root (mid (leaf)))"
+        assert [s[i : i + 5] for i in iter_child_offsets(s, depth=3)] == ["(leaf"]
+
+    def test_iter_child_offsets_ignores_indentation(self):
+        """Board files from KiCad indent inconsistently; only nesting counts."""
+        s = '(kicad_pcb\n\t\t\t(footprint "A")\n\t(footprint "B")\n)'
+        assert len(list(iter_child_offsets(s))) == 2
 
 
 class TestIntegerRotationAngle:


### PR DESCRIPTION
## The gap

A library collects duplicates the moment more than one source feeds it. An Eagle import lands a part the curated library already had. A SnapEDA download arrives under the vendor's naming. Someone re-adds a part because search did not find the existing name.

KiCad reports none of this, because the names differ — which is also why grepping for the name does not find it. The library grows, the BOM picks whichever symbol the schematic happened to reference, and nobody notices until two boards ship with different fields for the same chip.

## What this adds

`find_duplicate_symbols` groups symbols that look like the same part, and says on what evidence.

| strategy | groups on |
|---|---|
| `mpn` | manufacturer part number |
| `supplier` | distributor part number, for parts with no MPN field |
| `value_footprint` | same Value on the same Footprint |
| `graphics` | byte-identical drawn body |
| `name` | name ignoring case and separators |

Two design points came out of running it on a real 489-symbol library rather than from reasoning about the format.

**MPN matching has to normalise property names first.** That library holds the manufacturer part number as `MPN`, `MP`, `MANUFACTURER PART NUMBER` *and* `PART NUMBER`, depending on which importer wrote each symbol. A plain group-by on any one of those finds nothing. The tool compares under a normalised key and reports which property each symbol's value came from, so the result stays auditable.

**`graphics` is off by default.** Matching on the drawn body alone put 78 different resistor values into one group, because every resistor in a library shares one drawing. It is genuinely useful for finding a custom IC copied under a new name, so it stays available — documented as evidence rather than as a verdict. Symbols that `extends` another are excluded from it entirely: sharing a body is what `extends` is for.

## Making the report actionable

`schematicPaths` (files or directories, searched recursively) counts instances per symbol across the project. That is what turns a list of suspicious pairs into a decision — the duplicate nothing places is the one to retire. Each group carries `usageCount` and `usedIn` per member, an `unusedMembers` list, and a `suggestedKeep` with the reason it was chosen (most used; on a tie, the one with the fullest fields; deterministic after that).

A group found by several strategies is reported once with all the evidence attached, rather than once per strategy.

On the library above, the defaults reported 86 groups covering 116 redundant symbols, 69 of which no schematic places. One group holds five symbols for the same TI transceiver — `CC1200EP`, `CC1200EP-1`, `IC_CC1200RHBT`, `IC_CC1200RHBT_QFN`, `IC_FOG-CC1200-PA` — of which exactly one is in use.

## Test plan

32 tests in `tests/test_find_duplicate_symbols.py`:

- MPN match across two differently-named properties holding the same value, case-insensitively, with `ignoreCase: false` proving the comparison is the reason
- the property that supplied each key is reported, per group and per member
- `value_footprint` skips symbols missing either field
- `graphics` finds a body copied under a new name whose fields share nothing
- `graphics` is off by default, with the resistor-family finding recorded as the reason
- a symbol using `extends` is never a graphics duplicate
- three strategies agreeing produce one group, not three
- usage counts ignore the library nickname, since the same library is registered under different nicknames per project
- a directory of sheets is expanded; a missing sheet path does not abort the scan
- the suggested symbol is the used one, and the message says when no usage data was supplied
- unknown strategy, `.kicad_sch` passed by mistake, missing file, empty library, library with no duplicates

Full suite green: `pytest`, `black`, `isort`, `flake8`, `mypy`, `tsc --noEmit`, `eslint`, `prettier`, `vitest` (70 passed).

This branch also brings in `match_paren` / `iter_child_offsets` in `utils/sexpr_format.py`; that hunk is byte-identical to the one in #365, #366 and #368, so it merges in whichever order those land.

The rest of the branch does need a rebase once any sibling PR lands — an earlier note here said otherwise, which was only true of the `sexpr_format.py` hunk. Merging all seven locally, the overlaps are `CHANGELOG.md`, the hand-maintained tool counters in `README.md`, the dispatch table in `python/kicad_interface.py`, `python/schemas/tool_schemas.py`, and `src/tools/library-symbol.ts` (shared with #366). All of them resolve additively: keep both entries and sum the counts. `tests-ts/readme-counts.test.ts` then checks the README figure against `getRegistryStats()`, so an arithmetic slip fails CI rather than shipping. With all seven applied the total is 157 tools across 15 categories.
