### PR TITLE
fix(schematic): inherit the library symbol's Footprint on placement (#300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,16 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **Placed schematic instances inherit the library symbol's Footprint**
+  (#300, implementation by @stefangordon in #278). `create_component_instance`
+  wrote the caller's `footprint` argument verbatim, defaulted to `""`, so a
+  symbol with a perfectly good default footprint placed with an empty one and
+  the value survived only in the `lib_symbols` cache. Datasheet and
+  Description already inherited two lines above; Footprint now follows the
+  same pattern, an explicit argument still wins, and the value flows through
+  the escape-aware extractor (#348) and writer (#324) so a footprint
+  containing a quote inherits intact.
+
 - **`add_symbol_property` corrupted `.kicad_sym` libraries**. Every call dropped
   one closing paren, so the library stopped loading in eeschema. Eight defects,
   all in the same write path:

--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -1049,6 +1049,20 @@ class DynamicSymbolLoader:
             or ""
         )
 
+        # Footprint inherits from the library symbol the same way (#300): the
+        # library value is the default KiCad itself applies on placement, and
+        # most callers pass nothing. An explicit argument still wins. The
+        # extractor is the escape-aware one (#348), so a footprint containing
+        # a quote inherits intact and the escaping writer below (#324) emits
+        # it correctly.
+        if not footprint:
+            footprint = (
+                self._extract_lib_property_value(
+                    schematic_path, library_name, symbol_name, "Footprint"
+                )
+                or ""
+            )
+
         properties_str = "\n".join(
             [
                 _property("Reference", reference, ref_x, ref_y, ref_a, ref_eff, False),

--- a/tests/test_symbol_footprint_inherit.py
+++ b/tests/test_symbol_footprint_inherit.py
@@ -1,0 +1,83 @@
+"""Placed schematic instances inherit the library symbol's Footprint.
+
+Regression guard: create_component_instance previously wrote the Footprint
+straight from its (empty-default) argument and never consulted the library
+symbol, so a footprint set via create_symbol never propagated to placements —
+only a later edit_schematic_component set it. KiCad inherits the field on
+placement; the loader now does too.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.unit
+
+from commands.dynamic_symbol_loader import DynamicSymbolLoader  # noqa: E402
+
+# Minimal schematic whose lib_symbols entry carries a Footprint value.
+_SCH = """(kicad_sch (version 20231120) (generator test)
+  (lib_symbols
+    (symbol "MyLib:ESP32" (in_bom yes) (on_board yes)
+      (property "Reference" "U" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "ESP32" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "RF_Module:ESP32-C3-MINI-1" (at 0 -2.54 0) \
+(effects (font (size 1.27 1.27)) (hide yes)))
+      (property "Datasheet" "~" (at 0 -5 0) (effects (font (size 1.27 1.27)) (hide yes)))
+    )
+  )
+)
+"""
+
+
+def _placed_footprint(schematic_text: str) -> str:
+    """Return the Footprint value of the placed instance (outside lib_symbols)."""
+    instance = schematic_text[schematic_text.rfind("(symbol (lib_id") :]
+    m = re.search(r'\(property "Footprint" "([^"]*)"', instance)
+    return m.group(1) if m else ""
+
+
+@pytest.fixture()
+def schematic(tmp_path: Path) -> Path:
+    p = tmp_path / "t.kicad_sch"
+    p.write_text(_SCH, encoding="utf-8")
+    return p
+
+
+def test_placement_inherits_library_footprint(schematic: Path) -> None:
+    """No footprint passed -> inherit the library symbol's Footprint."""
+    loader = DynamicSymbolLoader(project_path=schematic.parent)
+    loader.create_component_instance(schematic, "MyLib", "ESP32", reference="U1", x=100, y=100)
+    assert _placed_footprint(schematic.read_text(encoding="utf-8")) == "RF_Module:ESP32-C3-MINI-1"
+
+
+def test_explicit_footprint_overrides_library(schematic: Path) -> None:
+    """An explicit footprint argument still wins over the library value."""
+    loader = DynamicSymbolLoader(project_path=schematic.parent)
+    loader.create_component_instance(
+        schematic, "MyLib", "ESP32", reference="U1", footprint="MyFP:Custom", x=100, y=100
+    )
+    assert _placed_footprint(schematic.read_text(encoding="utf-8")) == "MyFP:Custom"
+
+
+def test_inherited_footprint_with_quote_survives_escaping(tmp_path: Path) -> None:
+    """A library Footprint containing an escaped quote inherits intact (#300 + #336).
+
+    The extractor must be the escape-aware one and the writer must re-escape:
+    naive extraction would truncate at the inner quote, and a raw write would
+    split the value into several s-expression atoms.
+    """
+    sch = _SCH.replace('"RF_Module:ESP32-C3-MINI-1"', '"My \\"quoted\\" Lib:FP-1"')
+    p = tmp_path / "t.kicad_sch"
+    p.write_text(sch, encoding="utf-8")
+    loader = DynamicSymbolLoader(project_path=p.parent)
+    loader.create_component_instance(p, "MyLib", "ESP32", reference="U1", x=100, y=100)
+    text = p.read_text(encoding="utf-8")
+    instance = text[text.rfind("(symbol (lib_id") :]
+    m = re.search(r'\(property "Footprint" "((?:[^"\\]|\\.)*)"', instance)
+    assert m is not None
+    assert m.group(1) == 'My \\"quoted\\" Lib:FP-1'


### PR DESCRIPTION
Takes over #278 (Stefan Gordon), which has been silent since 07-01 with three pings — as committed to publicly on #300 when the grace period was set.

## What
`create_component_instance` defaulted `footprint` to `""` and wrote it verbatim, never consulting the library symbol. Datasheet and Description — two lines above — already inherit from the library entry. A symbol with a perfectly good default footprint therefore placed with an empty one, and the library value survived only in the `lib_symbols` cache. Exactly as #300 describes.

## How
The one missing symmetry: when no footprint is passed, read the library symbol's Footprint through `_extract_lib_property_value` beside the existing ds/desc block. An explicit argument still wins.

Two deliberate departures from #278 as filed:
- The original predates #348 and shipped its own quoted-value extractor using the naive `"([^"]*)"` pattern — cherry-picking that would regress the escaping work. Only the 4-line hook is taken; extraction goes through the current escape-aware helper.
- Landed after #354 so the inherited value also flows through the escaping writer. A new test pins the full interaction: a library Footprint containing `\"` inherits intact instead of truncating (naive read) or splitting into multiple atoms (raw write) — the hazard flagged when #300 was triaged.

Regression tests are #278's, kept as written (inherit when omitted; explicit argument wins), with authorship credited via Co-authored-by.

Closes #300. Closes #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)