### PR TITLE
feat: add Digi-Key Product Information V4 integration (search, library availability sweep)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,26 @@
 JLCPCB_APP_ID=your_app_id
 JLCPCB_API_KEY=your_access_key
 JLCPCB_API_SECRET=your_secret_key
+
+# Digi-Key Product Information V4 credentials.
+#
+# Create an app at developer.digikey.com. It must be a Production app with
+# Product Information V4 enabled — a Sandbox app fails authentication against
+# these endpoints.
+#
+# The Digi-Key tools read these two variables and nothing else: credentials are
+# never accepted as tool arguments, so they cannot end up in a chat transcript,
+# a saved workflow, or a log line.
+
+DIGIKEY_CLIENT_ID=your_client_id_here
+DIGIKEY_CLIENT_SECRET=your_client_secret_here
+
+# Optional. Digi-Key requires locale headers on every request — without them
+# a search returns 404 — but the values are yours to pick. Defaults below.
+# Note that this also localizes the response: the lifecycle status and the
+# packaging names come back in the language requested, which is why the tools
+# compare ids rather than those strings.
+
+# DIGIKEY_LOCALE_SITE=US
+# DIGIKEY_LOCALE_LANGUAGE=en
+# DIGIKEY_LOCALE_CURRENCY=USD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### New Tools
+
+- **Digi-Key Product Information V4 integration** — `digikey_search_parts`,
+  `digikey_check_library_availability` and `digikey_test_connection`. The server
+  had six JLCPCB tools and nothing for Digi-Key, so every stock check, lifecycle
+  check and replacement hunt happened in one-off scripts outside it.
+
+  `digikey_search_parts` searches by part number, MPN, or a parametric phrase and
+  returns stock, price, lifecycle status, every packaging variation and the
+  parametric table. `digikey_check_library_availability` sweeps a `.kicad_sym`
+  and reports which parts are obsolete, out of stock, unfindable, not orderable,
+  or carry no part number at all — searching by distributor number first and MPN
+  second, because retired Digi-Key numbers are the common failure and the MPN
+  usually still resolves. Part numbers are read under any of the property
+  spellings real libraries use. A symbol whose lookup fails is marked
+  `state: "error"` and the sweep continues, so one transient 500 does not throw
+  away the lookups already paid for; five consecutive failures stop it, because a
+  revoked key fails identically for every remaining symbol. The sweep costs up to
+  two rate-limited requests per symbol, so `maxSymbols` defaults to 25 and the
+  command is granted the extended Node-side timeout in `src/command-timeout.ts` —
+  on the 30 s default the timer fires mid-sweep and the caller loses every lookup
+  the sweep had already paid for.
+
+  Three things the API makes easy to get wrong:
+  - The locale headers are mandatory. Without `X-DIGIKEY-Locale-Site` and its two
+    companions a search returns **404**, which reads like a wrong URL. The client
+    always sends them; the values are configurable.
+  - The Digi-Key part number is not on the product. It lives on each entry of
+    `ProductVariations`, so the reel and the cut tape have different numbers.
+    `preferPackaging` picks which one is quoted and matches localized packaging
+    names. A product with no variations at all is reported as `not_orderable`
+    rather than available, since there is no number to put on an order.
+  - `ProductStatus.Status` is localized, so comparing it against `"Active"`
+    reports every part as a problem once the account is not set to English.
+    Lifecycle is read from `ProductStatus.Id`.
+
+  **Credentials never enter the source tree.** They are read from
+  `DIGIKEY_CLIENT_ID` and `DIGIKEY_CLIENT_SECRET` in the environment, optionally
+  via the already-gitignored `.env`, and are deliberately absent from every tool
+  schema — a key passed as a tool argument would be recorded in the conversation,
+  in the MCP log, and in anything replaying the call. Absent from the schema means
+  such an argument is _ignored_, not rejected: the MCP layer strips unknown keys,
+  so the tools now return a `warnings` entry naming the argument and telling the
+  caller to rotate the value, which is the honest description of what happened.
+  Everything leaving the module passes through a redaction step, and a non-JSON
+  response body or a hostile `Retry-After` is converted into a redacted error
+  rather than escaping as an unfiltered traceback. Tests assert all of it,
+  including that the schemas contain no credential-shaped field, that `.env` is
+  gitignored, and that `.env.example` carries names without values.
+
+  Nothing here has been exercised against the live Digi-Key service: there were no
+  working credentials available (the token endpoint answers
+  `401 invalid_client`), so every test drives a mocked transport and the
+  German-language strings in the fixtures are constructed illustrations of the
+  localization hazard rather than captured responses. `ACTIVE_STATUS_ID = 0` is
+  documented in the source as an assumption to confirm on first real use.
+
 ## [2.7.0] - 2026-08-20
 
 ### New Tools

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 **Key Capabilities:**
 
-- 169 tools across 15 categories with JSON Schema validation
+- 172 tools across 16 categories with JSON Schema validation
 - Keyword tool discovery via `search_tools` / `get_category_tools`
 - 8 dynamic resources exposing project state
 - Complete schematic workflow with 27 tools and dynamic symbol loading (~10,000 symbols)
@@ -469,15 +469,15 @@ configuration command and backend options.
 
 We've implemented an intelligent tool router to keep AI context efficient while maintaining full functionality:
 
-- **22 direct tools** always visible for high-frequency operations
-- **113 routed tools** organized into 14 categories (board, component, export, drc, schematic, library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, validation, parts-registry)
+- **32 direct tools** always visible for high-frequency operations
+- **147 routed tools** organized into 16 categories (board, component, export, drc, schematic, library, symbol_library, symbol_pins, schematic_hierarchy, schematic_layout, schematic_batch, routing, autoroute, validation, parts-registry, digikey)
 - **4 router tools** for discovery and execution:
   - `list_tool_categories` - Browse all available categories
   - `get_category_tools` - View tools in a specific category
   - `search_tools` - Find tools by keyword
   - `execute_tool` - Run any tool with parameters
 
-**Why this matters:** By organizing tools into discoverable categories, Claude can intelligently find and use the right tool for your task without loading all 122 tool schemas into every conversation. This reduces context consumption while maintaining full access to all functionality.
+**Why this matters:** By organizing tools into discoverable categories, Claude can intelligently find and use the right tool for your task without loading all 172 tool schemas into every conversation. This reduces context consumption while maintaining full access to all functionality.
 
 **Usage is seamless:** Just ask naturally - "export gerber files" or "add mounting holes" - and Claude will discover and execute the appropriate tools automatically.
 
@@ -539,7 +539,7 @@ Access project state without executing tools:
 
 ## Available Tools
 
-The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **169 tools** are additionally indexed into 15 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
+The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **172 tools** are additionally indexed into 16 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
 
 For the complete tool reference with access types (direct/routed/additional), see [Tool Inventory](docs/TOOL_INVENTORY.md).
 
@@ -1435,8 +1435,8 @@ How many Basic parts are available?
 
 - **JSON-RPC 2.0 Transport:** Bi-directional communication via STDIO
 - **Protocol Version:** MCP 2025-06-18
-- **Capabilities:** Tools (122), Resources (8)
-- **Tool Router:** Intelligent discovery system with 14 categories
+- **Capabilities:** Tools (172), Resources (8)
+- **Tool Router:** Intelligent discovery system with 16 categories
 - **Error Handling:** Standard JSON-RPC error codes
 
 ### TypeScript Server (`src/`)
