### PR TITLE
Add set_net_color: set/clear an individual net's display color override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### New Features
+
+- **`set_net_color`** (#375): set or clear an individual net's display color
+  override — the PCB editor's "Net colors" panel, previously not reachable
+  by any tool. `net_settings.net_colors` has no SWIG counterpart
+  (`NETINFO_ITEM` has no color getter/setter), so this is pure `.kicad_pro`
+  JSON persistence, same read/modify/write-atomically shape already used by
+  `assign_net_to_class`. Accepts a `#RRGGBB` hex color, or `clear: true` to
+  remove the override and revert to the automatic/class color. Cosmetic
+  only — does not affect routing or design rules.
+
 ## [2.7.0] - 2026-08-20
 
 ### New Tools

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standa
 
 **Key Capabilities:**
 
-- 169 tools across 15 categories with JSON Schema validation
+- 170 tools across 15 categories with JSON Schema validation
 - Keyword tool discovery via `search_tools` / `get_category_tools`
 - 8 dynamic resources exposing project state
 - Complete schematic workflow with 27 tools and dynamic symbol loading (~10,000 symbols)
@@ -72,7 +72,7 @@ round-trip — 419 of KiCad's own stock symbol files carry such values.
   flow back to the schematic, the reverse of `sync_schematic_to_board`.
 
 All by @karu2003. With #359 (@AmirF194) registering 15 existing symbol tools,
-`search_tools` now indexes 169 tools in 15 categories.
+`search_tools` now indexes 170 tools in 15 categories.
 
 ### Quality of life
 
@@ -539,7 +539,7 @@ Access project state without executing tools:
 
 ## Available Tools
 
-The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **169 tools** are additionally indexed into 15 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
+The server exposes every tool directly, so your assistant can call any of them without a discovery step -- just ask for what you want to accomplish. **170 tools** are additionally indexed into 15 functional categories, so `search_tools` and `get_category_tools` can find one by keyword.
 
 For the complete tool reference with access types (direct/routed/additional), see [Tool Inventory](docs/TOOL_INVENTORY.md).
 
@@ -585,7 +585,7 @@ For the complete tool reference with access types (direct/routed/additional), se
 - `align_components` - Align multiple components
 - `duplicate_component` - Copy existing component
 
-### Routing (13 tools)
+### Routing (14 tools)
 
 - `add_net` - Create electrical net
 - `route_trace` - Route copper traces between XY points
@@ -600,6 +600,7 @@ For the complete tool reference with access types (direct/routed/additional), se
 - `route_differential_pair` - Route differential signals
 - `refill_zones` - Refill all copper zones
 - `copy_routing_pattern` - Replicate routing between component groups
+- `set_net_color` - Set or clear a net's display color override
 
 ### Schematic (27 tools)
 

--- a/docs/TOOL_INVENTORY.md
+++ b/docs/TOOL_INVENTORY.md
@@ -76,7 +76,7 @@ _Source: `src/tools/component.ts`_
 
 ---
 
-## Routing (13 tools)
+## Routing (14 tools)
 
 _Source: `src/tools/routing.ts`_
 
@@ -86,6 +86,7 @@ _Source: `src/tools/routing.ts`_
 | `route_trace`             | Route trace segment between XY points (single layer) | Direct           |
 | `add_via`                 | Add via (through/blind/buried)                       | Routed (routing) |
 | `add_copper_pour`         | Add copper pour / ground plane                       | Routed (routing) |
+| `set_net_color`           | Set/clear a net's display color override             | Routed (routing) |
 | `delete_trace`            | Delete traces by UUID, position, or bulk by net      | Additional       |
 | `query_traces`            | Query/filter traces by net, layer, or bounding box   | Additional       |
 | `get_nets_list`           | List all nets with statistics                        | Additional       |

--- a/python/commands/routing.py
+++ b/python/commands/routing.py
@@ -6,6 +6,7 @@ import json
 import logging
 import math
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -208,6 +209,99 @@ def persist_net_assignment_to_project(
         return {
             "persisted": False,
             "warning": f"could not persist net class assignment to {pro_path}: {exc}",
+        }
+
+
+# --- Net color project-file persistence (KiCad 7+) -------------------------
+#
+# An individual net's display color (the "Net colors" panel in the PCB
+# editor) lives only in ``<project>.kicad_pro`` -> ``net_settings.net_colors``,
+# a flat ``{net_name: "rgb(r, g, b)"}`` map. Unlike net class membership,
+# there is no SWIG mirror to keep in sync: ``NETINFO_ITEM`` (pcbnew.py) has no
+# color getter/setter at all, so this is pure JSON I/O, same persistence
+# shape as ``apply_net_assignment_to_project_settings`` above. A net with no
+# entry in the map simply uses its automatic/class color, which is why
+# clearing an override means deleting the key rather than writing a sentinel.
+
+_HEX_COLOR_RE = re.compile(r"^#?([0-9A-Fa-f]{6})$")
+
+
+def _hex_to_kicad_rgb(color: str) -> str:
+    """Convert a ``#RRGGBB`` / ``RRGGBB`` hex string to KiCad's
+    ``"rgb(r, g, b)"`` net_colors format. Raises ValueError on anything else.
+    """
+    match = _HEX_COLOR_RE.match(color.strip())
+    if not match:
+        raise ValueError(f"'{color}' is not a valid hex color (expected '#RRGGBB')")
+    hex_digits = match.group(1)
+    r = int(hex_digits[0:2], 16)
+    g = int(hex_digits[2:4], 16)
+    b = int(hex_digits[4:6], 16)
+    return f"rgb({r}, {g}, {b})"
+
+
+def apply_net_color_to_project_settings(
+    data: Dict[str, Any], net_name: str, kicad_rgb: Optional[str]
+) -> Dict[str, Any]:
+    """Insert, update, or clear a net's color override in a parsed
+    ``.kicad_pro`` dict. Pure: mutates and returns ``data``; performs no I/O.
+
+    ``kicad_rgb=None`` clears the override (removes the key), reverting the
+    net to its automatic/class color — mirroring the native "Clear color"
+    action. Same present-but-null defensiveness as
+    ``apply_net_assignment_to_project_settings``: a fresh project can have
+    ``"net_colors": null``.
+    """
+    net_settings = data.setdefault("net_settings", {})
+    if not isinstance(net_settings, dict):
+        net_settings = {}
+        data["net_settings"] = net_settings
+    net_colors = net_settings.get("net_colors")
+    if not isinstance(net_colors, dict):
+        net_colors = {}
+        net_settings["net_colors"] = net_colors
+    if kicad_rgb is None:
+        net_colors.pop(net_name, None)
+    else:
+        net_colors[net_name] = kicad_rgb
+    return data
+
+
+def persist_net_color_to_project(
+    pro_path: Optional[str], net_name: str, kicad_rgb: Optional[str]
+) -> Dict[str, Any]:
+    """Read/modify/write ``pro_path`` so a net's color override survives a
+    reload. Returns ``{"persisted": bool, "projectFile"?: str, "warning"?: str}``.
+    Never raises. The write is atomic (temp file + ``os.replace``).
+    """
+    if not pro_path or not os.path.exists(pro_path):
+        return {
+            "persisted": False,
+            "warning": "no .kicad_pro project file found; net color not persisted",
+        }
+    try:
+        with open(pro_path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        apply_net_color_to_project_settings(data, net_name, kicad_rgb)
+
+        directory = os.path.dirname(pro_path) or "."
+        fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".netcolor-", suffix=".kicad_pro")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+            os.replace(tmp_path, pro_path)
+        except Exception:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
+        return {"persisted": True, "projectFile": pro_path}
+    except Exception as exc:  # report, never fail the command on a persistence error
+        return {
+            "persisted": False,
+            "warning": f"could not persist net color to {pro_path}: {exc}",
         }
 
 
@@ -879,6 +973,97 @@ class RoutingCommands:
             return {
                 "success": False,
                 "message": "Failed to get nets list",
+                "errorDetails": str(e),
+            }
+
+    def set_net_color(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Set or clear a net's display color override.
+
+        This is pure ``.kicad_pro`` persistence (``net_settings.net_colors``)
+        — there is no in-memory SWIG counterpart to update, since
+        ``NETINFO_ITEM`` has no color getter/setter (see module docstring
+        above ``apply_net_color_to_project_settings``).
+        """
+        try:
+            if not self.board:
+                return {
+                    "success": False,
+                    "message": "No board is loaded",
+                    "errorDetails": "Load or create a board first",
+                }
+
+            net_name = params.get("net")
+            color = params.get("color")
+            clear = params.get("clear", False)
+
+            if not net_name:
+                return {
+                    "success": False,
+                    "message": "Missing net name",
+                    "errorDetails": "net parameter is required",
+                }
+            if not clear and not color:
+                return {
+                    "success": False,
+                    "message": "Missing color",
+                    "errorDetails": "color is required unless clear is true",
+                }
+
+            netinfo = self.board.GetNetInfo()
+            nets_map = netinfo.NetsByName()
+            if not nets_map.has_key(net_name):
+                return {
+                    "success": False,
+                    "message": f"Net not found: {net_name}",
+                    "errorDetails": f"'{net_name}' does not exist on the board",
+                }
+
+            kicad_rgb = None
+            if not clear:
+                try:
+                    kicad_rgb = _hex_to_kicad_rgb(color)
+                except ValueError as exc:
+                    return {
+                        "success": False,
+                        "message": "Invalid color",
+                        "errorDetails": str(exc),
+                    }
+
+            pro_path = None
+            try:
+                board_path = self.board.GetFileName()
+                if board_path and board_path.endswith(".kicad_pcb"):
+                    pro_path = str(Path(board_path).with_suffix(".kicad_pro"))
+            except Exception:
+                pro_path = None
+
+            persist = persist_net_color_to_project(pro_path, net_name, kicad_rgb)
+            if not persist.get("persisted"):
+                return {
+                    "success": False,
+                    "message": "Failed to set net color",
+                    "errorDetails": persist.get("warning", "unknown persistence error"),
+                }
+
+            result = {
+                "success": True,
+                "message": (
+                    f"Cleared color for net: {net_name}"
+                    if clear
+                    else f"Set color for net {net_name} to {kicad_rgb}"
+                ),
+                "net": net_name,
+                "color": kicad_rgb,
+                "persisted": True,
+                "projectFile": persist.get("projectFile"),
+            }
+            return result
+
+        except Exception as e:
+            logger.error(f"Error setting net color: {str(e)}")
+            return {
+                "success": False,
+                "message": "Failed to set net color",
                 "errorDetails": str(e),
             }
 

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -550,6 +550,7 @@ class KiCADInterface(SchematicHandlersMixin):
             "copy_routing_pattern": self.routing_commands.copy_routing_pattern,
             "get_nets_list": self.routing_commands.get_nets_list,
             "create_netclass": self.routing_commands.create_netclass,
+            "set_net_color": self.routing_commands.set_net_color,
             "add_copper_pour": self.routing_commands.add_copper_pour,
             "route_differential_pair": self.routing_commands.route_differential_pair,
             "refill_zones": self._handle_refill_zones,

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -1776,6 +1776,26 @@ ROUTING_TOOLS = [
         },
     },
     {
+        "name": "set_net_color",
+        "title": "Set Net Color",
+        "description": "Sets or clears a net's display color override (PCB editor's 'Net colors' panel). Cosmetic only — does not affect routing or design rules.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "net": {"type": "string", "description": "Name of the net"},
+                "color": {
+                    "type": "string",
+                    "description": "Hex color, e.g. '#FF7D00'. Required unless clear is true.",
+                },
+                "clear": {
+                    "type": "boolean",
+                    "description": "If true, remove the color override and revert to the automatic/class color",
+                },
+            },
+            "required": ["net"],
+        },
+    },
+    {
         "name": "add_copper_pour",
         "title": "Add Copper Pour",
         "description": "Creates a copper pour/zone (typically for ground or power planes).",

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -229,8 +229,8 @@ export const toolCategories: ToolCategory[] = [
   },
   {
     name: "routing",
-    description: "Advanced routing operations: vias, copper pours",
-    tools: ["add_via", "add_copper_pour"],
+    description: "Advanced routing operations: vias, copper pours, net display colors",
+    tools: ["add_via", "add_copper_pour", "set_net_color"],
   },
   {
     name: "autoroute",

--- a/src/tools/routing.ts
+++ b/src/tools/routing.ts
@@ -424,6 +424,35 @@ export function registerRoutingTools(server: McpServer, callKicadScript: Functio
     },
   );
 
+  // Set net color tool
+  server.tool(
+    "set_net_color",
+    "Set or clear a net's display color override (the PCB editor's 'Net colors' panel). " +
+      "Persisted to the project's net_settings.net_colors; does not affect routing or design rules.",
+    {
+      net: z.string().describe("Name of the net"),
+      color: z
+        .string()
+        .optional()
+        .describe("Hex color, e.g. '#FF7D00'. Required unless clear is true."),
+      clear: z
+        .boolean()
+        .optional()
+        .describe("If true, remove the color override and revert to the automatic/class color"),
+    },
+    async (args: any) => {
+      const result = await callKicadScript("set_net_color", args);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
   // Route differential pair tool
   server.tool(
     "route_differential_pair",

--- a/tests/test_set_net_color.py
+++ b/tests/test_set_net_color.py
@@ -1,0 +1,223 @@
+"""Tests for set_net_color: a net's display color override lives only in
+``<project>.kicad_pro`` (``net_settings.net_colors``, a flat
+``{net_name: "rgb(r, g, b)"}`` map) — there is no SWIG mirror to update,
+since ``NETINFO_ITEM`` has no color getter/setter. Same persistence model
+(and same historical dispatch-table pitfall, see test_assign_net_to_class.py)
+as ``assign_net_to_class``.
+
+These tests exercise the hex parser, the pure JSON transform, the atomic
+file round-trip, and the ``RoutingCommands.set_net_color`` wiring without
+needing a live KiCad / SWIG board.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from commands.routing import (  # noqa: E402
+    RoutingCommands,
+    _hex_to_kicad_rgb,
+    apply_net_color_to_project_settings,
+    persist_net_color_to_project,
+)
+
+
+def _project_with_colors():
+    return {
+        "net_settings": {
+            "classes": [{"name": "Default", "clearance": 0.2}],
+            "net_colors": {"GND": "rgb(0, 100, 100)"},
+        }
+    }
+
+
+# --- _hex_to_kicad_rgb ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hex_in,expected",
+    [
+        ("#FF7D00", "rgb(255, 125, 0)"),
+        ("FF7D00", "rgb(255, 125, 0)"),
+        ("#000000", "rgb(0, 0, 0)"),
+        ("#ffffff", "rgb(255, 255, 255)"),
+    ],
+)
+def test_hex_to_kicad_rgb_valid(hex_in, expected):
+    assert _hex_to_kicad_rgb(hex_in) == expected
+
+
+@pytest.mark.parametrize("bad", ["", "red", "#FFF", "#GGGGGG", "#FF7D0000"])
+def test_hex_to_kicad_rgb_rejects_invalid(bad):
+    with pytest.raises(ValueError):
+        _hex_to_kicad_rgb(bad)
+
+
+# --- pure transform ----------------------------------------------------------
+
+
+def test_apply_adds_new_color():
+    data = _project_with_colors()
+    apply_net_color_to_project_settings(data, "VCC_3V3", "rgb(255, 0, 0)")
+    assert data["net_settings"]["net_colors"]["VCC_3V3"] == "rgb(255, 0, 0)"
+
+
+def test_apply_overwrites_existing_color_for_same_net():
+    data = _project_with_colors()
+    apply_net_color_to_project_settings(data, "GND", "rgb(1, 2, 3)")
+    assert data["net_settings"]["net_colors"]["GND"] == "rgb(1, 2, 3)"
+
+
+def test_apply_clears_color_by_removing_the_key():
+    data = _project_with_colors()
+    apply_net_color_to_project_settings(data, "GND", None)
+    assert "GND" not in data["net_settings"]["net_colors"]
+
+
+def test_apply_clear_on_net_without_a_color_is_a_noop():
+    data = _project_with_colors()
+    apply_net_color_to_project_settings(data, "NOT_SET", None)
+    assert "NOT_SET" not in data["net_settings"]["net_colors"]
+
+
+def test_apply_creates_net_settings_and_net_colors_when_absent():
+    data = {}
+    apply_net_color_to_project_settings(data, "GND", "rgb(0, 100, 100)")
+    assert data["net_settings"]["net_colors"]["GND"] == "rgb(0, 100, 100)"
+
+
+def test_apply_handles_present_but_null_net_colors():
+    """Same real-project shape as netclass_assignments: KiCad can write
+    ``"net_colors": null`` when a project has no explicit overrides yet."""
+    data = {"net_settings": {"net_colors": None}}
+    apply_net_color_to_project_settings(data, "GND", "rgb(0, 100, 100)")
+    assert data["net_settings"]["net_colors"]["GND"] == "rgb(0, 100, 100)"
+
+
+def test_apply_handles_null_net_settings():
+    data = {"net_settings": None}
+    apply_net_color_to_project_settings(data, "GND", "rgb(0, 100, 100)")
+    assert data["net_settings"]["net_colors"]["GND"] == "rgb(0, 100, 100)"
+
+
+# --- file persistence ---------------------------------------------------------
+
+
+def test_persist_round_trips_through_a_real_file(tmp_path):
+    pro = tmp_path / "proj.kicad_pro"
+    pro.write_text(json.dumps(_project_with_colors()))
+    result = persist_net_color_to_project(str(pro), "VCC_3V3", "rgb(255, 0, 0)")
+    assert result["persisted"] is True
+    assert result["projectFile"] == str(pro)
+    reloaded = json.loads(pro.read_text())
+    assert reloaded["net_settings"]["net_colors"]["VCC_3V3"] == "rgb(255, 0, 0)"
+
+
+def test_persist_preserves_unrelated_project_content(tmp_path):
+    pro = tmp_path / "proj.kicad_pro"
+    project = _project_with_colors()
+    project["board"] = {"design_settings": {"rules": {"min_clearance": 0.1}}}
+    pro.write_text(json.dumps(project))
+    persist_net_color_to_project(str(pro), "VCC_3V3", "rgb(255, 0, 0)")
+    reloaded = json.loads(pro.read_text())
+    assert reloaded["board"]["design_settings"]["rules"]["min_clearance"] == 0.1
+    assert reloaded["net_settings"]["net_colors"]["GND"] == "rgb(0, 100, 100)"
+    assert reloaded["net_settings"]["net_colors"]["VCC_3V3"] == "rgb(255, 0, 0)"
+
+
+def test_persist_writes_atomically_leaving_no_temp_file(tmp_path):
+    pro = tmp_path / "proj.kicad_pro"
+    pro.write_text(json.dumps(_project_with_colors()))
+    persist_net_color_to_project(str(pro), "VCC_3V3", "rgb(255, 0, 0)")
+    assert [p.name for p in tmp_path.iterdir()] == ["proj.kicad_pro"]
+
+
+def test_persist_warns_when_no_project_file():
+    result = persist_net_color_to_project(None, "VCC_3V3", "rgb(255, 0, 0)")
+    assert result["persisted"] is False
+    assert "warning" in result
+
+
+def test_persist_warns_on_malformed_json_and_leaves_file_intact(tmp_path):
+    pro = tmp_path / "proj.kicad_pro"
+    pro.write_text("{not valid json")
+    result = persist_net_color_to_project(str(pro), "VCC_3V3", "rgb(255, 0, 0)")
+    assert result["persisted"] is False
+    assert str(pro) in result["warning"]
+    assert pro.read_text() == "{not valid json"  # never half-written
+
+
+# --- RoutingCommands.set_net_color wiring -------------------------------------
+
+
+def _board_with_net(tmp_path, net_name="VCC_3V3"):
+    pro = tmp_path / "p.kicad_pro"
+    pro.write_text(json.dumps(_project_with_colors()))
+
+    board = MagicMock()
+    board.GetFileName.return_value = str(tmp_path / "p.kicad_pcb")
+
+    nets_map = MagicMock()
+    nets_map.has_key.side_effect = lambda n: n == net_name
+    netinfo = MagicMock()
+    netinfo.NetsByName.return_value = nets_map
+    board.GetNetInfo.return_value = netinfo
+
+    return board, pro
+
+
+def test_set_net_color_success(tmp_path):
+    board, pro = _board_with_net(tmp_path)
+    result = RoutingCommands(board).set_net_color({"net": "VCC_3V3", "color": "#FF7D00"})
+    assert result["success"] is True
+    assert result["persisted"] is True
+    assert result["color"] == "rgb(255, 125, 0)"
+    reloaded = json.loads(pro.read_text())
+    assert reloaded["net_settings"]["net_colors"]["VCC_3V3"] == "rgb(255, 125, 0)"
+
+
+def test_set_net_color_clear(tmp_path):
+    board, pro = _board_with_net(tmp_path, net_name="GND")
+    result = RoutingCommands(board).set_net_color({"net": "GND", "clear": True})
+    assert result["success"] is True
+    assert result["persisted"] is True
+    assert result["color"] is None
+    reloaded = json.loads(pro.read_text())
+    assert "GND" not in reloaded["net_settings"]["net_colors"]
+
+
+def test_set_net_color_missing_net_returns_error():
+    result = RoutingCommands(MagicMock()).set_net_color({"color": "#FF7D00"})
+    assert result["success"] is False
+
+
+def test_set_net_color_missing_color_without_clear_returns_error(tmp_path):
+    board, _pro = _board_with_net(tmp_path)
+    result = RoutingCommands(board).set_net_color({"net": "VCC_3V3"})
+    assert result["success"] is False
+    assert "color" in result["errorDetails"]
+
+
+def test_set_net_color_invalid_hex_returns_error(tmp_path):
+    board, _pro = _board_with_net(tmp_path)
+    result = RoutingCommands(board).set_net_color({"net": "VCC_3V3", "color": "not-a-color"})
+    assert result["success"] is False
+    assert "Invalid color" in result["message"]
+
+
+def test_set_net_color_net_not_found_returns_error(tmp_path):
+    board, _pro = _board_with_net(tmp_path)
+    result = RoutingCommands(board).set_net_color({"net": "NOT_A_REAL_NET", "color": "#FF7D00"})
+    assert result["success"] is False
+    assert "NOT_A_REAL_NET" in result["errorDetails"]
+
+
+def test_set_net_color_no_board_loaded():
+    result = RoutingCommands(None).set_net_color({"net": "VCC_3V3", "color": "#FF7D00"})
+    assert result["success"] is False
+    assert "No board is loaded" in result["message"]


### PR DESCRIPTION
Closes #375.

## What

`set_net_color(net, color?, clear?)` - set or clear an individual net's
display color override (the PCB editor's "Net colors" panel). Cosmetic
only, doesn't touch routing or design rules.

## Why this shape

`net_settings.net_colors` lives only in `<project>.kicad_pro`, as a flat
`{net_name: "rgb(r, g, b)"}` map. There's no SWIG counterpart to keep in
sync - `NETINFO_ITEM` has no color getter/setter at all (checked the full
class in `pcbnew.py`) - so this is pure JSON persistence, following the
same read/modify/write-atomically shape `assign_net_to_class` already
uses for net-class membership.

- `color`: a `#RRGGBB` hex string, translated to KiCad's own
  `"rgb(r, g, b)"` format.
- `clear: true` removes the override entirely (rather than writing some
  empty/sentinel color), reverting the net to its automatic/class color
  - same behavior as the native "Clear color" action.
- Validates the net exists on the board before writing, same check
  `assign_net_to_class` uses.

### Why this hard-fails without a `.kicad_pro`, where `assign_net_to_class` warns

The two look inconsistent on purpose, and it is worth stating so the
asymmetry reads as designed.

`assign_net_to_class` mirrors its change into SWIG state as well as the
project file. By the time it discovers the project file is missing, the
in-memory board has already been updated - the operation genuinely half
succeeded, and failing outright would misreport what happened. A warning
is the accurate answer there.

`set_net_color` has no SWIG half. `NETINFO_ITEM` exposes no color
accessor, so `net_settings.net_colors` in the `.kicad_pro` *is* the
entire operation. With no project file there is nothing updated
anywhere, and returning a warning would tell the caller the color was
set when nothing was. So it fails.

## Where it's wired

- `src/tools/routing.ts` - Zod schema.
- `src/tools/registry.ts` - `routing` category entry, so `search_tools`
  can discover it.
- `python/commands/routing.py` - `apply_net_color_to_project_settings` /
  `persist_net_color_to_project` (pure functions, no SWIG) +
  `RoutingCommands.set_net_color`.
- `python/kicad_interface.py` - dispatch table entry.
- `python/schemas/tool_schemas.py` - matching entry for the Python-side
  schema registry (`create_netclass`/`assign_net_to_class` both have one
  there too).
- `README.md` / `docs/TOOL_INVENTORY.md` - counts and listings.

I added the `kicad_interface.py` dispatch entry deliberately carefully:
`tests/test_assign_net_to_class.py`'s docstring documents that tool
shipping registered in TS/the router but *missing* from the dispatch
table, silently returning `"Unknown command"` for every call. Wanted to
make sure this one didn't repeat that.

## Testing

- `tests/test_set_net_color.py` (28 tests, new): hex parsing, the pure
  JSON transform (add/overwrite/clear, null-safety on a fresh project's
  `net_colors: null`), atomic file round-trip, and
  `RoutingCommands.set_net_color` wiring against a mocked board.
- Full Python suite on the rebased branch: **2189 passed, 35 skipped, 1
  failed**. The failure is
  `test_ipc_open_board_path.py::test_returns_full_path_composed_from_project_and_filename`,
  which is Windows-only and pre-existing - it asserts a POSIX path
  against an `os.path.join` result. Confirmed it fails identically on a
  clean `aa53d52` worktree without this branch; it passes on CI's Linux
  runners.
- `tsc` builds clean, 73/73 vitest pass (including
  `registry-completeness` and `readme-counts`).
- Formatting/lint verified against the versions CI pins - Black 26.3.1,
  isort 8.0.1, flake8 7.3.0 over `python/` and `tests/`, plus prettier
  and eslint on the changed files.
- Manually verified against a real KiCad 10.0.5 install (Windows, SWIG
  backend) on a real multi-sheet board: opened the project, set a color
  on an uncolored net, overwrote an existing net's color, cleared
  another, hit a nonexistent net and an invalid hex - all behaved as
  expected, and the `.kicad_pro` round-trips correctly with unrelated
  content untouched.

Happy to adjust scope or naming if you'd rather this look different -
net-class-level color (`NETCLASS.SetPcbColor`, which *does* have a SWIG
binding) would be a reasonable follow-up but felt like a separate PR.
