### PR TITLE
fix: correct get_open_board_path so IPC sessions are not silently pinned to SWIG

### DIFF
--- a/python/kicad_api/ipc_backend.py
+++ b/python/kicad_api/ipc_backend.py
@@ -220,9 +220,15 @@ class IPCBackend(KiCADBackend):
         if not self.is_connected():
             return None
         try:
-            for doc in self._kicad.get_open_documents():
-                if hasattr(doc, "path") and str(doc.path).endswith(".kicad_pcb"):
-                    return str(doc.path)
+            # kipy requires an explicit doc_type; a no-arg call raises TypeError.
+            # DocumentSpecifier exposes board_filename + project.path, not .path.
+            from kipy.proto.common.types import DocumentType
+
+            for doc in self._kicad.get_open_documents(DocumentType.DOCTYPE_PCB):
+                name = str(getattr(doc, "board_filename", "") or "")
+                if name.endswith(".kicad_pcb"):
+                    root = str(getattr(getattr(doc, "project", None), "path", "") or "")
+                    return os.path.join(root, name) if root else name
         except Exception as e:
             logger.debug(f"Could not read open documents via IPC: {e}")
         return None

--- a/tests/test_ipc_open_board_path.py
+++ b/tests/test_ipc_open_board_path.py
@@ -1,0 +1,138 @@
+"""Regression tests for IPCBackend.get_open_board_path (kipy DocumentSpecifier shape).
+
+Two independent defects made this method return None even when the live KiCad GUI
+had a board open:
+
+1. ``get_open_documents()`` was called with no argument, but kipy's signature is
+   ``get_open_documents(self, doc_type)`` — the call raised TypeError, which the
+   surrounding ``except Exception`` swallowed at debug level.
+2. The returned DocumentSpecifier has ``board_filename`` and ``project.path``; it
+   has NO ``.path`` attribute, so the ``hasattr(doc, "path")`` guard never matched.
+
+Because ``_pin_session_backend`` pins "ipc" only when ``get_open_board_path()``
+matches the session board, a None return silently pinned every session to SWIG —
+losing realtime UI sync with no user-visible error.
+"""
+
+import sys
+import types
+from pathlib import Path
+from typing import Any, List, Optional
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from kicad_api.ipc_backend import IPCBackend  # noqa: E402
+
+DOCTYPE_PCB = 2
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+
+class _FakeProject:
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+
+class _FakeDocumentSpecifier:
+    """Mirrors kipy's DocumentSpecifier: board_filename + project, and NO `.path`."""
+
+    def __init__(self, board_filename: str, project_path: str) -> None:
+        self.board_filename = board_filename
+        self.project = _FakeProject(project_path)
+
+
+class _FakeKiCad:
+    """Stands in for kipy.KiCad; doc_type is REQUIRED, exactly as upstream."""
+
+    def __init__(self, docs: List[Any]) -> None:
+        self._docs = docs
+        self.doc_types_requested: List[int] = []
+
+    def ping(self) -> None:
+        return None
+
+    def get_open_documents(self, doc_type: int) -> List[Any]:
+        self.doc_types_requested.append(doc_type)
+        return list(self._docs)
+
+
+def _install_fake_kipy(monkeypatch: Any) -> None:
+    """Resolve `from kipy.proto.common.types import DocumentType` without real kipy."""
+    types_mod = types.ModuleType("kipy.proto.common.types")
+    types_mod.DocumentType = types.SimpleNamespace(DOCTYPE_PCB=DOCTYPE_PCB)
+    for name, mod in (
+        ("kipy", types.ModuleType("kipy")),
+        ("kipy.proto", types.ModuleType("kipy.proto")),
+        ("kipy.proto.common", types.ModuleType("kipy.proto.common")),
+        ("kipy.proto.common.types", types_mod),
+    ):
+        monkeypatch.setitem(sys.modules, name, mod)
+
+
+def _make_backend(docs: List[Any]) -> IPCBackend:
+    backend = IPCBackend()
+    backend._kicad = _FakeKiCad(docs)
+    backend._connected = True
+    return backend
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+def test_returns_full_path_composed_from_project_and_filename(monkeypatch: Any) -> None:
+    """The board path is project.path + board_filename, not a `.path` attribute."""
+    _install_fake_kipy(monkeypatch)
+    backend = _make_backend([_FakeDocumentSpecifier("DankroRunner.kicad_pcb", "/home/u/proj/pcb")])
+
+    assert backend.get_open_board_path() == "/home/u/proj/pcb/DankroRunner.kicad_pcb"
+
+
+def test_requests_pcb_document_type_explicitly(monkeypatch: Any) -> None:
+    """A no-arg get_open_documents() raises TypeError upstream; assert we pass doc_type."""
+    _install_fake_kipy(monkeypatch)
+    backend = _make_backend([_FakeDocumentSpecifier("b.kicad_pcb", "/p")])
+
+    backend.get_open_board_path()
+
+    assert backend._kicad.doc_types_requested == [DOCTYPE_PCB]
+
+
+def test_document_specifier_has_no_path_attribute(monkeypatch: Any) -> None:
+    """Guard the shape assumption that caused the original bug."""
+    doc = _FakeDocumentSpecifier("b.kicad_pcb", "/p")
+
+    assert not hasattr(doc, "path")
+
+
+def test_returns_none_when_no_document_open(monkeypatch: Any) -> None:
+    _install_fake_kipy(monkeypatch)
+    backend = _make_backend([])
+
+    assert backend.get_open_board_path() is None
+
+
+def test_ignores_non_pcb_documents(monkeypatch: Any) -> None:
+    _install_fake_kipy(monkeypatch)
+    backend = _make_backend([_FakeDocumentSpecifier("sheet.kicad_sch", "/p")])
+
+    assert backend.get_open_board_path() is None
+
+
+def test_falls_back_to_bare_filename_when_project_path_empty(monkeypatch: Any) -> None:
+    """An unsaved/pathless project must not yield a path with a leading separator."""
+    _install_fake_kipy(monkeypatch)
+    backend = _make_backend([_FakeDocumentSpecifier("b.kicad_pcb", "")])
+
+    assert backend.get_open_board_path() == "b.kicad_pcb"
+
+
+def test_returns_none_when_not_connected(monkeypatch: Any) -> None:
+    _install_fake_kipy(monkeypatch)
+    backend = IPCBackend()
+
+    assert backend.get_open_board_path() is None