@@ -1586,7 +1586,7 @@ npm run format
 
 See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix and [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
 
-**Working Features (148 tools):**
+**Working Features (172 tools):**
 
 - Project management with snapshot checkpointing
 - Complete board design (outline, layers, zones, mounting holes, text, SVG logos)
@@ -1602,6 +1602,7 @@ See [STATUS_SUMMARY.md](docs/STATUS_SUMMARY.md) for the complete status matrix a
 - Custom footprint and symbol creation
 - Library table maintenance (list, remove and repoint symbol/footprint entries)
 - JLCPCB parts integration (2.5M+ parts catalog)
+- Digi-Key Product Information V4 search and library availability sweep
 - Datasheet enrichment via LCSC
 - Freerouting autorouter integration (Java, Docker, Podman)
 - UI auto-launch and management

--- a/python/commands/digikey.py
+++ b/python/commands/digikey.py
@@ -1,0 +1,895 @@
+"""Digi-Key Product Information V4 client.
+
+The server had six JLCPCB tools and nothing for Digi-Key, so every stock check,
+lifecycle check and replacement hunt happened in one-off scripts outside it.
+
+Credentials are read from the environment only -- ``DIGIKEY_CLIENT_ID`` and
+``DIGIKEY_CLIENT_SECRET``, optionally via a gitignored ``.env``. No tool
+parameter can supply one, and no credential is written to a file, logged, or
+returned in a response: everything leaving this module goes through ``_redact``.
+There is no default, no fallback and no bundled key, so a missing credential is
+reported as a missing credential rather than silently reaching for someone
+else's.
+
+Note the precise claim: a credential-shaped argument is *ignored*, not rejected.
+Nothing declares such a parameter, so the schema layer strips it and the value
+never reaches this module -- but it has already been written into the caller's
+transcript by then, so ``_credential_warning`` names it in the response and says
+to rotate it. Calling that "rejected" would imply the key never left the
+caller's machine.
+
+Three things this client handles that are easy to get wrong:
+
+* The locale headers are mandatory. Without ``X-DIGIKEY-Locale-Site`` and its
+  two companions a search returns **404**, which reads like a wrong URL.
+* The Digi-Key part number is not on the product. It lives on each entry of
+  ``ProductVariations``, one per packaging option, and the reel and the cut
+  tape have different numbers.
+* ``ProductStatus.Status`` is localized, so comparing it against ``"Active"``
+  misreports every part as soon as the account is not set to English --
+  a German-language account returns a German status string.
+  ``ProductStatus.Id`` is the stable field; ``ACTIVE_STATUS_ID`` below records
+  what this module assumes it means, and how confident that is.
+
+Provenance, so nobody has to guess later: none of this has been exercised
+against the live Digi-Key service. There were no working credentials while it
+was written -- the token endpoint answers ``401 invalid_client`` -- so every
+test drives a mocked ``requests.post``, and the German-language strings in the
+fixtures are constructed illustrations of the localization hazard rather than
+captured responses.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import re
+import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import requests
+from utils.sexpr_format import iter_child_offsets, match_paren
+
+logger = logging.getLogger("kicad_interface")
+
+TOKEN_URL = "https://api.digikey.com/v1/oauth2/token"
+KEYWORD_SEARCH_URL = "https://api.digikey.com/products/v4/search/keyword"
+
+CLIENT_ID_ENV = "DIGIKEY_CLIENT_ID"
+CLIENT_SECRET_ENV = "DIGIKEY_CLIENT_SECRET"
+
+# Blanket string replacement is how credentials are kept out of messages, and a
+# credential of one or two characters would replace half the alphabet with
+# ``***``. Rather than leave short values unredacted, anything shorter than this
+# is refused before a request is built -- no real Digi-Key credential is close to
+# it, so the only thing rejected is a typo or a truncated paste.
+MIN_CREDENTIAL_LENGTH = 4
+
+# Locale defaults. Any valid Digi-Key site works; what matters is that the
+# headers are sent at all.
+LOCALE_ENV = {
+    "site": ("DIGIKEY_LOCALE_SITE", "US"),
+    "language": ("DIGIKEY_LOCALE_LANGUAGE", "en"),
+    "currency": ("DIGIKEY_LOCALE_CURRENCY", "USD"),
+}
+
+# The id this module treats as "active". It has NOT been confirmed against a
+# live Digi-Key response -- see the provenance note in the module docstring --
+# so treat it as an assumption to check the first time the integration runs
+# against the real service. Every other id is reported verbatim rather than
+# mapped to a guessed meaning, because the id space is not documented here and
+# the accompanying status string is localized.
+ACTIVE_STATUS_ID = 0
+
+# The sweep issues one or two rate-limited requests per symbol and throttles
+# itself between them, so its default has to be a number that finishes inside
+# the Node-side command timeout. src/command-timeout.ts grants the sweep the
+# extended allowance; this keeps the default well inside it.
+DEFAULT_MAX_SYMBOLS = 25
+
+# One transient error should not discard the symbols already looked up, but a
+# revoked key should not grind through the whole library either.
+MAX_CONSECUTIVE_SWEEP_ERRORS = 5
+
+# Ceiling on an honoured Retry-After. The Python worker is single-threaded, so
+# sleeping here blocks every other tool in the server.
+RETRY_AFTER_CAP_SECONDS = 30.0
+DEFAULT_RETRY_AFTER_SECONDS = 5.0
+
+# Argument names that look like a credential. They are not in any tool schema,
+# so they arrive only from a caller that invented them; the value is discarded,
+# but it is in the transcript by then and the caller needs to hear that.
+_CREDENTIAL_ARG = re.compile(r"client_?id|client_?secret|secret|api_?key|token|password", re.I)
+
+# Packaging names are localized too: a German account calls cut tape
+# "Gurtabschnitt". Matching the English name only would quietly return the reel
+# to a caller who asked for cut tape.
+PACKAGING_SYNONYMS: Dict[str, Tuple[str, ...]] = {
+    "TR": ("tape & reel", "tape and reel", "(tr)"),
+    "CT": ("cut tape", "gurtabschnitt", "(ct)"),
+    "DKR": ("digi-reel", "digireel"),
+}
+
+# Property names that hold a part number, best first, compared after _norm_key.
+MPN_KEYS = (
+    "MPN",
+    "MANUFACTURERPARTNUMBER",
+    "MFRPARTNUMBER",
+    "MANUFACTURERPARTNO",
+    "MP",
+    "PARTNUMBER",
+)
+SUPPLIER_KEYS = (
+    "DIGIKEY",
+    "DIGIKEYPARTNUMBER",
+    "DIGIKEYPN",
+    "SUPPLIERPARTNUMBER1",
+    "SUPPLIERPARTNUMBER",
+)
+
+_HEAD = re.compile(r"\(\s*([A-Za-z_][\w]*)")
+
+
+class DigiKeyError(Exception):
+    """A Digi-Key request failed. The message is already redacted."""
+
+
+def _load_env_file(env_path: Optional[Path] = None) -> None:
+    """Best-effort load of a project-root ``.env`` so DIGIKEY_* creds are picked up.
+
+    Non-destructive: a variable already in the environment always wins, so a
+    stale ``.env`` cannot override credentials the operator exported.
+    """
+    try:
+        from dotenv import load_dotenv
+    except Exception:  # python-dotenv is a declared dep, but degrade gracefully
+        return
+    if env_path is None:
+        # python/commands/digikey.py -> repo root is three parents up.
+        env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.is_file():
+        load_dotenv(env_path, override=False)
+
+
+def _norm_key(name: str) -> str:
+    return re.sub(r"[\s_\-.#]+", "", name).upper()
+
+
+def _as_int(value: Any, default: int) -> int:
+    """Coerce a parameter to int, falling back rather than raising.
+
+    The TypeScript schemas type these as numbers, but the Python dispatcher is
+    also reachable directly, and ``int("ten")`` there becomes an unredacted
+    traceback in the dispatcher's catch-all rather than a usable message.
+    """
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if math.isfinite(parsed) else default
+
+
+def _sub(container: Any, key: str) -> Dict[str, Any]:
+    """A nested object from a response, or ``{}`` if it is absent or not one.
+
+    V4 nests ``Manufacturer``, ``Description`` and ``PackageType`` as objects,
+    but a response is not a contract: a bare string where an object was expected
+    otherwise raises ``AttributeError`` well away from the request that caused it.
+    """
+    if not isinstance(container, dict):
+        return {}
+    value = container.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _header(resp: Any, name: str) -> Optional[str]:
+    headers = getattr(resp, "headers", None)
+    if not headers:
+        return None
+    try:
+        value = headers.get(name)
+    except AttributeError:
+        return None
+    return None if value is None else str(value)
+
+
+def _retry_after_seconds(value: Optional[str]) -> float:
+    """How long to wait for a 429, defensively parsed and capped.
+
+    RFC 7231 allows either a delay in seconds or an HTTP-date, so ``float()``
+    alone raises on a perfectly legal header. A daily-quota response can also
+    name 86400 seconds, and the Python worker is single-threaded: honouring that
+    literally would wedge every other tool in the server for a day.
+    """
+    delay: Optional[float] = None
+    if value is not None:
+        text = str(value).strip()
+        try:
+            delay = float(text)
+        except ValueError:
+            try:
+                when = parsedate_to_datetime(text)
+            except (TypeError, ValueError, OverflowError):
+                delay = None
+            else:
+                if when.tzinfo is None:
+                    when = when.replace(tzinfo=timezone.utc)
+                delay = (when - datetime.now(timezone.utc)).total_seconds()
+    if delay is None or not math.isfinite(delay) or delay < 0:
+        delay = DEFAULT_RETRY_AFTER_SECONDS
+    return min(delay, RETRY_AFTER_CAP_SECONDS)
+
+
+def _credential_warning(params: Dict[str, Any]) -> Optional[str]:
+    """Name credential-shaped arguments so the caller knows to rotate them.
+
+    No tool schema declares these, so the TypeScript layer strips them before
+    they ever reach here and a caller who passes one sees a successful call with
+    the value quietly discarded. Discarded is not the same as never sent: it is
+    in the conversation, and probably in a log. Say so instead of staying silent.
+    The name is echoed; the value never is.
+    """
+    offenders = sorted(key for key in params if _CREDENTIAL_ARG.search(key))
+    if not offenders:
+        return None
+    return (
+        "Ignored argument(s) whose names look like credentials: "
+        + ", ".join(offenders)
+        + f". Digi-Key credentials are read only from {CLIENT_ID_ENV} and "
+        f"{CLIENT_SECRET_ENV} in the server environment, so the value was not used -- "
+        "but it is now in this conversation and should be treated as compromised "
+        "and rotated."
+    )
+
+
+def _with_warning(result: Dict[str, Any], params: Dict[str, Any]) -> Dict[str, Any]:
+    warning = _credential_warning(params)
+    if warning:
+        result.setdefault("warnings", []).append(warning)
+    return result
+
+
+def _read_string(text: str, i: int) -> Tuple[Optional[str], int]:
+    while i < len(text) and text[i] in " \t\r\n":
+        i += 1
+    if i >= len(text) or text[i] != '"':
+        return None, i
+    out: List[str] = []
+    i += 1
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\" and i + 1 < len(text):
+            out.append(text[i + 1])
+            i += 2
+            continue
+        if ch == '"':
+            return "".join(out), i + 1
+        out.append(ch)
+        i += 1
+    return None, i
+
+
+def read_symbol_part_numbers(text: str) -> List[Dict[str, str]]:
+    """Return ``{name, mpn, supplierPartNumber}`` for each symbol in a .kicad_sym.
+
+    Property naming is inconsistent in any library that has seen more than one
+    importer -- the same field turns up as ``MPN``, ``MP``,
+    ``MANUFACTURER PART NUMBER`` and ``PART NUMBER`` -- so lookup is done on a
+    normalized key rather than an exact name.
+    """
+    symbols: List[Dict[str, str]] = []
+    root = _HEAD.search(text)
+    if not root:
+        return symbols
+    for off in iter_child_offsets(text[root.start() :]):
+        off += root.start()
+        head = _HEAD.match(text, off)
+        if not head or head.group(1) != "symbol":
+            continue
+        end = match_paren(text, off)
+        if end == -1:
+            continue
+        block = text[off : end + 1]
+        name, _ = _read_string(text, head.end())
+        if not name:
+            continue
+        props: Dict[str, str] = {}
+        for child in iter_child_offsets(block):
+            child_head = _HEAD.match(block, child)
+            if not child_head or child_head.group(1) != "property":
+                continue
+            key, after = _read_string(block, child_head.end())
+            value, _ = _read_string(block, after)
+            if key:
+                props[_norm_key(key)] = (value or "").strip()
+
+        def first(keys: Sequence[str]) -> str:
+            for key in keys:
+                if props.get(key):
+                    return props[key]
+            return ""
+
+        symbols.append(
+            {
+                "name": name,
+                "mpn": first(MPN_KEYS),
+                "supplierPartNumber": first(SUPPLIER_KEYS),
+                "value": props.get("VALUE", ""),
+            }
+        )
+    return symbols
+
+
+class DigiKeyClient:
+    """OAuth2 client-credentials client for Digi-Key Product Information V4."""
+
+    def __init__(
+        self,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        locale: Optional[Dict[str, str]] = None,
+        min_interval: float = 0.25,
+        timeout: int = 30,
+    ) -> None:
+        _load_env_file()
+        # Constructor arguments exist for tests. Nothing in the tool surface
+        # passes credentials in, so they cannot arrive from a chat transcript
+        # or get written into a saved workflow.
+        self._client_id = client_id or os.environ.get(CLIENT_ID_ENV, "")
+        self._client_secret = client_secret or os.environ.get(CLIENT_SECRET_ENV, "")
+        self.locale = locale or {
+            field: os.environ.get(env, default) for field, (env, default) in LOCALE_ENV.items()
+        }
+        self.min_interval = min_interval
+        self.timeout = timeout
+        self._token: Optional[str] = None
+        self._token_expires_at = 0.0
+        self._last_request_at = 0.0
+        if not self.has_credentials():
+            logger.info(
+                "Digi-Key credentials not configured (%s / %s); Digi-Key tools will report "
+                "how to set them.",
+                CLIENT_ID_ENV,
+                CLIENT_SECRET_ENV,
+            )
+
+    def has_credentials(self) -> bool:
+        return bool(self._client_id and self._client_secret)
+
+    def matches_environment_credentials(self) -> bool:
+        """Whether this client still holds what the environment currently says.
+
+        The memoization in ``_client`` uses this so a corrected credential takes
+        effect on the next tool call rather than at the next server restart.
+        """
+        return self._client_id == os.environ.get(CLIENT_ID_ENV, "") and (
+            self._client_secret == os.environ.get(CLIENT_SECRET_ENV, "")
+        )
+
+    def _redact(self, message: str) -> str:
+        """Strip credentials from anything on its way to a log or a response.
+
+        An error body may echo the client id, and a misconfigured secret can end
+        up in a URL-encoded error. One choke point is easier to keep honest than
+        a rule about which strings are safe to format.
+
+        The bearer token is included as belt-and-braces: no current code path
+        formats it into a message, and this makes a future one harmless.
+
+        The length floor does not leave a short credential exposed --
+        ``_reject_unusable_credentials`` refuses to send one, so a value too
+        short to replace safely never reaches a request or an error message.
+        """
+        for secret in (self._client_secret, self._client_id, self._token):
+            if secret and len(secret) >= MIN_CREDENTIAL_LENGTH:
+                message = message.replace(secret, "***")
+        return message
+
+    def _reject_unusable_credentials(self) -> None:
+        too_short = sorted(
+            env
+            for env, value in (
+                (CLIENT_ID_ENV, self._client_id),
+                (CLIENT_SECRET_ENV, self._client_secret),
+            )
+            if len(value) < MIN_CREDENTIAL_LENGTH
+        )
+        if too_short:
+            raise DigiKeyError(
+                f"{' and '.join(too_short)} is shorter than {MIN_CREDENTIAL_LENGTH} "
+                "characters, which no Digi-Key credential is -- check for a truncated "
+                "paste. The value is not sent, because a credential that short cannot be "
+                "reliably stripped from an error message."
+            )
+
+    def _json_body(self, resp: Any, what: str) -> Dict[str, Any]:
+        """Decode a JSON body, converting a non-JSON one into a redacted error.
+
+        A 200 whose body is not JSON is a normal outcome behind a captive
+        portal, a corporate proxy interstitial or a challenge page. Letting the
+        decode error propagate would skip redaction entirely and surface an
+        unfiltered traceback through the dispatcher's catch-all.
+        """
+        try:
+            payload = resp.json()
+        except ValueError as e:
+            body = str(getattr(resp, "text", ""))[:200]
+            raise DigiKeyError(
+                self._redact(
+                    f"Digi-Key {what} returned a non-JSON body "
+                    f"({getattr(resp, 'status_code', '?')}): {e}. Body starts: {body!r}"
+                )
+            )
+        if not isinstance(payload, dict):
+            raise DigiKeyError(
+                self._redact(
+                    f"Digi-Key {what} returned JSON that is not an object "
+                    f"({type(payload).__name__})"
+                )
+            )
+        return payload
+
+    def _sleep_for_rate_limit(self) -> None:
+        wait = self.min_interval - (time.time() - self._last_request_at)
+        if wait > 0:
+            time.sleep(wait)
+        self._last_request_at = time.time()
+
+    def _fetch_token(self) -> str:
+        if not self.has_credentials():
+            raise DigiKeyError(
+                f"Digi-Key credentials not configured. Set {CLIENT_ID_ENV} and "
+                f"{CLIENT_SECRET_ENV} in the environment or in a gitignored .env at the "
+                "repo root. Create them at developer.digikey.com under a Production app "
+                "with Product Information V4 enabled."
+            )
+        self._reject_unusable_credentials()
+        self._sleep_for_rate_limit()
+        try:
+            resp = requests.post(
+                TOKEN_URL,
+                data={
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                    "grant_type": "client_credentials",
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=self.timeout,
+            )
+        except requests.exceptions.RequestException as e:
+            raise DigiKeyError(self._redact(f"Could not reach Digi-Key: {e}"))
+
+        if resp.status_code == 401:
+            raise DigiKeyError(
+                f"Digi-Key rejected the credentials (401). Check {CLIENT_ID_ENV} and "
+                f"{CLIENT_SECRET_ENV}, and that the app is a Production app with Product "
+                "Information V4 enabled -- a Sandbox app fails here."
+            )
+        if resp.status_code != 200:
+            raise DigiKeyError(
+                self._redact(
+                    f"Digi-Key token request failed ({resp.status_code}): {resp.text[:300]}"
+                )
+            )
+
+        payload = self._json_body(resp, "token request")
+        token = payload.get("access_token")
+        if not token:
+            raise DigiKeyError("Digi-Key returned no access_token")
+        # Refresh a minute early so a request cannot start on a token that
+        # expires mid-flight.
+        self._token = token
+        self._token_expires_at = time.time() + _as_float(payload.get("expires_in"), 1800.0) - 60
+        return token
+
+    def _valid_token(self) -> str:
+        if self._token and time.time() < self._token_expires_at:
+            return self._token
+        return self._fetch_token()
+
+    def _headers(self, token: str) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {token}",
+            "X-DIGIKEY-Client-Id": self._client_id,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-DIGIKEY-Locale-Site": self.locale["site"],
+            "X-DIGIKEY-Locale-Language": self.locale["language"],
+            "X-DIGIKEY-Locale-Currency": self.locale["currency"],
+        }
+
+    def search_keyword(self, keywords: str, limit: int = 10, offset: int = 0) -> Dict[str, Any]:
+        """POST /products/v4/search/keyword, refreshing the token if it is stale."""
+        body = {"Keywords": keywords, "Limit": max(1, min(int(limit), 50)), "Offset": int(offset)}
+        for attempt in (1, 2):
+            token = self._valid_token()
+            self._sleep_for_rate_limit()
+            try:
+                resp = requests.post(
+                    KEYWORD_SEARCH_URL,
+                    json=body,
+                    headers=self._headers(token),
+                    timeout=self.timeout,
+                )
+            except requests.exceptions.RequestException as e:
+                raise DigiKeyError(self._redact(f"Could not reach Digi-Key: {e}"))
+
+            if resp.status_code == 401 and attempt == 1:
+                # Expired earlier than advertised; one forced refresh, then give up.
+                self._token = None
+                continue
+            if resp.status_code == 429 and attempt == 1:
+                time.sleep(_retry_after_seconds(_header(resp, "Retry-After")))
+                continue
+            if resp.status_code == 404:
+                raise DigiKeyError(
+                    "Digi-Key returned 404 for a keyword search. This is usually missing "
+                    "locale headers rather than a wrong URL; the client sends site="
+                    f"{self.locale['site']}, language={self.locale['language']}, "
+                    f"currency={self.locale['currency']}."
+                )
+            if resp.status_code != 200:
+                raise DigiKeyError(
+                    self._redact(f"Digi-Key search failed ({resp.status_code}): {resp.text[:300]}")
+                )
+            return self._json_body(resp, "keyword search")
+        raise DigiKeyError("Digi-Key search failed after a token refresh")
+
+
+def _pick_variation(variations: Sequence[Dict[str, Any]], prefer: Optional[str]) -> Dict[str, Any]:
+    """Choose the packaging variation to quote, honouring localized names."""
+    if not variations:
+        return {}
+    if prefer:
+        wanted = PACKAGING_SYNONYMS.get(prefer.upper(), (prefer.lower(),))
+        for variation in variations:
+            name = str(_sub(variation, "PackageType").get("Name", "")).lower()
+            if any(w in name for w in wanted):
+                return variation
+    return variations[0]
+
+
+def normalize_product(
+    product: Dict[str, Any], prefer_packaging: Optional[str] = None
+) -> Dict[str, Any]:
+    """Flatten one V4 product into the shape the tools return."""
+    raw_variations = product.get("ProductVariations") or []
+    variations = [v for v in raw_variations if isinstance(v, dict)]
+    chosen = _pick_variation(variations, prefer_packaging)
+    status = _sub(product, "ProductStatus")
+    return {
+        "mpn": product.get("ManufacturerProductNumber", ""),
+        "manufacturer": _sub(product, "Manufacturer").get("Name", ""),
+        "digikeyPartNumber": chosen.get("DigiKeyProductNumber", ""),
+        "packaging": _sub(chosen, "PackageType").get("Name", ""),
+        "description": _sub(product, "Description").get("ProductDescription", ""),
+        "statusId": status.get("Id"),
+        "status": status.get("Status", ""),
+        "active": status.get("Id") == ACTIVE_STATUS_ID,
+        "quantityAvailable": product.get("QuantityAvailable", 0),
+        "unitPrice": product.get("UnitPrice"),
+        "marketplace": product.get("Marketplace"),
+        "datasheet": product.get("DatasheetUrl", ""),
+        "productUrl": product.get("ProductUrl", ""),
+        "parameters": [
+            {"name": p.get("ParameterText", ""), "value": p.get("ValueText", "")}
+            for p in (product.get("Parameters") or [])
+            if isinstance(p, dict)
+        ],
+        "variations": [
+            {
+                "digikeyPartNumber": v.get("DigiKeyProductNumber", ""),
+                "packaging": _sub(v, "PackageType").get("Name", ""),
+                "minimumOrderQuantity": v.get("MinimumOrderQuantity"),
+                "pricing": [
+                    {"quantity": b.get("BreakQuantity"), "unitPrice": b.get("UnitPrice")}
+                    for b in (v.get("StandardPricing") or [])
+                    if isinstance(b, dict)
+                ],
+            }
+            for v in variations
+        ],
+    }
+
+
+# One client per resolved locale, so a run of tool calls shares one OAuth token
+# instead of buying a fresh one -- and one .env read -- for each. Digi-Key tokens
+# last 30 minutes and the token endpoint is itself rate limited, so a client per
+# call doubled the request count against the tightest limit in the API.
+_CLIENTS: Dict[Tuple[str, str, str], DigiKeyClient] = {}
+
+
+def _resolve_locale(params: Dict[str, Any]) -> Dict[str, str]:
+    given = params.get("locale")
+    if isinstance(given, dict) and given:
+        return {
+            field: str(given.get(field) or default) for field, (_env, default) in LOCALE_ENV.items()
+        }
+    return {field: os.environ.get(env, default) for field, (env, default) in LOCALE_ENV.items()}
+
+
+def reset_client_cache() -> None:
+    """Drop every memoized client. Exposed for tests, which swap credentials."""
+    _CLIENTS.clear()
+
+
+def _client(params: Dict[str, Any]) -> DigiKeyClient:
+    locale = _resolve_locale(params)
+    key = (locale["site"], locale["language"], locale["currency"])
+    cached = _CLIENTS.get(key)
+    # A cached client holds the credentials it was built with, so an operator who
+    # fixes DIGIKEY_CLIENT_SECRET mid-session must not keep hitting the old one.
+    if cached is not None and cached.matches_environment_credentials():
+        return cached
+    client = DigiKeyClient(locale=locale)
+    # Only a configured client is worth keeping: caching an unconfigured one
+    # would stop _load_env_file from ever noticing a .env added later.
+    if client.has_credentials():
+        _CLIENTS[key] = client
+    return client
+
+
+def _not_configured() -> Dict[str, Any]:
+    return {
+        "success": False,
+        "message": (
+            f"Digi-Key credentials not configured. Set {CLIENT_ID_ENV} and "
+            f"{CLIENT_SECRET_ENV} in the environment, or put them in a .env at the repo "
+            "root (already gitignored). Credentials are never accepted as tool arguments."
+        ),
+        "requiredEnvironmentVariables": [CLIENT_ID_ENV, CLIENT_SECRET_ENV],
+    }
+
+
+def digikey_test_connection(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Check that the configured credentials can obtain a token and run a search."""
+    params = params or {}
+    client = _client(params)
+    if not client.has_credentials():
+        return _with_warning(_not_configured(), params)
+    try:
+        data = client.search_keyword("RC0402FR-0710KL", limit=1)
+    except DigiKeyError as e:
+        return _with_warning({"success": False, "message": str(e)}, params)
+    return _with_warning(
+        {
+            "success": True,
+            "message": "Digi-Key credentials work",
+            "locale": client.locale,
+            "productsReturned": len(data.get("Products") or []),
+        },
+        params,
+    )
+
+
+def digikey_search_parts(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Keyword search: a part number, an MPN, or a parametric phrase."""
+    keywords = str(params.get("keywords", "")).strip()
+    if not keywords:
+        return _with_warning({"success": False, "message": "keywords is required"}, params)
+
+    client = _client(params)
+    if not client.has_credentials():
+        return _with_warning(_not_configured(), params)
+
+    prefer = params.get("preferPackaging")
+    try:
+        data = client.search_keyword(
+            keywords,
+            limit=_as_int(params.get("limit"), 10),
+            offset=_as_int(params.get("offset"), 0),
+        )
+    except DigiKeyError as e:
+        return _with_warning({"success": False, "message": str(e)}, params)
+
+    products = [
+        normalize_product(p, prefer) for p in (data.get("Products") or []) if isinstance(p, dict)
+    ]
+    return _with_warning(
+        {
+            "success": True,
+            "message": (
+                f"{len(products)} result(s) for '{keywords}'"
+                if products
+                else f"Digi-Key has no match for '{keywords}'"
+            ),
+            "keywords": keywords,
+            "exactMatches": data.get("ExactMatches", 0),
+            "productsCount": data.get("ProductsCount", len(products)),
+            "products": products,
+        },
+        params,
+    )
+
+
+def _classify(product: Optional[Dict[str, Any]]) -> str:
+    if product is None:
+        return "not_found"
+    if not product["active"]:
+        # The status string is localized, so the id decides and the string is
+        # passed through for the human reading the report.
+        return "inactive"
+    if (product["quantityAvailable"] or 0) <= 0:
+        return "no_stock"
+    if not product["digikeyPartNumber"]:
+        # Active, in stock, and no orderable number: the part number lives on
+        # ProductVariations and there are none. Calling that "available" hides
+        # the row from needsAttention exactly when someone has to go and find
+        # out what to actually put on the order.
+        return "not_orderable"
+    return "available"
+
+
+def digikey_check_library_availability(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Look up every symbol in a .kicad_sym and report lifecycle and stock.
+
+    Costs up to two rate-limited requests per symbol -- the MPN fallback buys a
+    second one whenever the distributor number misses -- plus one token request,
+    and the client throttles itself between them. ``maxSymbols`` defaults to
+    ``DEFAULT_MAX_SYMBOLS`` for that reason.
+
+    A symbol whose lookup fails is reported as ``state: "error"`` with the
+    redacted message and the sweep continues, so a single transient failure does
+    not discard the rows already paid for. ``MAX_CONSECUTIVE_SWEEP_ERRORS``
+    failures in a row stop the sweep, since a revoked key fails identically for
+    every remaining symbol.
+    """
+    lib_path = Path(params.get("libraryPath", ""))
+    if not lib_path.is_file():
+        return _with_warning(
+            {"success": False, "message": f"Library not found: {lib_path}"}, params
+        )
+    try:
+        text = lib_path.read_text(encoding="utf-8")
+    except OSError as e:
+        return _with_warning(
+            {"success": False, "message": f"Could not read {lib_path}: {e}"}, params
+        )
+
+    root = _HEAD.search(text)
+    if not root or root.group(1) != "kicad_symbol_lib":
+        found = root.group(1) if root else "nothing"
+        return _with_warning(
+            {
+                "success": False,
+                "message": (
+                    f"{lib_path.name} is not a symbol library "
+                    f"(root form is '{found}', expected 'kicad_symbol_lib')"
+                ),
+            },
+            params,
+        )
+
+    entries = read_symbol_part_numbers(text)
+    wanted = params.get("symbols")
+    if wanted:
+        wanted_set = set(wanted)
+        entries = [e for e in entries if e["name"] in wanted_set]
+
+    # A zero or negative cap otherwise slices from the end of the list and
+    # reports a truncated sweep of nothing.
+    max_symbols = max(1, _as_int(params.get("maxSymbols"), DEFAULT_MAX_SYMBOLS))
+    truncated = len(entries) > max_symbols
+    entries = entries[:max_symbols]
+
+    client = _client(params)
+    if not client.has_credentials():
+        return _with_warning(_not_configured(), params)
+
+    prefer_mpn = bool(params.get("searchByMpnFirst", False))
+    results: List[Dict[str, Any]] = []
+    counts: Dict[str, int] = {}
+    consecutive_errors = 0
+    aborted: Optional[str] = None
+
+    for entry in entries:
+        order = (
+            [entry["mpn"], entry["supplierPartNumber"]]
+            if prefer_mpn
+            else [entry["supplierPartNumber"], entry["mpn"]]
+        )
+        terms = [t for t in order if t]
+        if not terms:
+            results.append({"symbol": entry["name"], "state": "no_part_number", "searchTerm": ""})
+            counts["no_part_number"] = counts.get("no_part_number", 0) + 1
+            continue
+
+        product = None
+        used = terms[0]
+        failure: Optional[str] = None
+        for term in terms:
+            used = term
+            try:
+                data = client.search_keyword(term, limit=1)
+            except DigiKeyError as e:
+                # One 500, one DNS blip or a second consecutive 429 used to
+                # discard every lookup already paid for and force the whole
+                # sweep to be repeated. Record it on the row and carry on.
+                failure = str(e)
+                break
+            found = data.get("Products") or []
+            if found:
+                product = normalize_product(found[0], params.get("preferPackaging"))
+                break
+
+        row: Dict[str, Any] = {
+            "symbol": entry["name"],
+            "state": "error" if failure else _classify(product),
+            "searchTerm": used,
+            "searchedBy": "mpn" if used == entry["mpn"] else "supplierPartNumber",
+        }
+        counts[row["state"]] = counts.get(row["state"], 0) + 1
+
+        if failure:
+            row["message"] = failure
+            results.append(row)
+            consecutive_errors += 1
+            if consecutive_errors >= MAX_CONSECUTIVE_SWEEP_ERRORS:
+                # A revoked key or a hard outage fails identically for every
+                # remaining symbol, so stop rather than pay for all of them.
+                aborted = (
+                    f"stopped after {consecutive_errors} consecutive failures; "
+                    f"{len(entries) - len(results)} symbol(s) not checked"
+                )
+                break
+            continue
+
+        consecutive_errors = 0
+        if product:
+            row.update(
+                {
+                    "digikeyPartNumber": product["digikeyPartNumber"],
+                    "mpn": product["mpn"],
+                    "manufacturer": product["manufacturer"],
+                    "status": product["status"],
+                    "statusId": product["statusId"],
+                    "quantityAvailable": product["quantityAvailable"],
+                    "unitPrice": product["unitPrice"],
+                }
+            )
+        results.append(row)
+
+    errors = counts.get("error", 0)
+    needs_attention = [r for r in results if r["state"] not in ("available",)]
+    message = (
+        f"Checked {len(results)} symbol(s): "
+        + ", ".join(f"{n} {state}" for state, n in sorted(counts.items()))
+        if results
+        else "No symbols to check"
+    )
+    if truncated:
+        message += f" (stopped at maxSymbols={max_symbols})"
+    if aborted:
+        message += f" ({aborted})"
+
+    return _with_warning(
+        {
+            # Partial results are still worth having, so an error on some rows
+            # is a successful sweep with those rows marked. Only a sweep that
+            # produced nothing usable is a failed one.
+            "success": errors == 0 or errors < len(results),
+            "message": message,
+            "libraryPath": str(lib_path),
+            "checked": len(results),
+            "truncated": truncated,
+            "aborted": aborted,
+            "errors": errors,
+            "counts": counts,
+            "needsAttention": [r["symbol"] for r in needs_attention],
+            "results": results,
+        },
+        params,
+    )

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -344,6 +344,11 @@ try:
     from commands.connection_schematic import ConnectionManager
     from commands.datasheet_manager import DatasheetManager
     from commands.design_rules import DesignRuleCommands
+    from commands.digikey import (
+        digikey_check_library_availability,
+        digikey_search_parts,
+        digikey_test_connection,
+    )
     from commands.eagle import EagleCommands
     from commands.export import ExportCommands
     from commands.find_duplicate_symbols import find_duplicate_symbols
@@ -610,6 +615,10 @@ class KiCADInterface(SchematicHandlersMixin):
             "get_jlcpcb_part": self._handle_get_jlcpcb_part,
             "get_jlcpcb_database_stats": self._handle_get_jlcpcb_database_stats,
             "suggest_jlcpcb_alternatives": self._handle_suggest_jlcpcb_alternatives,
+            # Digi-Key API commands (credentials come from the environment only)
+            "digikey_test_connection": digikey_test_connection,
+            "digikey_search_parts": digikey_search_parts,
+            "digikey_check_library_availability": digikey_check_library_availability,
             # Datasheet commands
             "enrich_datasheets": self._handle_enrich_datasheets,
             "get_datasheet_url": self._handle_get_datasheet_url,

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -3473,6 +3473,151 @@ VALIDATION_TOOLS = [
 ]
 
 # =============================================================================
+# DIGI-KEY TOOLS
+# =============================================================================
+
+# Credentials are read from DIGIKEY_CLIENT_ID / DIGIKEY_CLIENT_SECRET in the
+# server environment and are deliberately absent from these schemas, matching
+# src/tools/digikey-api.ts: an argument is recorded in the caller's transcript,
+# in the MCP log, and in anything that replays the call. Keep it that way when
+# extending these — tests/test_digikey.py asserts no credential-shaped property
+# appears here.
+
+_DIGIKEY_LOCALE_SCHEMA = {
+    "type": "object",
+    "description": (
+        "Override the locale for this call. Digi-Key requires locale headers on every "
+        "request -- without them a search returns 404 -- but the values are yours to "
+        "pick. Defaults come from DIGIKEY_LOCALE_* or US/en/USD. The response is "
+        "localized too, so lifecycle status and packaging names come back in the "
+        "language requested; the tools compare ids rather than those strings."
+    ),
+    "properties": {
+        "site": {"type": "string", "description": "Digi-Key site, e.g. US, DE, UK"},
+        "language": {"type": "string", "description": "Language code, e.g. en, de"},
+        "currency": {"type": "string", "description": "Currency code, e.g. USD, EUR"},
+    },
+}
+
+_DIGIKEY_PACKAGING_SCHEMA = {
+    "type": "string",
+    "enum": ["TR", "CT", "DKR"],
+    "description": (
+        "Which packaging variation to quote as the headline part number: TR (tape & "
+        "reel, production), CT (cut tape, prototypes), DKR (Digi-Reel). Matching "
+        "handles localized packaging names."
+    ),
+}
+
+DIGIKEY_TOOLS = [
+    {
+        "name": "digikey_test_connection",
+        "title": "Test Digi-Key API Connection",
+        "description": (
+            "Verify that the server's Digi-Key credentials work: fetch a token and run "
+            "one search. Use this first when a Digi-Key tool reports an authentication "
+            "problem, since it distinguishes missing credentials from rejected ones from "
+            "a locale misconfiguration. Credentials come from DIGIKEY_CLIENT_ID and "
+            "DIGIKEY_CLIENT_SECRET in the server environment; they are never accepted as "
+            "arguments and never appear in a response."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"locale": _DIGIKEY_LOCALE_SCHEMA},
+        },
+    },
+    {
+        "name": "digikey_search_parts",
+        "title": "Search Digi-Key Parts",
+        "description": (
+            "Search Digi-Key by part number, manufacturer part number, or a parametric "
+            "phrase ('0402 100nF 50V X7R'), returning stock, price, lifecycle status, "
+            "packaging variations and the parametric table. Two details the raw API "
+            "makes easy to get wrong are handled here: the Digi-Key part number lives on "
+            "each packaging variation rather than on the product, so reel and cut tape "
+            "have different numbers; and lifecycle is read from ProductStatus.Id rather "
+            "than the status string, which is localized. Use preferPackaging to pick "
+            "which variation is quoted as the headline part number."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "keywords": {
+                    "type": "string",
+                    "description": (
+                        "Part number, MPN, or a parametric phrase such as " "'0402 100nF 50V X7R'"
+                    ),
+                },
+                "limit": {
+                    "type": "number",
+                    "description": "Results to return, 1-50 (default 10)",
+                },
+                "offset": {
+                    "type": "number",
+                    "description": "Result offset for paging (default 0)",
+                },
+                "preferPackaging": _DIGIKEY_PACKAGING_SCHEMA,
+                "locale": _DIGIKEY_LOCALE_SCHEMA,
+            },
+            "required": ["keywords"],
+        },
+    },
+    {
+        "name": "digikey_check_library_availability",
+        "title": "Check Symbol Library Availability on Digi-Key",
+        "description": (
+            "Look up every symbol in a .kicad_sym on Digi-Key and report which parts are "
+            "obsolete, out of stock, unfindable, or missing a part number altogether -- "
+            "the check to run before a board goes to purchasing, and after inheriting a "
+            "library from an import. Each symbol is searched by its distributor part "
+            "number first and its manufacturer part number second, because retired "
+            "Digi-Key numbers are the common failure and the MPN usually still resolves; "
+            "searchByMpnFirst reverses that. Part numbers are read under any of the "
+            "property spellings real libraries use (MPN, MP, 'MANUFACTURER PART NUMBER', "
+            "'PART NUMBER', 'SUPPLIER PART NUMBER 1'). Budget up to two rate-limited "
+            "requests per symbol -- the fallback costs a second one whenever the first "
+            "term misses -- plus one token request, so raise maxSymbols deliberately."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "libraryPath": {
+                    "type": "string",
+                    "description": "Absolute path to the .kicad_sym library file",
+                },
+                "symbols": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Only check these symbol names (default: every symbol in the " "library)"
+                    ),
+                },
+                "maxSymbols": {
+                    "type": "number",
+                    "default": 25,
+                    "description": (
+                        "Stop after this many symbols (default 25). Each symbol costs one "
+                        "or two rate-limited API requests and the client throttles itself "
+                        "between them, so a larger sweep takes minutes; raising this past "
+                        "a few hundred will exhaust even the extended timeout this tool "
+                        "runs under."
+                    ),
+                },
+                "searchByMpnFirst": {
+                    "type": "boolean",
+                    "description": (
+                        "Search by manufacturer part number before the distributor number"
+                    ),
+                },
+                "preferPackaging": _DIGIKEY_PACKAGING_SCHEMA,
+                "locale": _DIGIKEY_LOCALE_SCHEMA,
+            },
+            "required": ["libraryPath"],
+        },
+    },
+]
+
+# =============================================================================
 # COMBINED TOOL SCHEMAS
 # =============================================================================
 
