### PR TITLE
fix: kipy 0.7.x / KiCad 10 IPC backend compatibility (IPC 后端兼容修复)

### DIFF
--- a/python/kicad_api/ipc_backend.py
+++ b/python/kicad_api/ipc_backend.py
@@ -145,8 +145,10 @@ class IPCBackend(KiCADBackend):
 
         def worker() -> None:
             try:
-                kicad = KiCad(socket_path=path) if path else KiCad()
-                kicad.ping()  # returns None on success, raises on failure
+                # kipy 0.7.1: KiCad() auto-dials the running KiCad; ping() can
+                # time out even when connected, so verify with get_version().
+                kicad = KiCad() if not path else KiCad(socket_path=path)
+                kicad.get_version()
                 result["kicad"] = kicad
             except Exception as e:  # noqa: BLE001 — surfaced to caller below
                 result["error"] = e
@@ -679,29 +681,33 @@ class IPCBoardAPI(BoardAPI):
                 lib_name = None
                 fp_name = footprint_path
 
-            # Get the footprint library table
-            fp_lib_table = pcbnew.GetGlobalFootprintLib()
+            # KiCad 10 removed GetGlobalFootprintLib; load by .pretty dir path.
+            def _pretty_dirs() -> list:
+                roots = [
+                    os.environ.get("KICAD_FOOTPRINTS_DIR", r"D:\kicad\share\kicad\footprints"),
+                    r"D:\kicad\custom-lib",
+                    os.path.expanduser(r"~\Documents\KiCad\10.0\libraries"),
+                ]
+                dirs: list = []
+                for root in roots:
+                    if lib_name:
+                        dirs.append(os.path.join(root, lib_name + ".pretty"))
+                    elif os.path.isdir(root):
+                        dirs.extend(
+                            os.path.join(root, d)
+                            for d in os.listdir(root)
+                            if d.endswith(".pretty")
+                        )
+                return dirs
 
-            if lib_name:
-                # Load from specific library
+            for pretty_dir in _pretty_dirs():
                 try:
-                    loaded_fp = pcbnew.FootprintLoad(fp_lib_table, lib_name, fp_name)
+                    loaded_fp = pcbnew.FootprintLoad(pretty_dir, fp_name)
                     if loaded_fp:
-                        logger.info(f"Loaded footprint '{fp_name}' from library '{lib_name}'")
+                        logger.info(f"Loaded footprint '{fp_name}' from {pretty_dir}")
                         return loaded_fp
                 except Exception as e:
-                    logger.warning(f"Could not load from {lib_name}: {e}")
-            else:
-                # Search all libraries for the footprint
-                lib_names = fp_lib_table.GetLogicalLibs()
-                for lib in lib_names:
-                    try:
-                        loaded_fp = pcbnew.FootprintLoad(fp_lib_table, lib, fp_name)
-                        if loaded_fp:
-                            logger.info(f"Found footprint '{fp_name}' in library '{lib}'")
-                            return loaded_fp
-                    except:
-                        continue
+                    logger.debug(f"FootprintLoad failed for {pretty_dir}: {e}")
 
             logger.warning(f"Footprint '{footprint_path}' not found in any library")
             return None
@@ -741,8 +747,19 @@ class IPCBoardAPI(BoardAPI):
 
             # Try to get the board path from kipy
             try:
-                docs = self._kicad.get_open_documents()
+                from kipy.proto.common.types import DocumentType
+                docs = self._kicad.get_open_documents(DocumentType.DOCTYPE_PCB)
                 for doc in docs:
+                    # kipy 0.7.x DocumentSpecifier: board_filename + project.path
+                    bf = getattr(doc, "board_filename", None)
+                    proj = getattr(doc, "project", None)
+                    proj_path = getattr(proj, "path", None) if proj else None
+                    if bf:
+                        if proj_path:
+                            board_path = os.path.join(str(proj_path), str(bf))
+                        else:
+                            board_path = str(bf)
+                        break
                     if hasattr(doc, "path") and str(doc.path).endswith(".kicad_pcb"):
                         board_path = str(doc.path)
                         break

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -5241,7 +5241,7 @@ print("ok")
         """IPC handler for place_component - places component with real-time UI update"""
         try:
             reference = params.get("reference", params.get("componentId", ""))