### PR DESCRIPTION
## Problem

`IPCBackend.get_open_board_path()` always returns `None`, even when the live KiCad GUI has a board open.

Because `_pin_session_backend()` pins the session to `"ipc"` only when `get_open_board_path()` matches the session board, that `None` silently pins **every** session to SWIG. A user who has correctly enabled the IPC server still gets `_backend: "swig"`, `_realtime: false` and no live UI sync — and nothing is surfaced above `logger.debug`, so it looks like the IPC setup simply didn't take.

## Root cause

Two independent defects in the same loop (`python/kicad_api/ipc_backend.py`):

```python
for doc in self._kicad.get_open_documents():          # 1
    if hasattr(doc, "path") and str(doc.path).endswith(".kicad_pcb"):   # 2
        return str(doc.path)
```

1. **Missing required argument.** kipy's signature is `get_open_documents(self, doc_type)`. The no-arg call raises `TypeError: KiCad.get_open_documents() missing 1 required positional argument: 'doc_type'`, which the surrounding `except Exception` swallows at debug level.

2. **Wrong attribute.** Even with (1) fixed, the returned `DocumentSpecifier` has **no** `.path` attribute, so the `hasattr` guard never matches. Observed shape against KiCad 10.0.5:

   ```
   board_filename: DankroRunner.kicad_pcb
   project.path:   /home/…/hardware/pcb/track_b
   hasattr(doc, "path"): False
   ```

The path therefore has to be composed from `project.path` + `board_filename`.

## Fix

Pass `DocumentType.DOCTYPE_PCB` explicitly and compose the path from the real field names, falling back to the bare filename when the project has no path (so an unsaved project can't yield a stray leading separator). The `kipy` import is kept function-local, matching `connect()`, so the module still imports without kicad-python installed.

## Verification

Environment: KiCad 10.0.5 (Ubuntu 24.04 package), IPC server enabled, PCB editor open.

Before — `open_board`:
```json
{"sessionBackend": "swig", "_backend": "swig", "_realtime": false}
```

After — `open_board`:
```json
{"sessionBackend": "ipc", "_backend": "ipc", "_realtime": true}
```

`get_board_info` then serves live data over IPC (`componentCount: 13`, `trackCount: 24`, `netCount: 21`), matching an independent `kipy` read of the same board.

## Tests

Adds `tests/test_ipc_open_board_path.py` (7 cases). It's a genuine regression test — **3 of the 7 fail** against the current code and all 7 pass with the fix:

```
FAILED test_returns_full_path_composed_from_project_and_filename
FAILED test_requests_pcb_document_type_explicitly
FAILED test_falls_back_to_bare_filename_when_project_path_empty
3 failed, 4 passed
```

The tests inject a fake `kipy` module into `sys.modules`, so they run without kicad-python and without a live KiCad.

Full suite: `1799 passed, 12 skipped, 8 failed`. The 8 failures are in `test_autoroute_best_of_n.py` / `test_freerouting.py` and are **pre-existing** — I confirmed they fail identically on a clean checkout with this branch stashed. `black` is clean on both changed files.