### PR TITLE
fix(setup-macos): verify/install Python requirements so --verify can't pass on a server that won't start; document Claude Code registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,13 @@ npm run build
 
 **Note:** The `--system-site-packages` flag is required to access KiCAD's `pcbnew` module from the virtual environment.
 
+**Note:** If you skip the virtual environment, install the requirements with KiCAD's bundled interpreter — a plain `pip3 install -r requirements.txt` goes to system Python, which the server never uses, and the server then fails to start (the MCP client times out after 30s with no visible error):
+
+```bash
+/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3 \
+  -m pip install --user -r requirements.txt
+```
+
 #### Automated Setup
 
 To simplify configuration with Claude Desktop, this repository provides a macOS setup script:
@@ -996,7 +1003,20 @@ Use the same configuration format as Claude Desktop above.
 
 ### Claude Code
 
-Claude Code automatically detects MCP servers in the current directory. No additional configuration needed.
+Claude Code does **not** read the Claude Desktop configuration file, and it only auto-detects servers listed in a project's `.mcp.json` (this repository does not ship one). Register the server explicitly with `claude mcp add`:
+
+```bash
+# macOS example — adjust KICAD_PYTHON/PYTHONPATH per platform (see table above)
+claude mcp add --scope user kicad \
+  --env KICAD_PYTHON=/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3 \
+  --env PYTHONPATH=/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages \
+  --env LOG_LEVEL=info \
+  -- node /path/to/KiCAD-MCP-Server/dist/index.js
+```
+
+With `--scope user` the server is available in every project; use `--scope project` to write a shareable `.mcp.json` instead. On macOS, `setup-macos.sh` prints this command with the detected paths filled in.
+
+Verify with `claude mcp list` — the server should report ✔ Connected.
 
 ### OpenCode (Windows)
 

--- a/docs/PLATFORM_GUIDE.md
+++ b/docs/PLATFORM_GUIDE.md
@@ -276,6 +276,9 @@ echo 'export PYTHONPATH=/usr/lib/kicad/lib/python3/dist-packages' >> ~/.bashrc
 # Verify pcbnew module
 /Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3 -c "import pcbnew; print(pcbnew.GetBuildVersion())"
 