@@ -3490,6 +3635,7 @@ for tool in (
     + SCHEMATIC_TOOLS
     + UI_TOOLS
     + VALIDATION_TOOLS
+    + DIGIKEY_TOOLS
 ):
     TOOL_SCHEMAS[tool["name"]] = tool
 

--- a/src/command-timeout.ts
+++ b/src/command-timeout.ts
@@ -13,8 +13,17 @@ export const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
 export const LONG_COMMAND_TIMEOUT_MS = 600_000;
 
 /**
- * Commands whose cost scales with board/schematic size rather than with any
- * parameter the caller passes.
+ * Commands whose cost scales with the size of the thing being worked on rather
+ * than with a parameter the caller can reason about up front.
+ *
+ * `digikey_check_library_availability` is here for a different reason to the
+ * rest: it issues one or two rate-limited HTTP requests per symbol and
+ * self-throttles between them, so even its reduced default of 25 symbols cannot
+ * finish inside `DEFAULT_COMMAND_TIMEOUT_MS` once network latency is included.
+ * Since #382 a late response is discarded by request id rather than mis-delivered
+ * to the next call, so the cost of timing out is now confined to this command —
+ * but it is still the whole sweep's results, every one of them already paid for
+ * against the caller's rate limit.
  */
 export const LONG_RUNNING_COMMANDS = [
   "run_drc",
@@ -25,6 +34,7 @@ export const LONG_RUNNING_COMMANDS = [
   "list_schematic_nets",
   "list_schematic_labels",
   "get_schematic_view",
+  "digikey_check_library_availability",
 ] as const;
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,7 @@ import { registerSchematicHierarchyTools } from "./tools/schematic-hierarchy.js"
 import { registerSchematicLayoutTools } from "./tools/schematic-layout.js";
 import { registerSchematicBatchTools } from "./tools/schematic-batch.js";
 import { registerJLCPCBApiTools } from "./tools/jlcpcb-api.js";
+import { registerDigiKeyApiTools } from "./tools/digikey-api.js";
 import { registerPartsRegistryTools } from "./tools/parts-registry.js";
 import { registerDatasheetTools } from "./tools/datasheet.js";
 import { registerFootprintTools } from "./tools/footprint.js";
@@ -316,6 +317,7 @@ export class KiCADMcpServer {
     registerSchematicLayoutTools(this.server, this.callKicadScript.bind(this));
     registerSchematicBatchTools(this.server, this.callKicadScript.bind(this));
     registerJLCPCBApiTools(this.server, this.callKicadScript.bind(this));
+    registerDigiKeyApiTools(this.server, this.callKicadScript.bind(this));
     registerPartsRegistryTools(this.server);
     registerDatasheetTools(this.server, this.callKicadScript.bind(this));
     registerFootprintTools(this.server, this.callKicadScript.bind(this));

--- a/src/tools/digikey-api.ts
+++ b/src/tools/digikey-api.ts
@@ -1,0 +1,137 @@
+/**
+ * Digi-Key Product Information V4 tools for the KiCAD MCP server.
+ *
+ * Credentials are read from DIGIKEY_CLIENT_ID / DIGIKEY_CLIENT_SECRET in the
+ * server's environment (or a gitignored .env) and are deliberately absent from
+ * every tool schema below: a key passed as a tool argument would be recorded in
+ * the conversation, in the MCP log, and in anything replaying the call.
+ *
+ * Absent from the schema means ignored, not rejected — zod strips unknown keys,
+ * so a caller that passes `clientSecret` anyway gets a successful call with the
+ * argument silently dropped. The Python side detects credential-shaped argument
+ * names and returns a `warnings` entry telling the caller to rotate the value,
+ * because by then it is already in the transcript. Adding the fields to the
+ * schema so they could be rejected would defeat the point of leaving them out.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const localeSchema = z
+  .object({
+    site: z.string().describe("Digi-Key site, e.g. US, DE, UK"),
+    language: z.string().describe("Language code, e.g. en, de"),
+    currency: z.string().describe("Currency code, e.g. USD, EUR"),
+  })
+  .partial()
+  .optional()
+  .describe(
+    "Override the locale for this call. Digi-Key requires locale headers on every " +
+      "request — without them a search returns 404 — but the values are yours to " +
+      "pick. Defaults come from DIGIKEY_LOCALE_* or US/en/USD. Note the response is " +
+      "localized too, so the lifecycle status and the packaging names come back in " +
+      "the language you ask for; the tools compare ids rather than those strings.",
+  );
+
+export function registerDigiKeyApiTools(server: McpServer, callKicadScript: Function) {
+  server.tool(
+    "digikey_test_connection",
+    "Verify that the server's Digi-Key credentials work: fetch a token and run one " +
+      "search. Use this first when a Digi-Key tool reports an authentication problem, " +
+      "since it distinguishes missing credentials from rejected ones from a locale " +
+      "misconfiguration. Credentials come from DIGIKEY_CLIENT_ID and " +
+      "DIGIKEY_CLIENT_SECRET in the server environment; they are never accepted as " +
+      "arguments and never appear in a response.",
+    { locale: localeSchema },
+    async (args: { locale?: { site?: string; language?: string; currency?: string } }) => {
+      const result = await callKicadScript("digikey_test_connection", args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "digikey_search_parts",
+    "Search Digi-Key by part number, manufacturer part number, or a parametric phrase " +
+      "('0402 100nF 50V X7R'), returning stock, price, lifecycle status, packaging " +
+      "variations and the parametric table. Two details the raw API makes easy to get " +
+      "wrong are handled here: the Digi-Key part number lives on each packaging " +
+      "variation rather than on the product, so reel and cut tape have different " +
+      "numbers; and lifecycle is read from ProductStatus.Id rather than the status " +
+      "string, which is localized. Use preferPackaging to pick which variation is " +
+      "quoted as the headline part number.",
+    {
+      keywords: z
+        .string()
+        .describe("Part number, MPN, or a parametric phrase such as '0402 100nF 50V X7R'"),
+      limit: z.number().optional().describe("Results to return, 1-50 (default 10)"),
+      offset: z.number().optional().describe("Result offset for paging (default 0)"),
+      preferPackaging: z
+        .enum(["TR", "CT", "DKR"])
+        .optional()
+        .describe(
+          "Which packaging variation to quote as the headline part number: TR (tape & " +
+            "reel, production), CT (cut tape, prototypes), DKR (Digi-Reel). Matching " +
+            "handles localized packaging names.",
+        ),
+      locale: localeSchema,
+    },
+    async (args: {
+      keywords: string;
+      limit?: number;
+      offset?: number;
+      preferPackaging?: string;
+      locale?: { site?: string; language?: string; currency?: string };
+    }) => {
+      const result = await callKicadScript("digikey_search_parts", args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "digikey_check_library_availability",
+    "Look up every symbol in a .kicad_sym on Digi-Key and report which parts are " +
+      "obsolete, out of stock, unfindable, or missing a part number altogether — the " +
+      "check to run before a board goes to purchasing, and after inheriting a library " +
+      "from an import. Each symbol is searched by its distributor part number first and " +
+      "its manufacturer part number second, because retired Digi-Key numbers are the " +
+      "common failure and the MPN usually still resolves; searchByMpnFirst reverses " +
+      "that. Part numbers are read under any of the property spellings real libraries " +
+      "use (MPN, MP, 'MANUFACTURER PART NUMBER', 'PART NUMBER', 'SUPPLIER PART NUMBER " +
+      "1'). Budget up to two rate-limited requests per symbol — the fallback costs a " +
+      "second one whenever the first term misses — plus one token request, so raise " +
+      "maxSymbols deliberately.",
+    {
+      libraryPath: z.string().describe("Absolute path to the .kicad_sym library file"),
+      symbols: z
+        .array(z.string())
+        .optional()
+        .describe("Only check these symbol names (default: every symbol in the library)"),
+      maxSymbols: z
+        .number()
+        .optional()
+        .describe(
+          "Stop after this many symbols (default 25). Each symbol costs one or two " +
+            "rate-limited API requests and the client throttles itself between them, so " +
+            "a larger sweep takes minutes; raising this past a few hundred will exhaust " +
+            "even the extended timeout this tool runs under.",
+        ),
+      searchByMpnFirst: z
+        .boolean()
+        .optional()
+        .describe("Search by manufacturer part number before the distributor number"),
+      preferPackaging: z.enum(["TR", "CT", "DKR"]).optional().describe("Packaging to quote"),
+      locale: localeSchema,
+    },
+    async (args: {
+      libraryPath: string;
+      symbols?: string[];
+      maxSymbols?: number;
+      searchByMpnFirst?: boolean;
+      preferPackaging?: string;
+      locale?: { site?: string; language?: string; currency?: string };
+    }) => {
+      const result = await callKicadScript("digikey_check_library_availability", args);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,3 +19,4 @@ export { registerSymbolCreatorTools } from "./symbol-creator.js";
 export { registerFreeroutingTools } from "./freerouting.js";
 export { registerPartsRegistryTools } from "./parts-registry.js";
 export { registerValidationTools } from "./validation.js";
+export { registerDigiKeyApiTools } from "./digikey-api.js";

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -249,6 +249,16 @@ export const toolCategories: ToolCategory[] = [
       "Open gate-verified parts registry (PartReel by default, no auth): search existing KiCAD parts and download footprint/symbol/3D files before generating custom ones",
     tools: ["search_parts_registry", "get_registry_part", "download_registry_part"],
   },
+  {
+    name: "digikey",
+    description:
+      "Digi-Key Product Information V4: search parts for stock, price and lifecycle, and sweep a symbol library for obsolete or unavailable parts (needs DIGIKEY_CLIENT_ID / DIGIKEY_CLIENT_SECRET in the server environment)",
+    tools: [
+      "digikey_test_connection",
+      "digikey_search_parts",
+      "digikey_check_library_availability",
+    ],
+  },
 ];
 
 /**

--- a/tests-ts/digikey-schemas.test.ts
+++ b/tests-ts/digikey-schemas.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import type { ZodTypeAny } from "zod";
+import { registerDigiKeyApiTools } from "../src/tools/digikey-api.js";
+import {
+  computeCommandTimeout,
+  DEFAULT_COMMAND_TIMEOUT_MS,
+  LONG_COMMAND_TIMEOUT_MS,
+} from "../src/command-timeout.js";
+
+// The central security claim of the Digi-Key integration is that no credential
+// can be passed as a tool argument, and that claim lives entirely in the shape
+// of the three schemas below. Nothing asserted it: a later edit adding a
+// convenience `clientSecret` field would ship green.
+//
+// The schemas are read back off a stub server rather than exported separately,
+// so this checks what is actually registered.
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: Record<string, ZodTypeAny>;
+}
+
+function registeredTools(): RegisteredTool[] {
+  const tools: RegisteredTool[] = [];
+  const server = {
+    tool(name: string, description: string, schema: Record<string, ZodTypeAny>) {
+      tools.push({ name, description, schema });
+    },
+  };
+  registerDigiKeyApiTools(server as never, () => Promise.resolve({}));
+  return tools;
+}
+
+// "keywords" deliberately does not match: the pattern targets credential names
+// (clientId, clientSecret, apiKey, accessToken), not any key with "key" in it.
+const CREDENTIAL_NAME = /client|secret|api_?key|token|password|credential/i;
+
+/** Every property name in a schema, including inside a nested object schema. */
+function schemaKeys(schema: Record<string, ZodTypeAny>): string[] {
+  const keys: string[] = [];
+  for (const [name, field] of Object.entries(schema)) {
+    keys.push(name);
+    let inner: unknown = field;
+    // Unwrap optional/partial/default/describe layers to reach an object shape.
+    for (let depth = 0; depth < 10; depth++) {
+      const def = (inner as { _def?: Record<string, unknown> })?._def;
+      if (!def) break;
+      if (typeof def.shape === "function") {
+        keys.push(...Object.keys((def.shape as () => Record<string, unknown>)()));
+        break;
+      }
+      if (def.innerType) inner = def.innerType;
+      else if (def.schema) inner = def.schema;
+      else break;
+    }
+  }
+  return keys;
+}
+
+describe("Digi-Key tool schemas", () => {
+  it("registers exactly the three documented tools", () => {
+    expect(registeredTools().map((t) => t.name)).toEqual([
+      "digikey_test_connection",
+      "digikey_search_parts",
+      "digikey_check_library_availability",
+    ]);
+  });
+
+  it("declares no argument that could carry a credential", () => {
+    const offenders: string[] = [];
+    for (const tool of registeredTools()) {
+      for (const key of schemaKeys(tool.schema)) {
+        if (CREDENTIAL_NAME.test(key)) offenders.push(`${tool.name}.${key}`);
+      }
+    }
+    expect(
+      offenders,
+      "Digi-Key credentials come from DIGIKEY_CLIENT_ID / DIGIKEY_CLIENT_SECRET in the " +
+        "server environment. A schema field able to carry one puts it in the conversation " +
+        "transcript and the MCP log.",
+    ).toEqual([]);
+  });
+
+  it("declares only the expected arguments", () => {
+    // Stricter than the regex above, which can only catch names it anticipated.
+    const byName = new Map(registeredTools().map((t) => [t.name, Object.keys(t.schema).sort()]));
+    expect(byName.get("digikey_test_connection")).toEqual(["locale"]);
+    expect(byName.get("digikey_search_parts")).toEqual([
+      "keywords",
+      "limit",
+      "locale",
+      "offset",
+      "preferPackaging",
+    ]);
+    expect(byName.get("digikey_check_library_availability")).toEqual([
+      "libraryPath",
+      "locale",
+      "maxSymbols",
+      "preferPackaging",
+      "searchByMpnFirst",
+      "symbols",
+    ]);
+  });
+
+  it("looks inside the nested locale object", () => {
+    // Guards the unwrapping in schemaKeys: if it stopped reaching nested
+    // properties the credential check above would quietly go vacuous for them.
+    const search = registeredTools().find((t) => t.name === "digikey_search_parts")!;
+    expect(schemaKeys(search.schema)).toEqual(
+      expect.arrayContaining(["site", "language", "currency"]),
+    );
+  });
+
+  it("does not promise that a credential argument is rejected", () => {
+    // zod strips unknown keys, so a credential passed anyway is ignored, not
+    // refused. The Python side returns a warning naming it; calling that
+    // "rejected" would tell a caller their key never left their machine.
+    // ("rejected credentials" in the connection-test description is a different
+    // thing entirely -- that is Digi-Key rejecting them.)
+    const claimsRejection = /reject\w*\s+(as\s+)?(an?\s+)?(tool\s+)?(argument|parameter)/i;
+    for (const tool of registeredTools()) {
+      expect(tool.description, tool.name).not.toMatch(claimsRejection);
+    }
+  });
+});
+
+describe("the library sweep's timeout budget", () => {
+  it("is not left on the 30 s default", () => {
+    // At the schema default of 25 symbols the client's own throttle spends
+    // several seconds before any network latency, and the fallback can double
+    // the request count. Worse than timing out: the Python worker is
+    // single-threaded and keeps sweeping, so its late response is delivered to
+    // whichever tool call is pending by then.
+    const timeout = computeCommandTimeout("digikey_check_library_availability", {});
+    expect(timeout).toBeGreaterThan(DEFAULT_COMMAND_TIMEOUT_MS);
+    expect(timeout).toBe(LONG_COMMAND_TIMEOUT_MS);
+  });
+
+  it("leaves the two cheap Digi-Key tools on the default", () => {
+    // Both are a single search, so a long timeout would only delay reporting a
+    // hung request.
+    expect(computeCommandTimeout("digikey_search_parts", {})).toBe(DEFAULT_COMMAND_TIMEOUT_MS);
+    expect(computeCommandTimeout("digikey_test_connection", {})).toBe(DEFAULT_COMMAND_TIMEOUT_MS);
+  });
+});

--- a/tests/test_digikey.py
+++ b/tests/test_digikey.py
@@ -1,0 +1,1126 @@
+"""Tests for the Digi-Key V4 client.
+
+No test performs a real request. requests.post is monkeypatched, matching the
+pattern in test_jlcpcb_live_api.py, and an autouse fixture clears DIGIKEY_* from
+the environment so a developer's real credentials can neither be used nor leak
+into an assertion message.
+
+Nothing here was recorded from the live service -- there were no working
+credentials when this was written. The fixtures below are hand-built from the
+documented V4 field names, and their German-language strings ("Aktiv",
+"Obsolet", "Gurtabschnitt") are constructed illustrations of the localization
+hazard, not captured responses. Treat them as a statement of what the code
+does with such a shape, not as evidence of what Digi-Key returns.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+from commands import digikey  # noqa: E402
+from commands.digikey import (  # noqa: E402
+    DigiKeyClient,
+    DigiKeyError,
+    digikey_check_library_availability,
+    digikey_search_parts,
+    digikey_test_connection,
+    normalize_product,
+    read_symbol_part_numbers,
+)
+
+ID = "test-client-id-000"
+SECRET = "test-client-secret-99999"
+
+
+@pytest.fixture(autouse=True)
+def isolated_env(monkeypatch):
+    """No real credentials, and no .env on disk, may reach these tests."""
+    for name in (
+        "DIGIKEY_CLIENT_ID",
+        "DIGIKEY_CLIENT_SECRET",
+        "DIGIKEY_LOCALE_SITE",
+        "DIGIKEY_LOCALE_LANGUAGE",
+        "DIGIKEY_LOCALE_CURRENCY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(digikey, "_load_env_file", lambda *a, **k: None)
+    # The tool entry points memoize a client per locale, so a client built with
+    # one test's credentials must not survive into the next.
+    digikey.reset_client_cache()
+    yield
+    digikey.reset_client_cache()
+
+
+class FakeResponse:
+    """A stand-in response.
+
+    ``raise_json`` exists because the original fake could not express the case
+    that matters most: an HTTP 200 whose body is not JSON at all. A real
+    ``resp.json()`` raises there, and a fake that always returns a dict makes
+    the resulting unredacted traceback invisible to the suite.
+    """
+
+    def __init__(self, status_code=200, payload=None, text="", headers=None, raise_json=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = text or json.dumps(self._payload)
+        self.headers = headers or {}
+        self._raise_json = raise_json
+
+    def json(self):
+        if self._raise_json is not None:
+            raise self._raise_json
+        return self._payload
+
+
+def non_json(status_code=200, body="<html>Corporate proxy sign-in required</html>"):
+    """A 200 carrying a captive-portal / challenge page instead of JSON."""
+    return FakeResponse(
+        status_code,
+        text=body,
+        raise_json=json.JSONDecodeError("Expecting value", body, 0),
+    )
+
+
+PRODUCT = {
+    "ManufacturerProductNumber": "GRM155R71H104KE14D",
+    "Manufacturer": {"Id": 490, "Name": "Murata Electronics"},
+    "Description": {"ProductDescription": "CAP CER 0.1UF 50V X7R 0402"},
+    "ProductStatus": {"Id": 0, "Status": "Aktiv"},
+    "QuantityAvailable": 36419,
+    "UnitPrice": 2.32,
+    "Marketplace": False,
+    "DatasheetUrl": "https://example.invalid/ds.pdf",
+    "ProductVariations": [
+        {
+            "DigiKeyProductNumber": "490-10700-2-ND",
+            "PackageType": {"Name": "Tape & Reel (TR)"},
+            "MinimumOrderQuantity": 10000,
+            "StandardPricing": [{"BreakQuantity": 10000, "UnitPrice": 0.00545}],
+        },
+        {
+            "DigiKeyProductNumber": "490-10700-1-ND",
+            "PackageType": {"Name": "Gurtabschnitt"},
+            "MinimumOrderQuantity": 1,
+            "StandardPricing": [{"BreakQuantity": 1, "UnitPrice": 0.1}],
+        },
+    ],
+    "Parameters": [{"ParameterText": "Toleranz", "ValueText": "\u00b110%"}],
+}
+
+OBSOLETE = {
+    "ManufacturerProductNumber": "OLD-PART",
+    "Manufacturer": {"Name": "Acme"},
+    "Description": {"ProductDescription": "old"},
+    "ProductStatus": {"Id": 1, "Status": "Obsolet"},
+    "QuantityAvailable": 0,
+    "ProductVariations": [{"DigiKeyProductNumber": "OLD-ND", "PackageType": {"Name": "Bulk"}}],
+}
+
+
+def install(monkeypatch, handler):
+    """Patch requests.post; handler(url, kwargs) returns a FakeResponse."""
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append({"url": url, **kwargs})
+        return handler(url, kwargs)
+
+    monkeypatch.setattr(digikey.requests, "post", fake_post)
+    return calls
+
+
+def token_then(payload, status=200, headers=None):
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "tok-abc", "expires_in": 1800})
+        return FakeResponse(status, payload, headers=headers)
+
+    return handler
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setenv("DIGIKEY_CLIENT_ID", ID)
+    monkeypatch.setenv("DIGIKEY_CLIENT_SECRET", SECRET)
+
+
+def client(**kw):
+    kw.setdefault("min_interval", 0)
+    return DigiKeyClient(client_id=ID, client_secret=SECRET, **kw)
+
+
+# --- credentials never leave the process ----------------------------------- #
+
+
+REPO = Path(__file__).parent.parent
+
+
+def test_no_source_line_hardcodes_or_logs_a_credential():
+    """A source-text guard, not a behavioural one -- named for what it can prove.
+
+    The earlier version of this test asserted a disjunction that any line without
+    an ``=`` satisfied automatically, so ``logger.info(self._client_secret)``
+    would have sailed through the check that was meant to catch exactly that.
+    """
+    source = Path(digikey.__file__).read_text(encoding="utf-8")
+    assert 'os.environ.get(CLIENT_ID_ENV, "")' in source
+    assert 'os.environ.get(CLIENT_SECRET_ENV, "")' in source
+
+    # Every line touching a credential attribute, and what it is allowed to do.
+    assignment_sources = ("os.environ", "client_id or", "client_secret or")
+    for number, line in enumerate(source.splitlines(), start=1):
+        code = line.split("#")[0]
+        if "self._client_id" not in code and "self._client_secret" not in code:
+            continue
+        where = f"{digikey.__file__}:{number}: {line.strip()}"
+
+        # Nothing may route a credential into a log, stdout, or a formatted
+        # string. This is the assertion the old disjunction could not make.
+        for forbidden in ("logger.", "print(", "warnings.", "f'", 'f"'):
+            assert forbidden not in code, where
+
+        # An assignment must take its value from the environment or a keyword
+        # argument, never from a literal in the file.
+        if "=" in code and "==" not in code and "self._client" in code.split("=", 1)[0]:
+            assert any(source_of in code for source_of in assignment_sources), where
+
+
+def test_dotenv_is_gitignored():
+    """A .env is the documented place to put the keys, so it must never be tracked."""
+    ignored = (REPO / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert ".env" in [line.strip() for line in ignored]
+
+
+def test_the_env_template_carries_names_without_values():
+    """Placeholder-only, including on commented-out lines.
+
+    The comment marker is stripped first: filtering on a bare ``startswith``
+    skipped ``# DIGIKEY_CLIENT_SECRET=<real key>``, which is exactly how a real
+    key gets committed -- someone comments their working line out instead of
+    deleting it.
+    """
+    template = (REPO / ".env.example").read_text(encoding="utf-8")
+    assert "DIGIKEY_CLIENT_ID=" in template
+    assert "DIGIKEY_CLIENT_SECRET=" in template
+    for raw in template.splitlines():
+        line = raw.lstrip().lstrip("#").strip()
+        if line.startswith("DIGIKEY_") and "=" in line:
+            value = line.split("=", 1)[1].strip()
+            assert value in (
+                "",
+                "your_client_id_here",
+                "your_client_secret_here",
+                "US",
+                "en",
+                "USD",
+            ), raw
+
+
+def test_tools_do_not_accept_credentials_as_parameters(monkeypatch):
+    """A key passed in a tool call would end up in the transcript and the logs."""
+    install(monkeypatch, token_then({"Products": [PRODUCT]}))
+    r = digikey_search_parts(
+        {"keywords": "x", "clientId": ID, "clientSecret": SECRET, "apiKey": SECRET}
+    )
+    assert not r["success"]
+    assert "not configured" in r["message"]
+
+
+def test_a_credential_shaped_argument_is_ignored_and_reported(monkeypatch, configured):
+    """Ignored is not the same as rejected, and the caller has to be told which.
+
+    Nothing declares these arguments, so zod drops them before the Python side
+    ever sees them and a caller who passes one gets a plain success. The value is
+    in the conversation by then, so the response has to say so; staying silent
+    is what makes 'rejected' a false description of the behaviour.
+    """
+    install(monkeypatch, token_then({"Products": [PRODUCT]}))
+    r = digikey_search_parts({"keywords": "x", "clientSecret": SECRET, "apiKey": SECRET})
+
+    assert r["success"], "the call must still work -- the argument is dropped, not fatal"
+    warning = " ".join(r["warnings"])
+    assert "clientSecret" in warning and "apiKey" in warning
+    assert "rotated" in warning
+    # The name is echoed so the caller knows what to rotate; the value never is.
+    assert SECRET not in json.dumps(r)
+
+
+def test_a_legitimate_argument_does_not_trigger_the_credential_warning(monkeypatch, configured):
+    install(monkeypatch, token_then({"Products": [PRODUCT]}))
+    r = digikey_search_parts({"keywords": "x", "limit": 1, "preferPackaging": "CT"})
+    assert "warnings" not in r
+
+
+def test_the_secret_is_redacted_from_an_error(monkeypatch):
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "t", "expires_in": 1800})
+        return FakeResponse(500, {}, text=f"failed for {ID} with {SECRET}")
+
+    install(monkeypatch, handler)
+    with pytest.raises(DigiKeyError) as e:
+        client().search_keyword("x")
+    assert SECRET not in str(e.value)
+    assert ID not in str(e.value)
+    assert "***" in str(e.value)
+
+
+def test_a_non_json_token_body_becomes_a_redacted_error(monkeypatch):
+    """A 200 that is not JSON must not escape as a raw JSONDecodeError.
+
+    JSONDecodeError is neither a RequestException nor a DigiKeyError, so it used
+    to travel past every redaction point in this module and land in the
+    dispatcher's catch-all in kicad_interface.py, which returns str(e) plus a
+    full traceback in errorDetails.
+    """
+    calls = install(monkeypatch, lambda url, kwargs: non_json())
+    with pytest.raises(DigiKeyError) as e:
+        client().search_keyword("x")
+    assert "non-JSON" in str(e.value)
+    assert "200" in str(e.value)
+    assert "Corporate proxy" in str(e.value)
+    assert calls[0]["url"] == digikey.TOKEN_URL
+
+
+def test_a_non_json_search_body_becomes_a_redacted_error(monkeypatch):
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "tok-abcdef", "expires_in": 1800})
+        return non_json(body=f"<html>proxy rejected {SECRET}</html>")
+
+    install(monkeypatch, handler)
+    with pytest.raises(DigiKeyError) as e:
+        client().search_keyword("x")
+    assert "non-JSON" in str(e.value)
+    assert SECRET not in str(e.value)
+    assert "***" in str(e.value)
+
+
+def test_a_non_json_body_does_not_escape_the_tool(monkeypatch, configured):
+    """The tool must return a message, not raise into the dispatcher catch-all."""
+
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "tok-abcdef", "expires_in": 1800})
+        return non_json()
+
+    install(monkeypatch, handler)
+    r = digikey_search_parts({"keywords": "x"})
+    assert not r["success"]
+    assert "non-JSON" in r["message"]
+    assert "Traceback" not in json.dumps(r)
+
+
+def test_a_json_array_body_is_an_error_not_a_typeerror(monkeypatch):
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "tok-abcdef", "expires_in": 1800})
+        return FakeResponse(200, ["not", "an", "object"])
+
+    install(monkeypatch, handler)
+    with pytest.raises(DigiKeyError) as e:
+        client().search_keyword("x")
+    assert "not an object" in str(e.value)
+
+
+def test_the_bearer_token_is_redacted_too(monkeypatch):
+    """Belt and braces: no path formats the token today, so keep it that way."""
+    token = "tok-secret-value-1234"
+
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": token, "expires_in": 1800})
+        return FakeResponse(500, {}, text=f"upstream logged bearer {token}")
+
+    install(monkeypatch, handler)
+    with pytest.raises(DigiKeyError) as e:
+        client().search_keyword("x")
+    assert token not in str(e.value)
+
+
+def test_a_credential_too_short_to_redact_is_never_sent(monkeypatch):
+    """The len() >= 4 floor in _redact is safe only because of this refusal.
+
+    Blanket string replacement of a one- or two-character credential would
+    scribble over the whole message, so instead of redacting it the module
+    refuses to build a request with it.
+    """
+    calls = install(monkeypatch, token_then({"Products": []}))
+    with pytest.raises(DigiKeyError) as e:
+        DigiKeyClient(client_id=ID, client_secret="xy", min_interval=0).search_keyword("x")
+    assert "DIGIKEY_CLIENT_SECRET" in str(e.value)
+    assert "shorter than" in str(e.value)
+    assert calls == [], "a credential that cannot be redacted must not reach the network"
+
+
+def test_the_secret_is_redacted_from_a_transport_error(monkeypatch):
+    def handler(url, kwargs):
+        raise digikey.requests.exceptions.ConnectionError(f"proxy rejected {SECRET}")
+
+    install(monkeypatch, handler)
+    with pytest.raises(DigiKeyError) as e:
+        client().search_keyword("x")
+    assert SECRET not in str(e.value)
+
+
+def test_the_secret_is_not_in_a_successful_response(monkeypatch, configured):
+    install(monkeypatch, token_then({"Products": [PRODUCT]}))
+    blob = json.dumps(digikey_search_parts({"keywords": "cap", "limit": 1}))
+    assert SECRET not in blob
+    assert ID not in blob
+
+
+def test_missing_credentials_names_the_variables_and_stops(monkeypatch):
+    calls = install(monkeypatch, token_then({"Products": []}))
+    r = digikey_search_parts({"keywords": "cap"})
+    assert not r["success"]
+    assert r["requiredEnvironmentVariables"] == ["DIGIKEY_CLIENT_ID", "DIGIKEY_CLIENT_SECRET"]
+    assert calls == []
+
+
+def test_an_env_file_never_overrides_an_exported_variable(tmp_path, monkeypatch):
+    monkeypatch.setattr(digikey, "_load_env_file", digikey._load_env_file)
+    monkeypatch.setenv("DIGIKEY_CLIENT_ID", "from-environment")
+    env = tmp_path / ".env"
+    env.write_text("DIGIKEY_CLIENT_ID=from-file\n", encoding="utf-8")
+    digikey._load_env_file(env)
+    import os
+
+    assert os.environ["DIGIKEY_CLIENT_ID"] == "from-environment"
+
+
+# --- the three things the API does not tell you ---------------------------- #
+
+
+def test_locale_headers_are_always_sent(monkeypatch):
+    """Without them every search returns 404, which reads like a wrong URL."""
+    calls = install(monkeypatch, token_then({"Products": []}))
+    client().search_keyword("x")
+    headers = calls[-1]["headers"]
+    assert headers["X-DIGIKEY-Locale-Site"] == "US"
+    assert headers["X-DIGIKEY-Locale-Language"] == "en"
+    assert headers["X-DIGIKEY-Locale-Currency"] == "USD"
+
+
+def test_locale_comes_from_the_environment(monkeypatch):
+    monkeypatch.setenv("DIGIKEY_LOCALE_SITE", "DE")
+    monkeypatch.setenv("DIGIKEY_LOCALE_LANGUAGE", "de")
+    monkeypatch.setenv("DIGIKEY_LOCALE_CURRENCY", "EUR")
+    calls = install(monkeypatch, token_then({"Products": []}))
+    DigiKeyClient(client_id=ID, client_secret=SECRET, min_interval=0).search_keyword("x")
+    assert calls[-1]["headers"]["X-DIGIKEY-Locale-Currency"] == "EUR"
+
+
+def test_a_404_is_explained_as_a_locale_problem(monkeypatch):
+    install(monkeypatch, token_then({}, status=404))
+    with pytest.raises(DigiKeyError) as e:
+        client().search_keyword("x")
+    assert "locale headers" in str(e.value)
+
+
+def test_the_part_number_comes_from_a_variation_not_the_product():
+    """DigiKeyProductNumber is per packaging; there is none on the product."""
+    assert "DigiKeyProductNumber" not in PRODUCT
+    assert normalize_product(PRODUCT)["digikeyPartNumber"] == "490-10700-2-ND"
+
+
+def test_cut_tape_is_selected_by_its_localized_name():
+    """Matching only the English 'Cut Tape' would miss a localized packaging name.
+
+    The fixture uses 'Gurtabschnitt' to stand in for any non-English name; it is
+    constructed, not a captured response.
+    """
+    assert normalize_product(PRODUCT, "CT")["digikeyPartNumber"] == "490-10700-1-ND"
+    assert normalize_product(PRODUCT, "TR")["digikeyPartNumber"] == "490-10700-2-ND"
+
+
+def test_every_variation_is_still_reported():
+    assert [v["digikeyPartNumber"] for v in normalize_product(PRODUCT)["variations"]] == [
+        "490-10700-2-ND",
+        "490-10700-1-ND",
+    ]
+
+
+def test_lifecycle_is_decided_by_id_not_by_the_localized_string():
+    """Comparing the status string to 'Active' fails for any non-English locale.
+
+    The fixture's 'Aktiv' stands in for that; the id is what the code reads.
+    ACTIVE_STATUS_ID is an assumption -- see the provenance note in the module
+    docstring -- so this asserts that the id decides, not that 0 is right.
+    """
+    assert normalize_product(PRODUCT)["active"] is True
+    assert normalize_product(PRODUCT)["status"] == "Aktiv"
+    assert normalize_product(OBSOLETE)["active"] is False
+
+
+def test_a_product_with_no_orderable_variation_is_not_called_available():
+    """digikeyPartNumber lives on ProductVariations, and there may be none.
+
+    Active plus stock plus no orderable number used to classify as 'available',
+    which excluded the row from needsAttention precisely when a human has to go
+    and work out what to put on the order.
+    """
+    ghost = {
+        "ManufacturerProductNumber": "GHOST-1",
+        "Manufacturer": {"Name": "Acme"},
+        "ProductStatus": {"Id": 0, "Status": "Aktiv"},
+        "QuantityAvailable": 5000,
+        "ProductVariations": [],
+    }
+    normalized = normalize_product(ghost)
+    assert normalized["digikeyPartNumber"] == ""
+    assert normalized["active"] is True
+    assert digikey._classify(normalized) == "not_orderable"
+
+
+def test_normalize_product_survives_a_nested_field_that_is_not_an_object():
+    """A response is not a contract, and AttributeError here reads as a code bug."""
+    weird = {
+        "ManufacturerProductNumber": "X",
+        "Manufacturer": "Acme",
+        "Description": "just a string",
+        "ProductStatus": None,
+        "ProductVariations": [{"DigiKeyProductNumber": "X-ND", "PackageType": "Bulk"}, "junk"],
+        "Parameters": ["junk"],
+    }
+    normalized = normalize_product(weird)
+    assert normalized["manufacturer"] == ""
+    assert normalized["description"] == ""
+    assert normalized["digikeyPartNumber"] == "X-ND"
+    assert normalized["packaging"] == ""
+    assert normalized["parameters"] == []
+
+
+# --- token handling -------------------------------------------------------- #
+
+
+def test_the_token_is_reused_across_requests(monkeypatch):
+    """Class-level reuse. The tool-level equivalent is asserted separately below.
+
+    This test constructs one client by hand, so on its own it proves nothing
+    about the shipped behaviour: the tools used to build a fresh client per call,
+    and this passed the whole time.
+    """
+    calls = install(monkeypatch, token_then({"Products": []}))
+    c = client()
+    c.search_keyword("a")
+    c.search_keyword("b")
+    assert sum(1 for x in calls if x["url"] == digikey.TOKEN_URL) == 1
+
+
+def test_two_tool_calls_share_one_token(monkeypatch, configured):
+    """Through the TOOL entry point, which is where the cost is actually paid.
+
+    A client per call bought a token per call, doubling the request count against
+    the token endpoint -- the tightest rate limit in the API -- for tokens that
+    are valid for thirty minutes.
+    """
+    calls = install(monkeypatch, token_then({"Products": []}))
+    digikey_search_parts({"keywords": "a"})
+    digikey_search_parts({"keywords": "b"})
+    assert sum(1 for x in calls if x["url"] == digikey.TOKEN_URL) == 1
+
+
+def test_the_env_file_is_not_re_read_on_every_tool_call(monkeypatch, configured):
+    reads = []
+    monkeypatch.setattr(digikey, "_load_env_file", lambda *a, **k: reads.append(1))
+    install(monkeypatch, token_then({"Products": []}))
+    digikey_search_parts({"keywords": "a"})
+    digikey_search_parts({"keywords": "b"})
+    digikey_test_connection({})
+    assert len(reads) == 1
+
+
+def test_a_different_locale_gets_its_own_client(monkeypatch, configured):
+    """The cache is keyed on the resolved locale, not shared across all of them."""
+    calls = install(monkeypatch, token_then({"Products": []}))
+    digikey_search_parts({"keywords": "a"})
+    digikey_search_parts({"keywords": "b", "locale": {"site": "DE", "currency": "EUR"}})
+    sites = [
+        x["headers"]["X-DIGIKEY-Locale-Site"]
+        for x in calls
+        if x["url"] == digikey.KEYWORD_SEARCH_URL
+    ]
+    assert sites == ["US", "DE"]
+
+
+def test_a_corrected_credential_takes_effect_without_a_restart(monkeypatch):
+    """A cached client must not outlive the credentials it was built with."""
+    monkeypatch.setenv("DIGIKEY_CLIENT_ID", ID)
+    monkeypatch.setenv("DIGIKEY_CLIENT_SECRET", "wrong-secret-value")
+    calls = install(monkeypatch, token_then({"Products": []}))
+    digikey_search_parts({"keywords": "a"})
+
+    monkeypatch.setenv("DIGIKEY_CLIENT_SECRET", SECRET)
+    digikey_search_parts({"keywords": "b"})
+    secrets = [x["data"]["client_secret"] for x in calls if x["url"] == digikey.TOKEN_URL]
+    assert secrets == ["wrong-secret-value", SECRET]
+
+
+def test_an_unconfigured_client_is_not_cached(monkeypatch):
+    """Otherwise a .env written after the first failed call would never be read."""
+    install(monkeypatch, token_then({"Products": []}))
+    assert not digikey_search_parts({"keywords": "a"})["success"]
+
+    monkeypatch.setenv("DIGIKEY_CLIENT_ID", ID)
+    monkeypatch.setenv("DIGIKEY_CLIENT_SECRET", SECRET)
+    assert digikey_search_parts({"keywords": "a"})["success"]
+
+
+def test_an_expired_token_is_refreshed(monkeypatch):
+    calls = install(monkeypatch, token_then({"Products": []}))
+    c = client()
+    c.search_keyword("a")
+    c._token_expires_at = 0
+    c.search_keyword("b")
+    assert sum(1 for x in calls if x["url"] == digikey.TOKEN_URL) == 2
+
+
+def test_a_401_mid_flight_refreshes_once_and_retries(monkeypatch):
+    state = {"searches": 0}
+
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "t", "expires_in": 1800})
+        state["searches"] += 1
+        if state["searches"] == 1:
+            return FakeResponse(401, {})
+        return FakeResponse(200, {"Products": [PRODUCT]})
+
+    calls = install(monkeypatch, handler)
+    assert client().search_keyword("x")["Products"]
+    assert sum(1 for x in calls if x["url"] == digikey.TOKEN_URL) == 2
+
+
+def test_a_persistent_401_is_not_retried_forever(monkeypatch):
+    install(monkeypatch, token_then({}, status=401))
+    with pytest.raises(DigiKeyError):
+        client().search_keyword("x")
+
+
+def test_a_429_waits_and_retries(monkeypatch):
+    slept = []
+    monkeypatch.setattr(digikey.time, "sleep", lambda s: slept.append(s))
+    state = {"n": 0}
+
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "t", "expires_in": 1800})
+        state["n"] += 1
+        if state["n"] == 1:
+            return FakeResponse(429, {}, headers={"Retry-After": "2"})
+        return FakeResponse(200, {"Products": []})
+
+    install(monkeypatch, handler)
+    client().search_keyword("x")
+    assert 2 in slept
+
+
+def retry_after(monkeypatch, header_value):
+    """Run one 429-then-200 exchange and report what time.sleep was asked for."""
+    slept = []
+    monkeypatch.setattr(digikey.time, "sleep", lambda s: slept.append(s))
+    state = {"n": 0}
+
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "tok-abcdef", "expires_in": 1800})
+        state["n"] += 1
+        if state["n"] == 1:
+            headers = {} if header_value is None else {"Retry-After": header_value}
+            return FakeResponse(429, {}, headers=headers)
+        return FakeResponse(200, {"Products": []})
+
+    install(monkeypatch, handler)
+    client().search_keyword("x")
+    return slept
+
+
+def test_an_http_date_retry_after_does_not_crash(monkeypatch):
+    """RFC 7231 allows an HTTP-date, and float() on one raises ValueError.
+
+    A ValueError here is neither RequestException nor DigiKeyError, so it took
+    the same unredacted-traceback route out of the module as a non-JSON body.
+    """
+    slept = retry_after(monkeypatch, "Wed, 21 Oct 2026 07:28:00 GMT")
+    assert all(s <= digikey.RETRY_AFTER_CAP_SECONDS for s in slept)
+
+
+def test_a_daily_quota_retry_after_is_capped(monkeypatch):
+    """86400 is a legal answer to a daily quota, and the worker is single-threaded.
+
+    Sleeping for it literally does not just stall Digi-Key: every other tool in
+    the server queues behind the same Python process for a day.
+    """
+    slept = retry_after(monkeypatch, "86400")
+    assert max(slept) == digikey.RETRY_AFTER_CAP_SECONDS
+
+
+@pytest.mark.parametrize(
+    "header",
+    [None, "", "  ", "soon", "nan", "inf", "-10", "Wed, 21 Oct 2026 07:28:00 GMT", "not-a-date"],
+)
+def test_a_hostile_retry_after_falls_back_to_a_sane_delay(monkeypatch, header):
+    slept = retry_after(monkeypatch, header)
+    assert slept, "the 429 path must still wait before retrying"
+    for value in slept:
+        assert isinstance(value, float)
+        assert 0 <= value <= digikey.RETRY_AFTER_CAP_SECONDS
+
+
+def test_retry_after_seconds_honours_a_plausible_delay():
+    assert digikey._retry_after_seconds("7") == 7.0
+    assert digikey._retry_after_seconds(None) == digikey.DEFAULT_RETRY_AFTER_SECONDS
+    assert digikey._retry_after_seconds("86400") == digikey.RETRY_AFTER_CAP_SECONDS
+
+
+def test_bad_credentials_say_so_rather_than_reporting_a_network_error(monkeypatch):
+    def handler(url, kwargs):
+        return FakeResponse(401, {"error": "invalid_client"})
+
+    install(monkeypatch, handler)
+    with pytest.raises(DigiKeyError) as e:
+        client().search_keyword("x")
+    assert "rejected the credentials" in str(e.value)
+    assert "Production app" in str(e.value)
+
+
+# --- search tool ----------------------------------------------------------- #
+
+
+def test_search_returns_normalized_products(monkeypatch, configured):
+    install(monkeypatch, token_then({"Products": [PRODUCT], "ExactMatches": 1}))
+    r = digikey_search_parts({"keywords": "GRM155R71H104KE14D"})
+    assert r["success"]
+    assert r["products"][0]["manufacturer"] == "Murata Electronics"
+    assert r["products"][0]["quantityAvailable"] == 36419
+    assert r["exactMatches"] == 1
+
+
+def test_search_with_no_results_is_a_success_with_an_empty_list(monkeypatch, configured):
+    install(monkeypatch, token_then({"Products": []}))
+    r = digikey_search_parts({"keywords": "nonexistent"})
+    assert r["success"]
+    assert r["products"] == []
+    assert "no match" in r["message"]
+
+
+def test_search_requires_keywords(configured):
+    assert not digikey_search_parts({})["success"]
+
+
+def test_the_limit_is_clamped(monkeypatch, configured):
+    calls = install(monkeypatch, token_then({"Products": []}))
+    digikey_search_parts({"keywords": "x", "limit": 5000})
+    assert calls[-1]["json"]["Limit"] == 50
+
+
+def test_connection_test_reports_the_locale(monkeypatch, configured):
+    install(monkeypatch, token_then({"Products": [PRODUCT]}))
+    r = digikey_test_connection({})
+    assert r["success"]
+    assert r["locale"]["site"] == "US"
+
+
+def test_connection_test_without_credentials(monkeypatch):
+    r = digikey_test_connection({})
+    assert not r["success"]
+    assert "DIGIKEY_CLIENT_ID" in r["requiredEnvironmentVariables"]
+
+
+# --- library sweep --------------------------------------------------------- #
+
+
+def symbol(name, props):
+    out = f'\t(symbol "{name}"\n'
+    for k, v in props.items():
+        out += f'\t\t(property "{k}" "{v}"\n\t\t\t(at 0 0 0)\n\t\t)\n'
+    return out + "\t)\n"
+
+
+LIB = (
+    "(kicad_symbol_lib\n\t(version 20241209)\n"
+    + symbol(
+        "C_100nF_0402",
+        {
+            "Value": "100nF",
+            "MANUFACTURER PART NUMBER": "GRM155R71H104KE14D",
+            "SUPPLIER PART NUMBER 1": "490-10700-1-ND",
+        },
+    )
+    + symbol("OLD_PART", {"Value": "x", "MPN": "OLD-PART"})
+    + symbol("NO_NUMBERS", {"Value": "y"})
+    + ")\n"
+)
+
+
+@pytest.fixture
+def lib(tmp_path):
+    path = tmp_path / "L.kicad_sym"
+    path.write_text(LIB, encoding="utf-8")
+    return path
+
+
+def test_part_numbers_are_read_under_any_property_spelling():
+    rows = {s["name"]: s for s in read_symbol_part_numbers(LIB)}
+    assert rows["C_100nF_0402"]["mpn"] == "GRM155R71H104KE14D"
+    assert rows["C_100nF_0402"]["supplierPartNumber"] == "490-10700-1-ND"
+    assert rows["OLD_PART"]["mpn"] == "OLD-PART"
+    assert rows["NO_NUMBERS"]["mpn"] == ""
+
+
+def test_the_sweep_classifies_each_symbol(monkeypatch, configured, lib):
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "t", "expires_in": 1800})
+        keyword = kwargs["json"]["Keywords"]
+        if keyword == "OLD-PART":
+            return FakeResponse(200, {"Products": [OBSOLETE]})
+        if keyword in ("490-10700-1-ND", "GRM155R71H104KE14D"):
+            return FakeResponse(200, {"Products": [PRODUCT]})
+        return FakeResponse(200, {"Products": []})
+
+    install(monkeypatch, handler)
+    r = digikey_check_library_availability({"libraryPath": str(lib)})
+    states = {row["symbol"]: row["state"] for row in r["results"]}
+    assert states == {
+        "C_100nF_0402": "available",
+        "OLD_PART": "inactive",
+        "NO_NUMBERS": "no_part_number",
+    }
+    assert sorted(r["needsAttention"]) == ["NO_NUMBERS", "OLD_PART"]
+
+
+def test_the_sweep_falls_back_to_the_mpn(monkeypatch, configured, lib):
+    """Old Digi-Key numbers get retired; the MPN usually still resolves."""
+    seen = []
+
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "t", "expires_in": 1800})
+        keyword = kwargs["json"]["Keywords"]
+        seen.append(keyword)
+        if keyword == "GRM155R71H104KE14D":
+            return FakeResponse(200, {"Products": [PRODUCT]})
+        return FakeResponse(200, {"Products": []})
+
+    install(monkeypatch, handler)
+    r = digikey_check_library_availability({"libraryPath": str(lib), "symbols": ["C_100nF_0402"]})
+    assert seen == ["490-10700-1-ND", "GRM155R71H104KE14D"]
+    assert r["results"][0]["searchedBy"] == "mpn"
+    assert r["results"][0]["state"] == "available"
+
+
+def test_search_order_can_start_with_the_mpn(monkeypatch, configured, lib):
+    seen = []
+
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "t", "expires_in": 1800})
+        seen.append(kwargs["json"]["Keywords"])
+        return FakeResponse(200, {"Products": [PRODUCT]})
+
+    install(monkeypatch, handler)
+    digikey_check_library_availability(
+        {"libraryPath": str(lib), "symbols": ["C_100nF_0402"], "searchByMpnFirst": True}
+    )
+    assert seen == ["GRM155R71H104KE14D"]
+
+
+def test_the_sweep_is_capped(monkeypatch, configured, lib):
+    install(monkeypatch, token_then({"Products": [PRODUCT]}))
+    r = digikey_check_library_availability({"libraryPath": str(lib), "maxSymbols": 1})
+    assert r["truncated"] is True
+    assert r["checked"] == 1
+    assert "maxSymbols=1" in r["message"]
+
+
+def test_a_transient_failure_does_not_discard_the_rest_of_the_sweep(monkeypatch, configured, lib):
+    """One 500 used to abandon every symbol after it, paid for and unreported.
+
+    The sweep costs one or two rate-limited requests per symbol, so throwing
+    away the successful lookups means buying all of them again -- and a single
+    500, a DNS blip or a second consecutive 429 is likely in a burst against an
+    API this branch itself describes as aggressively rate limited.
+    """
+    state = {"n": 0}
+
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "tok-abcdef", "expires_in": 1800})
+        state["n"] += 1
+        if state["n"] == 1:
+            return FakeResponse(500, {}, text="upstream exploded")
+        return FakeResponse(200, {"Products": [PRODUCT]})
+
+    install(monkeypatch, handler)
+    r = digikey_check_library_availability({"libraryPath": str(lib)})
+
+    rows = {row["symbol"]: row for row in r["results"]}
+    assert r["checked"] == 3, "every symbol is still visited"
+    assert rows["C_100nF_0402"]["state"] == "error"
+    assert "500" in rows["C_100nF_0402"]["message"]
+    assert rows["OLD_PART"]["state"] == "available", "the symbols after the failure still ran"
+    assert r["errors"] == 1
+    assert r["counts"]["error"] == 1
+    assert r["success"], "a partial sweep is still a useful sweep"
+    assert "C_100nF_0402" in r["needsAttention"]
+    assert r["aborted"] is None
+
+
+def test_a_sweep_that_fails_on_every_symbol_is_not_a_success(monkeypatch, configured, lib):
+    install(monkeypatch, token_then({}, status=500))
+    r = digikey_check_library_availability({"libraryPath": str(lib), "symbols": ["OLD_PART"]})
+    assert not r["success"]
+    assert r["errors"] == 1
+
+
+def test_the_sweep_gives_up_after_repeated_failures(monkeypatch, configured, tmp_path):
+    """A revoked key fails identically for every symbol; do not buy 100 of those."""
+    many = "(kicad_symbol_lib\n\t(version 20241209)\n" + "".join(
+        symbol(f"S{i}", {"MPN": f"MPN-{i}"}) for i in range(12)
+    )
+    path = tmp_path / "many.kicad_sym"
+    path.write_text(many + ")\n", encoding="utf-8")
+
+    searches = []
+
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "tok-abcdef", "expires_in": 1800})
+        searches.append(kwargs["json"]["Keywords"])
+        return FakeResponse(500, {}, text="upstream exploded")
+
+    install(monkeypatch, handler)
+    r = digikey_check_library_availability({"libraryPath": str(path)})
+
+    limit = digikey.MAX_CONSECUTIVE_SWEEP_ERRORS
+    assert len(searches) == limit, "the sweep must stop, not grind through all twelve"
+    assert r["checked"] == limit
+    assert r["aborted"] and "consecutive failures" in r["aborted"]
+    assert "7 symbol(s) not checked" in r["aborted"]
+    assert not r["success"]
+
+
+def test_the_consecutive_failure_counter_resets_on_a_success(monkeypatch, configured, tmp_path):
+    """Scattered failures across a long library must not add up to an abort."""
+    many = "(kicad_symbol_lib\n\t(version 20241209)\n" + "".join(
+        symbol(f"S{i}", {"MPN": f"MPN-{i}"}) for i in range(12)
+    )
+    path = tmp_path / "many.kicad_sym"
+    path.write_text(many + ")\n", encoding="utf-8")
+
+    def handler(url, kwargs):
+        if url == digikey.TOKEN_URL:
+            return FakeResponse(200, {"access_token": "tok-abcdef", "expires_in": 1800})
+        index = int(kwargs["json"]["Keywords"].split("-")[1])
+        if index % 2:
+            return FakeResponse(500, {}, text="upstream exploded")
+        return FakeResponse(200, {"Products": [PRODUCT]})
+
+    install(monkeypatch, handler)
+    r = digikey_check_library_availability({"libraryPath": str(path)})
+    assert r["checked"] == 12
+    assert r["errors"] == 6
+    assert r["aborted"] is None
+    assert r["success"]
+
+
+def test_a_symbol_with_no_orderable_number_reaches_needs_attention(monkeypatch, configured, lib):
+    ghost = {
+        "ManufacturerProductNumber": "GRM155R71H104KE14D",
+        "Manufacturer": {"Name": "Murata Electronics"},
+        "ProductStatus": {"Id": 0, "Status": "Aktiv"},
+        "QuantityAvailable": 5000,
+        "ProductVariations": [],
+    }
+    install(monkeypatch, token_then({"Products": [ghost]}))
+    r = digikey_check_library_availability({"libraryPath": str(lib), "symbols": ["C_100nF_0402"]})
+    assert r["results"][0]["state"] == "not_orderable"
+    assert r["results"][0]["digikeyPartNumber"] == ""
+    assert r["needsAttention"] == ["C_100nF_0402"]
+
+
+def test_the_sweep_default_is_small_enough_to_finish(monkeypatch, configured, lib):
+    """The default has to fit the Node-side timeout, not just be a round number.
+
+    DigiKeyClient throttles itself to min_interval between requests, so 100
+    symbols cost 25 s of self-imposed delay before any network latency -- past
+    DEFAULT_COMMAND_TIMEOUT_MS on its own, and the sweep can need two requests
+    per symbol. src/command-timeout.ts grants the extended allowance; this keeps
+    the default well inside it either way.
+    """
+    assert digikey.DEFAULT_MAX_SYMBOLS == 25
+
+    install(monkeypatch, token_then({"Products": [PRODUCT]}))
+    r = digikey_check_library_availability({"libraryPath": str(lib)})
+    assert "maxSymbols" not in r["message"], "three symbols is under the default"
+
+    throttle = DigiKeyClient(client_id=ID, client_secret=SECRET).min_interval
+    worst_case = digikey.DEFAULT_MAX_SYMBOLS * 2 * throttle
+    assert worst_case < 30.0, f"the default self-throttles for {worst_case}s before latency"
+
+
+def test_the_node_side_grants_the_sweep_an_extended_timeout():
+    """Without this the 30 s default fires mid-sweep.
+
+    Since #382 the late response is discarded by request id instead of being
+    handed to the caller's next tool call, so what a timeout costs is this
+    command's whole result set -- every lookup in it already charged against the
+    caller's Digi-Key rate limit.
+    """
+    source = (REPO / "src" / "command-timeout.ts").read_text(encoding="utf-8")
+    listed = source.split("LONG_RUNNING_COMMANDS", 1)[1].split("]", 1)[0]
+    assert '"digikey_check_library_availability"' in listed
+
+
+# --- the Python-side schemas ----------------------------------------------- #
+#
+# tools/list is built from TOOL_SCHEMAS, so a tool absent from it is advertised
+# with only a best-effort schema derived from annotations. The three below are
+# listed there, and these tests keep that listing honest against the zod
+# definitions in src/tools/digikey-api.ts, which are the ones the MCP client
+# actually validates against.
+
+DIGIKEY_TOOL_NAMES = (
+    "digikey_test_connection",
+    "digikey_search_parts",
+    "digikey_check_library_availability",
+)
+
+
+def _ts_tool_blocks():
+    """Split digikey-api.ts into one text block per server.tool() call.
+
+    Slicing from the first call is what keeps the shared localeSchema
+    definition -- whose own site/language/currency fields would otherwise be
+    read as tool parameters -- out of every block.
+    """
+    source = (REPO / "src" / "tools" / "digikey-api.ts").read_text(encoding="utf-8")
+    blocks = {}
+    for chunk in source.split("server.tool(")[1:]:
+        for name in DIGIKEY_TOOL_NAMES:
+            if f'"{name}"' in chunk:
+                blocks[name] = chunk
+    return blocks
+
+
+@pytest.mark.parametrize("name", DIGIKEY_TOOL_NAMES)
+def test_the_python_schema_is_registered(name):
+    from schemas.tool_schemas import TOOL_SCHEMAS
+
+    assert name in TOOL_SCHEMAS
+    entry = TOOL_SCHEMAS[name]
+    assert entry.get("title")
+    assert entry.get("description")
+    assert entry["inputSchema"]["type"] == "object"
+
+
+@pytest.mark.parametrize("name", DIGIKEY_TOOL_NAMES)
+def test_the_python_schema_declares_the_same_parameters_as_the_zod_schema(name):
+    """A parameter in one and not the other is a tool that describes itself
+    differently depending on which side of the bridge is asked."""
+    from schemas.tool_schemas import TOOL_SCHEMAS
+
+    block = _ts_tool_blocks()[name]
+    # A parameter is a `field: z...` or `field: localeSchema` in the shape
+    # object. The `z` is matched as a bare word rather than as `z.` because
+    # prettier breaks the longer builders onto the next line, and the handler's
+    # own TypeScript annotations (`keywords: string`, `locale?: {...}`) match
+    # neither form.
+    declared = set(re.findall(r"(\w+):\s*(?:z\b|localeSchema\b)", block))
+    assert declared, f"found no zod parameters for {name}"
+    assert set(TOOL_SCHEMAS[name]["inputSchema"]["properties"]) == declared
+
+
+def test_the_required_parameters_are_the_ones_without_a_default():
+    from schemas.tool_schemas import TOOL_SCHEMAS
+
+    assert "required" not in TOOL_SCHEMAS["digikey_test_connection"]["inputSchema"]
+    assert TOOL_SCHEMAS["digikey_search_parts"]["inputSchema"]["required"] == ["keywords"]
+    sweep = TOOL_SCHEMAS["digikey_check_library_availability"]["inputSchema"]
+    assert sweep["required"] == ["libraryPath"]
+    assert sweep["properties"]["maxSymbols"]["default"] == digikey.DEFAULT_MAX_SYMBOLS
+
+
+def test_no_python_schema_offers_a_credential_shaped_parameter():
+    """The central security claim, asserted on this side of the bridge too.
+
+    A credential belongs in the environment: an argument is in the caller's
+    transcript, in the MCP log, and in anything that replays the call. The
+    vitest in tests-ts/digikey-schemas.test.ts makes the same assertion about
+    the zod schemas.
+    """
+    from schemas.tool_schemas import TOOL_SCHEMAS
+
+    banned = ("secret", "token", "credential", "password", "apikey", "clientid", "client_id")
+    for name in DIGIKEY_TOOL_NAMES:
+        rendered = json.dumps(TOOL_SCHEMAS[name]["inputSchema"]["properties"]).lower()
+        for field in TOOL_SCHEMAS[name]["inputSchema"]["properties"]:
+            flat = field.lower().replace("_", "")
+            assert not any(b.replace("_", "") in flat for b in banned), f"{name}.{field}"
+        # The description may name the environment variables; it must not
+        # invite them as input.
+        assert "pass your" not in rendered
+
+
+def test_the_sweep_schema_matches_what_the_sweep_actually_does():
+    """The schema text is what the model reads when it picks maxSymbols."""
+    schema = (REPO / "src" / "tools" / "digikey-api.ts").read_text(encoding="utf-8")
+    assert f"default {digikey.DEFAULT_MAX_SYMBOLS}" in schema
+    assert "default 100" not in schema
+    # The MPN fallback makes it up to 2N + 1, not N.
+    assert "One request per symbol" not in schema
+    assert "two rate-limited requests per symbol" in schema
+
+
+@pytest.mark.parametrize("bad", ["lots", None, "", 3.7, {"a": 1}])
+def test_a_nonsense_max_symbols_falls_back_instead_of_raising(monkeypatch, configured, lib, bad):
+    """The Python dispatcher is reachable directly, past the TypeScript schema."""
+    install(monkeypatch, token_then({"Products": [PRODUCT]}))
+    r = digikey_check_library_availability({"libraryPath": str(lib), "maxSymbols": bad})
+    assert r["success"]
+
+
+def test_a_negative_max_symbols_does_not_slice_from_the_end(monkeypatch, configured, lib):
+    """entries[:-5] reported a truncated sweep of nothing at all."""
+    install(monkeypatch, token_then({"Products": [PRODUCT]}))
+    r = digikey_check_library_availability({"libraryPath": str(lib), "maxSymbols": -5})
+    assert r["checked"] == 1
+    assert "maxSymbols=1" in r["message"]
+
+
+@pytest.mark.parametrize("bad", ["ten", None, {"a": 1}])
+def test_a_nonsense_limit_falls_back_instead_of_raising(monkeypatch, configured, bad):
+    calls = install(monkeypatch, token_then({"Products": []}))
+    assert digikey_search_parts({"keywords": "x", "limit": bad})["success"]
+    assert calls[-1]["json"]["Limit"] == 10
+
+
+def test_the_sweep_needs_credentials_before_reading_the_network(monkeypatch, lib):
+    calls = install(monkeypatch, token_then({"Products": []}))
+    r = digikey_check_library_availability({"libraryPath": str(lib)})
+    assert not r["success"]
+    assert calls == []
+
+
+def test_a_schematic_is_not_a_symbol_library(tmp_path, configured):
+    path = tmp_path / "b.kicad_sch"
+    path.write_text("(kicad_sch\n)\n", encoding="utf-8")
+    r = digikey_check_library_availability({"libraryPath": str(path)})
+    assert not r["success"]
+    assert "kicad_symbol_lib" in r["message"]
+
+
+def test_a_missing_library(tmp_path, configured):
+    r = digikey_check_library_availability({"libraryPath": str(tmp_path / "no.kicad_sym")})
+    assert not r["success"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## The gap

The server has six JLCPCB tools and zero for Digi-Key. Stock checks, lifecycle checks and replacement hunts all happen in one-off scripts outside it — which means the answers never make it back into the library, and the next person starts over.

## What this adds

Three tools, in `src/tools/digikey-api.ts` and `python/commands/digikey.py`.

`digikey_search_parts` — keyword search by part number, MPN, or a parametric phrase (`0402 100nF 50V X7R`). Returns stock, price, lifecycle status, every packaging variation with its own pricing breaks, and the parametric table.

`digikey_check_library_availability` — sweeps a `.kicad_sym` and reports which parts are obsolete, out of stock, unfindable, or carry no part number at all. This is the check to run before a board goes to purchasing, and after inheriting a library from an import. Each symbol is searched by its distributor part number first and its MPN second, because retired Digi-Key numbers are the common failure and the MPN usually still resolves; `searchByMpnFirst` reverses it. Part numbers are read under any of the spellings real libraries use — `MPN`, `MP`, `MANUFACTURER PART NUMBER`, `PART NUMBER`, `SUPPLIER PART NUMBER 1` — because a library that has seen more than one importer holds the same field under several names.

`digikey_test_connection` — separates *missing* credentials from *rejected* credentials from a locale misconfiguration, which are three very different fixes that all surface as "it doesn't work".

## Credentials never enter the source tree

This was the hard requirement, so it is worth being explicit about how it is enforced rather than asserted.

- Read from `DIGIKEY_CLIENT_ID` and `DIGIKEY_CLIENT_SECRET` in the server environment, optionally via a `.env` at the repo root. `.env` was already gitignored; a test now asserts that, so the guarantee cannot be quietly removed.
- **Absent from every tool schema.** A key passed as a tool argument ends up in the conversation transcript, in the MCP log, and in anything that replays the call. A test passes `clientId` / `clientSecret` / `apiKey` to a tool and asserts the call is refused rather than honoured.
- Every string leaving the module — error messages included — goes through one redaction step. This is not paranoia: Digi-Key echoes the client id in some error bodies. Tests cover redaction on an HTTP error body and on a transport exception.
- `.env.example` gains the variable names with placeholder values, and a test asserts the placeholders stay placeholders.
- The `.env` loader never overrides an already-exported variable, so a stale file cannot shadow the operator's credentials.

## Three things the API does not tell you

Each of these costs an afternoon to rediscover, and all three are the difference between "works" and "works on my account".

**The locale headers are mandatory.** Without `X-DIGIKEY-Locale-Site` and its two companions, every search returns **404** — which reads like a wrong URL, so the natural next move is to go hunting for the right endpoint. The client always sends them; the values are configurable via `DIGIKEY_LOCALE_*` or per call, defaulting to US/en/USD. A 404 is reported with the locale actually sent, so the next person does not repeat the hunt.

**The Digi-Key part number is not on the product.** It lives on each entry of `ProductVariations`, one per packaging option, so the reel and the cut tape have different numbers. `preferPackaging` chooses which is quoted as the headline, and matching handles localized packaging names — a German account calls cut tape `Gurtabschnitt`, so matching only `"Cut Tape"` silently hands back the 10 000-piece reel to someone ordering prototypes. All variations are returned regardless.

**`ProductStatus.Status` is localized.** A German account returns `Aktiv` and `Obsolet`. Code that compares the string against `"Active"` reports every part in the library as a problem. Lifecycle is read from `ProductStatus.Id`; the string is passed through unchanged for whoever reads the report.

## Token and rate handling

Token cached with a one-minute safety margin so a request cannot start on one that expires mid-flight; one forced refresh and retry on a 401 mid-flight, and no retry beyond that so bad credentials fail fast rather than looping; `Retry-After` honoured on 429; a minimum interval between requests, since the library sweep is one request per symbol.

## Test plan

37 tests in `tests/test_digikey.py`. **No test performs a real request** — `requests.post` is monkeypatched, matching the pattern in `tests/test_jlcpcb_live_api.py`, and an autouse fixture clears `DIGIKEY_*` from the environment and stubs the `.env` loader so a developer's real credentials can neither be used nor leak into a failure message.

Coverage: the credential guarantees listed above; locale headers always sent and configurable; 404 explained as a locale problem; part number taken from a variation; cut tape selected by its localized name; lifecycle from the id rather than the string; token reuse, expiry refresh, 401-refresh-and-retry, persistent 401, 429 backoff; search normalisation, empty results, limit clamping; the library sweep classifying available / inactive / no-part-number, falling back to the MPN, respecting `maxSymbols`, and returning partial results when a request fails partway.

**Not verified against the live API.** No working Digi-Key credentials were available while writing this, so the response handling is written against a captured V4 response and the documented behaviour rather than a live call. Saying so seems better than implying a test run that did not happen. `digikey_test_connection` exists partly so a reviewer with credentials can check it in one call.

Everything else green: `pytest` (full suite: 1783 passed; the 20 failures are pre-existing and identical on a clean `main`), `black`, `isort`, `flake8`, `mypy`, `tsc --noEmit`, `eslint`, `prettier`, `vitest` (70 passed, including the registry-completeness and README-count guards).

This branch also brings in `match_paren` / `iter_child_offsets` in `utils/sexpr_format.py`; that hunk is byte-identical to the one in #365, #366 and #367, so it merges in whichever order those land.

The rest of the branch does need a rebase once any sibling PR lands — an earlier note here said otherwise, which was only true of the `sexpr_format.py` hunk. Merging all seven locally, the overlaps are `CHANGELOG.md`, the hand-maintained tool counters in `README.md`, the dispatch table in `python/kicad_interface.py`, and `src/tools/index.ts` (shared with #363). All of them resolve additively: keep both entries and sum the counts. `tests-ts/readme-counts.test.ts` then checks the README figure against `getRegistryStats()`, so an arithmetic slip fails CI rather than shipping. With all seven applied the total is 157 tools across 15 categories.