-            footprint = params.get("footprint", "")
+            footprint = params.get("footprint") or params.get("componentId", "")
             position = params.get("position", {})
             x = position.get("x", 0) if isinstance(position, dict) else params.get("x", 0)
             y = position.get("y", 0) if isinstance(position, dict) else params.get("y", 0)

--- a/src/command-timeout.ts
+++ b/src/command-timeout.ts
@@ -17,6 +17,14 @@ export const LONG_COMMAND_TIMEOUT_MS = 600_000;
  * parameter the caller passes.
  */
 export const LONG_RUNNING_COMMANDS = [
+  "open_project",
+  "create_project",
+  "open_board",
+  "reload_board",
+  "close_project",
+  "place_component",
+  "get_component_list",
+  "get_board_info",
   "run_drc",
   "export_gerber",
   "export_pdf",


### PR DESCRIPTION
## 修复内容 / What this fixes

让 KiCAD-MCP-Server 的 IPC 后端在 **kicad-python 0.7.x + KiCad 10** 环境下可用（实时 UI 同步）。
Fixes the IPC backend so it works with **kicad-python 0.7.x + KiCad 10** (real-time UI sync).

### 问题 / Problem
在 KiCad 10.0.5 + kicad-python 0.7.1 下，IPC 后端连接失败并静默回退到 SWIG（`_realtime: false`），
因为服务器代码针对的是旧版 kipy API。另外 KiCad 10 移除了 `pcbnew.GetGlobalFootprintLib`。
Under KiCad 10.0.5 + kicad-python 0.7.1, the IPC backend fails to connect and silently
falls back to SWIG (`_realtime: false`), because the server code targets an older kipy API.
Also, KiCad 10 removed `pcbnew.GetGlobalFootprintLib`.

### 改动 / Changes
1. **ipc_backend.py – connect()**: `KiCad()` 自动拨号 + 用 `get_version()` 验证（新 kipy 的 `ping()` 会超时）
   `KiCad()` auto-dial + verify via `get_version()` (new kipy's `ping()` times out)
2. **ipc_backend.py – board path**: `get_open_documents(DocumentType.DOCTYPE_PCB)`（新 kipy 需要参数），
   并用 `board_filename` + `project.path` 组装板文件路径（`DocumentSpecifier` 已无 `path` 字段）
   `get_open_documents(DocumentType.DOCTYPE_PCB)` (new kipy requires the arg) and assemble the
   board path from `board_filename` + `project.path` (no more `path` field on DocumentSpecifier)
3. **ipc_backend.py – footprint loading**: 改为按 `.pretty` 目录 `pcbnew.FootprintLoad`
   （KiCad 10 移除了 `GetGlobalFootprintLib`）
   load footprints by `.pretty` dir path (KiCad 10 removed `GetGlobalFootprintLib`)
4. **kicad_interface.py – _ipc_place_component**: 当 `footprint` 参数缺失时回退到 `componentId`
   fall back to `componentId` when the `footprint` param is missing
5. **command-timeout.ts**: 将 `open_project` / `create_project` / `open_board` / `place_component`
   等加入长时命令列表（SWIG 初始化可能超过 30s）
   treat `open_project` / `create_project` / `open_board` / `place_component` as long-running
   (SWIG init can exceed 30s)

### 测试 / Testing
- 环境: Windows 11 · KiCad 10.0.5（便携版）· kicad-python 0.7.1 · Node 24 / TS 2.6.0
- Environment: Windows 11 · KiCad 10.0.5 (portable) · kicad-python 0.7.1 · Node 24 / TS 2.6.0
- ✅ `open_project` → `_backend: "ipc"`, `_realtime: true`（实时会话）
- ✅ IPC `place_component` → 成功，KiCad GUI 实时显示（含自定义库封装）
- ✅ `npm run build` 通过；冒烟测试通过

### 相关 / Related
- 会话固定机制（session pinning, #223）在 KiCad 10 下正常：板子需在 GUI 中打开才能 pin IPC
- session pinning (#223) works under KiCad 10: the board must be open in the GUI to pin IPC

---
中文说明：本 PR 修复 KiCad 10 + kicad-python 0.7.x 环境下 IPC 实时控制不可用的问题，共 5 处改动，
已在 Windows 上实测（实时放件成功）。如有任何格式或命名规范问题，请告知，我会调整。谢谢！