+# Install project dependencies using KiCAD's bundled Python
+/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3 -m pip install --user -r requirements.txt
+
 # Or use the setup script to verify everything at once
 bash setup-macos.sh --verify
 ```

--- a/setup-macos.sh
+++ b/setup-macos.sh
@@ -18,8 +18,10 @@ Usage:
 Options:
   --verify               Check prerequisites and print detected paths
   --dry-run              Show config and merged Claude Desktop config without writing
-  --apply                Write/update Claude Desktop config
-  --yes                  Do not prompt before writing (only with --apply)
+  --apply                Write/update Claude Desktop config; offers to install
+                         missing Python dependencies first
+  --yes                  Do not prompt before writing or installing dependencies
+                         (only with --apply)
   --name NAME            MCP server name (default: kicad)
   --claude-config PATH   Path to Claude Desktop config file
                          (default: ~/Library/Application Support/Claude/claude_desktop_config.json)
@@ -117,6 +119,13 @@ fi
 DIST_JS="$REPO_ROOT/dist/index.js"
 
 DEFAULT_KICAD_PYTHON="/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3"
+
+# Prefer a repo-local venv (created per the README's manual macOS setup) so the
+# generated config points at the interpreter that has the requirements
+# installed. An explicit KICAD_PYTHON env var still wins.
+if [[ -z "${KICAD_PYTHON:-}" && -x "$REPO_ROOT/venv/bin/python3" ]]; then
+  KICAD_PYTHON="$REPO_ROOT/venv/bin/python3"
+fi
 KICAD_PYTHON="${KICAD_PYTHON:-$DEFAULT_KICAD_PYTHON}"
 
 command -v python3 >/dev/null 2>&1 || fail "python3 not found"
@@ -132,6 +141,7 @@ result = {
     "python_executable": sys.executable,
     "python_version": sys.version.split()[0],
     "purelib": sysconfig.get_paths().get("purelib"),
+    "in_venv": sys.prefix != getattr(sys, "base_prefix", sys.prefix),
     "pcbnew_ok": False,
     "pcbnew_version": None,
     "pcbnew_error": None,
@@ -158,6 +168,43 @@ if [[ "$PCBNEW_OK" != "true" ]]; then
   fail "KiCad Python could not import pcbnew. Details: $PCBNEW_ERROR"
 fi
 
+IN_VENV="$(python3 -c 'import json,sys; print("true" if json.loads(sys.argv[1])["in_venv"] else "false")' "$DETECT_JSON")"
+
+# Runtime requirements as "import-name:pip-package" pairs. The Python bridge
+# imports several of these at startup; if one is missing the server dies
+# before answering the MCP handshake and the client just times out after 30s
+# with no visible error (issue #350).
+REQUIRED_PY_MODULES="sexpdata:sexpdata skip:kicad-skip PIL:Pillow colorlog:colorlog pydantic:pydantic requests:requests dotenv:python-dotenv cairosvg:cairosvg kipy:kicad-python"
+
+check_missing_packages() {
+  "$KICAD_PYTHON" - "$REQUIRED_PY_MODULES" <<'PY'
+import importlib, sys
+missing = []
+for pair in sys.argv[1].split():
+    module_name, package_name = pair.split(":", 1)
+    try:
+        importlib.import_module(module_name)
+    except Exception:
+        missing.append(package_name)
+print(" ".join(missing))
+PY
+}
+
+MISSING_PACKAGES="$(check_missing_packages)"
+
+REQUIREMENTS_FILE="$REPO_ROOT/requirements.txt"
+if [[ "$IN_VENV" == "true" ]]; then
+  PIP_INSTALL_CMD=("$KICAD_PYTHON" -m pip install -r "$REQUIREMENTS_FILE")
+else
+  PIP_INSTALL_CMD=("$KICAD_PYTHON" -m pip install --user -r "$REQUIREMENTS_FILE")
+fi
+
+missing_deps_message() {
+  warn "The KiCAD MCP server will not start until the missing Python packages are installed:"
+  echo "    ${BOLD}${PIP_INSTALL_CMD[*]}${RESET}"
+  echo "  ${DIM}Without them the MCP client times out after 30s with no visible error.${RESET}"
+}
+
 CONFIG_FRAGMENT_JSON="$(python3 - "$NODE_PATH" "$DIST_JS" "$KICAD_PYTHON" "$PYTHONPATH_VALUE" <<'PY'
 import json, sys
 fragment = {
@@ -180,6 +227,11 @@ show_detected() {
   echo "  ${SYM_OK} build artifact   $DIST_JS"
   echo "  ${SYM_OK} KiCad Python     $KICAD_PYTHON"
   echo "  ${SYM_OK} pcbnew import    $PCBNEW_VERSION"
+  if [[ -z "$MISSING_PACKAGES" ]]; then
+    echo "  ${SYM_OK} python deps      all requirements importable"
+  else
+    echo "  ${SYM_FAIL} python deps      missing: $MISSING_PACKAGES"
+  fi
 
   section "Configuration"
   echo "  Server name:       ${BOLD}$SERVER_NAME${RESET}"
@@ -236,10 +288,28 @@ print(json.dumps({"status": status, "merged": existing}, indent=2))
 PY
 }
 
+show_claude_code_hint() {
+  section "Claude Code (optional)"
+  echo "  Claude Code (the CLI) does not read the Claude Desktop config."
+  echo "  To register the server there as well, run:"
+  echo
+  echo "  claude mcp add --scope user $SERVER_NAME \\"
+  echo "    --env KICAD_PYTHON=\"$KICAD_PYTHON\" \\"
+  echo "    --env PYTHONPATH=\"$PYTHONPATH_VALUE\" \\"
+  echo "    --env LOG_LEVEL=info \\"
+  echo "    -- \"$NODE_PATH\" \"$DIST_JS\""
+}
+
 if [[ "$MODE" == "verify" ]]; then
   show_detected
   section "Proposed Claude Desktop entry ('$SERVER_NAME')"
   echo "$CONFIG_FRAGMENT_JSON"
+  show_claude_code_hint
+  if [[ -n "$MISSING_PACKAGES" ]]; then
+    echo
+    missing_deps_message
+    exit 1
+  fi
   exit 0
 fi
 
@@ -272,7 +342,32 @@ echo "${DIM}Merged config preview:${RESET}"
 echo "$MERGED_JSON"
 
 if [[ "$MODE" == "dry-run" ]]; then
+  if [[ -n "$MISSING_PACKAGES" ]]; then
+    echo
+    missing_deps_message
+  fi
   exit 0
+fi
+
+if [[ -n "$MISSING_PACKAGES" ]]; then
+  section "Python dependencies"
+  warn "Missing for $KICAD_PYTHON: $MISSING_PACKAGES"
+  DO_INSTALL=$ASSUME_YES
+  if [[ $ASSUME_YES -ne 1 ]]; then
+    echo
+    read -r -p "Install them now with '${PIP_INSTALL_CMD[*]}' ? [y/N] " REPLY
+    case "$REPLY" in
+      y|Y|yes|YES) DO_INSTALL=1 ;;
+    esac
+  fi
+  if [[ $DO_INSTALL -eq 1 ]]; then
+    "${PIP_INSTALL_CMD[@]}"
+    STILL_MISSING="$(check_missing_packages)"
+    [[ -z "$STILL_MISSING" ]] || fail "Still missing after install: $STILL_MISSING"
+    info "Python dependencies installed."
+  else
+    missing_deps_message
+  fi
 fi
 
 mkdir -p "$CLAUDE_CONFIG_DIR"
@@ -314,4 +409,6 @@ echo "  2. Reopen Claude Desktop"
 echo "  3. In a new chat, check: + → Connectors"
 echo "  4. Verify with:"
 echo "     Use the ${BOLD}$SERVER_NAME${RESET} MCP server to run ${BOLD}check_kicad_ui${RESET}."
+
+show_claude_code_hint
 echo


### PR DESCRIPTION
Closes #350. Related: #99, #143.

## Problem

`setup-macos.sh --verify` validates the `pcbnew` import but never checks the Python requirements. The README's plain `pip3 install -r requirements.txt` puts them into **system** Python, while the generated config runs the server with **KiCad's bundled** interpreter — so `python/kicad_interface.py` dies on `import sexpdata` before the MCP handshake, and the client just times out after 30s with no visible error. `--verify` shows all green the whole time.

There was also a second incoherence: the README's manual macOS setup creates a `./venv` from KiCad's Python and installs the requirements there — but the setup script then writes `KICAD_PYTHON` pointing at the bundled interpreter, which never sees that venv. Following both documented paths together still produced a broken install.

## Changes

**`setup-macos.sh`**
- `--verify` now import-checks all production requirements with the same interpreter the generated config points at, reports a `python deps` line alongside the existing checks, and exits 1 with the exact pip command when something is missing.
- `--apply` offers to install missing requirements (into KiCad Python's user site, or into `./venv` without `--user` when a venv is in use — `pip --user` errors inside venvs) and re-verifies before writing the config. `--yes` covers this prompt too.
- The script now prefers `./venv/bin/python3` when present (an explicit `KICAD_PYTHON` env var still wins), so the manual and automated setup paths compose correctly.
- Prints the equivalent `claude mcp add` registration for Claude Code users, since Claude Code does not read the Claude Desktop config.

**`README.md`**
- Replaces the Claude Code section's "automatically detects MCP servers in the current directory" claim (which #99 tripped over — Claude Code only auto-detects a project `.mcp.json`, and this repo doesn't ship one) with a working `claude mcp add` example.
- Adds a note to the macOS section: skipping the venv means installing requirements with the bundled interpreter, with the exact command.

**`docs/PLATFORM_GUIDE.md`**
- Adds the macOS install-requirements line that the Windows section already had.

## Testing (macOS, KiCad 10.0.5, Python 3.9.13)

- `--verify` with deps present: all green, exit 0, Claude Code hint printed.
- `--verify` with deps hidden (`PYTHONNOUSERSITE=1`): reports `missing: sexpdata kicad-skip Pillow colorlog pydantic python-dotenv cairosvg kicad-python`, exit 1, actionable pip command. (`requests` correctly not flagged — KiCad bundles it.)
- `--dry-run` with deps missing: warns, still exits 0.
- Full `--apply --yes` against a fresh `--system-site-packages` venv with deps hidden: detects missing packages, pip-installs into the venv (no `--user`), re-verifies, writes a correct config pointing at the venv interpreter (tested against a scratch `--claude-config` path).
- `bash -n` and shellcheck clean (the one remaining shellcheck warning, SC2088, is pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
