### PR TITLE
fix(bridge): correlate Python responses to requests by ID (#373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,27 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **Python bridge responses are now correlated to their requests by ID**
+  (#373, root cause diagnosed exactly by the reporter; implementation adapted
+  from @kerby2000's #371). The Node-Python protocol was a single-slot,
+  ID-free pipeline: when a request timed out and the next one dispatched, the
+  late response resolved the _wrong_ handler -- command B silently received
+  command A's result, and every response after that was off by one until the
+  next timeout. The reported "no pending request" drops were the visible
+  second-order symptom. Requests now carry a bridge-local `requestId` that
+  Python echoes back as `_requestId`; stale responses are discarded with a
+  log line instead of being delivered to whoever is pending. Timeout
+  callbacks only abandon their own request, and partial frames left by a
+  timed-out command complete and are discarded by ID rather than corrupting
+  the next response.
+
+- **Each server process writes its own log file** (#373, second finding).
+  Multiple concurrent servers shared one `kicad_interface.log` through
+  rotating handlers; on Windows the rotation collides with the sibling's
+  open handle (`WinError 32`). Logs are now per-PID
+  (`kicad_interface-<pid>.log`), with a best-effort sweep of logs older than
+  seven days so the per-PID naming cannot accumulate without bound.
+
 - **`add_symbol_property` corrupted `.kicad_sym` libraries**. Every call dropped
   one closing paren, so the library stopped loading in eeschema. Eight defects,
   all in the same write path:

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -99,7 +99,21 @@ _LOG_LEVEL = _parse_log_level()
 try:
     log_dir = Path.home() / ".kicad-mcp" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
-    log_file = str(log_dir / "kicad_interface.log")
+    # One log file per process (#373): multiple concurrent servers rotating
+    # the same file collide on Windows (WinError 32 -- the file is locked by
+    # whichever sibling holds it open), killing the rotation and the logging.
+    log_file = str(log_dir / f"kicad_interface-{os.getpid()}.log")
+    # Best-effort sweep of logs from dead processes so per-PID naming cannot
+    # accumulate without bound (the concern that motivated #181's rotation).
+    try:
+        import time as _time
+
+        _cutoff = _time.time() - 7 * 24 * 3600
+        for _old_log in log_dir.glob("kicad_interface-*.log*"):
+            if _old_log.stat().st_mtime < _cutoff:
+                _old_log.unlink()
+    except OSError:
+        pass
     max_log_bytes = _parse_positive_int_env("KICAD_MCP_LOG_MAX_BYTES", 10 * 1024 * 1024)
     backup_count = _parse_positive_int_env("KICAD_MCP_LOG_BACKUP_COUNT", 3)
     if max_log_bytes:
@@ -6285,6 +6299,20 @@ print("ok")
             }
 
 
+def _attach_internal_request_id(response: Any, request_id: Any) -> Any:
+    """Echo the TypeScript bridge's requestId without mutating command results.
+
+    The Node side correlates responses to requests by this ID (#373): without
+    it, a response arriving after its request timed out was delivered to
+    whichever request was pending next, silently resolving command B with
+    command A's result and desyncing every response after it. Uncorrelated
+    responses (no ID, e.g. the ready marker) pass through untouched.
+    """
+    if request_id is None or not isinstance(response, dict):
+        return response
+    return {**response, "_requestId": request_id}
+
+
 def _write_response(response_fd: Any, response: Any) -> None:
     """Write a JSON response to the original stdout fd.
 
@@ -6320,6 +6348,7 @@ def main() -> None:
             try:
                 # Parse command
                 logger.debug(f"Received input: {line.strip()}")
+                internal_request_id = None
                 command_data = json.loads(line)
 
                 # Check if this is JSON-RPC 2.0 format
@@ -6449,6 +6478,7 @@ def main() -> None:
                     logger.info("Detected custom format message")
                     command = command_data.get("command")
                     params = command_data.get("params", {})
+                    internal_request_id = command_data.get("requestId")
 
                     if not command:
                         logger.error("Missing command field")
@@ -6462,6 +6492,7 @@ def main() -> None:
                         response = interface.handle_command(command, params)
 
                 # Send response via the clean fd (immune to pcbnew stdout noise)
+                response = _attach_internal_request_id(response, internal_request_id)
                 logger.debug(f"Sending response: {response}")
                 _write_response(_response_fd, response)
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -229,13 +229,21 @@ export class KiCADMcpServer {
   private kicadScriptPath: string;
   private stdioTransport!: StdioServerTransport;
   private requestQueue: Array<{
-    request: any;
+    request: {
+      command: string;
+      params: any;
+      timeout: number;
+      requestId: number;
+    };
     resolve: Function;
     reject: Function;
   }> = [];
   private processingRequest = false;
   private responseBuffer: string = "";
+  /** Monotonic bridge-local ID; Python echoes it back as `_requestId` (#373). */
+  private nextInternalRequestId = 1;
   private currentRequestHandler: {
+    requestId: number;
     resolve: Function;
     reject: Function;
     timeoutHandle: NodeJS.Timeout;
@@ -670,28 +678,30 @@ export class KiCADMcpServer {
         return;
       }
 
-      const requestStr = JSON.stringify({ command: "_warmup", params: {} });
-      this.responseBuffer = "";
+      const requestId = this.allocateInternalRequestId();
+      const requestStr = JSON.stringify({ command: "_warmup", params: {}, requestId });
 
       const timeoutHandle = setTimeout(() => {
+        // Only abandon our own slot: if the warm-up response already arrived,
+        // the handler belongs to a later request (#373).
+        if (this.currentRequestHandler?.requestId !== requestId) return;
         logger.warn(
           `Warm-up timed out after ${timeoutMs / 1000} s — ` +
             "continuing without full initialisation",
         );
-        this.responseBuffer = "";
         this.processingRequest = false;
         this.currentRequestHandler = null;
         resolve();
+        setTimeout(() => this.processNextRequest(), 0);
       }, timeoutMs);
 
       // Use the existing request infrastructure to avoid race conditions
       // with the persistent stdout handler.
       this.processingRequest = true;
       this.currentRequestHandler = {
+        requestId,
         resolve: (result: any) => {
           clearTimeout(timeoutHandle);
-          this.processingRequest = false;
-          this.currentRequestHandler = null;
           if (result?.success) {
             logger.info(`Warm-up succeeded: pcbnew ${result.version} (${result.elapsed_s}s)`);
           } else {
@@ -701,8 +711,6 @@ export class KiCADMcpServer {
         },
         reject: (err: Error) => {
           clearTimeout(timeoutHandle);
-          this.processingRequest = false;
-          this.currentRequestHandler = null;
           logger.warn(`Warm-up failed: ${err.message} — continuing`);
           resolve(); // don't fail the whole server
         },
@@ -737,7 +745,12 @@ export class KiCADMcpServer {
 
       // Add request to queue with timeout info
       this.requestQueue.push({
-        request: { command, params, timeout: commandTimeout },
+        request: {
+          command,
+          params,
+          timeout: commandTimeout,
+          requestId: this.allocateInternalRequestId(),
+        },
         resolve,
         reject,
       });
@@ -763,111 +776,76 @@ export class KiCADMcpServer {
   }
 
   /**
-   * Try to parse a complete JSON response from the buffer.
+   * Try to parse complete JSON response frames from the buffer.
    *
    * Responses from the Python side are single-line JSON terminated by '\n'
-   * (written via _write_response).  The buffer may also contain non-JSON
+   * (written via _write_response). The buffer may also contain non-JSON
    * preamble lines (e.g. C-level warnings from pcbnew that leaked to the
    * response fd before the redirect took effect).
    *
-   * Strategy:
-   *  1. Fast path: JSON.parse(buffer) — works for clean, complete responses
-   *     (JSON.parse tolerates trailing whitespace/newlines).
-   *  2. If that fails and the buffer has no '\n' yet, the response line is
-   *     still arriving in chunks — keep collecting.
-   *  3. If the buffer has '\n', split into lines and search from the END for
-   *     a parseable JSON line.  This avoids prematurely resolving with a
-   *     truncated JSON object when a large response is still chunking in.
+   * Consume only newline-delimited frames. Each bridge request carries a
+   * process-local request ID which Python echoes back as `_requestId`; a
+   * response whose ID does not match the pending request is discarded
+   * instead of being delivered to whichever request happens to be pending
+   * (#373). Without this, one timeout desynced the pipeline permanently:
+   * request A times out, request B dispatches, A's late response resolves
+   * B's handler, and every response after that is off by one.
    */
   private tryParseResponse(): void {
-    if (!this.currentRequestHandler) {
-      // No pending request, clear buffer if it has data (shouldn't happen)
-      if (this.responseBuffer.trim()) {
-        logger.warn(
-          `Received data with no pending request: ${this.responseBuffer.substring(0, 100)}...`,
-        );
-        this.responseBuffer = "";
+    while (true) {
+      const newlineIndex = this.responseBuffer.indexOf("\n");
+      if (newlineIndex < 0) return; // frame still arriving — keep collecting
+
+      const line = this.responseBuffer.slice(0, newlineIndex).trim();
+      this.responseBuffer = this.responseBuffer.slice(newlineIndex + 1);
+      if (!line) continue;
+
+      let result: any;
+      try {
+        result = JSON.parse(line);
+      } catch {
+        logger.warn(`Stripped non-JSON preamble from Python response: ${line.substring(0, 200)}`);
+        continue;
       }
+
+      const responseRequestId =
+        result && typeof result === "object" ? result._requestId : undefined;
+      const handler = this.currentRequestHandler;
+      if (!handler) {
+        logger.warn(
+          `Discarding Python response ${String(responseRequestId)} with no pending request`,
+        );
+        continue;
+      }
+
+      if (responseRequestId !== handler.requestId) {
+        // A late response from a request that already timed out. Discarding
+        // it (rather than resolving the current handler with it) is the fix:
+        // the pending request's own response is still on its way.
+        logger.warn(
+          `Discarding stale Python response ${String(responseRequestId)}; ` +
+            `waiting for ${handler.requestId}`,
+        );
+        continue;
+      }
+
+      delete result._requestId;
+      logger.debug(
+        `Completed KiCAD command ${handler.requestId} with result: ` +
+          `${result.success ? "success" : "failure"}`,
+      );
+
+      clearTimeout(handler.timeoutHandle);
+      this.currentRequestHandler = null;
+      this.processingRequest = false;
+      handler.resolve(result);
+      setTimeout(() => this.processNextRequest(), 0);
       return;
     }
+  }
 
-    let result: any;
-
-    // Fast path: try to parse the response as JSON.  Handles the common
-    // case of a clean, complete JSON response (possibly with trailing \n).
-    try {
-      result = JSON.parse(this.responseBuffer);
-    } catch {
-      // Direct parse failed.  Either the response is still arriving in
-      // chunks, or the buffer has non-JSON preamble from pcbnew.
-      //
-      // The Python side writes each response as a single line of JSON
-      // terminated by \n.  We use the newline as the completion signal:
-      // if there is no \n in the buffer yet, the JSON line is still
-      // being assembled from chunks — keep collecting.
-      if (!this.responseBuffer.includes("\n")) {
-        return;
-      }
-
-      // Buffer contains newline(s).  Split into lines and look for a
-      // complete JSON object, searching from the END so that preamble
-      // lines (which may themselves contain '{') are skipped.
-      const lines = this.responseBuffer.split("\n");
-      let jsonLineIndex = -1;
-
-      for (let i = lines.length - 1; i >= 0; i--) {
-        const line = lines[i].trim();
-        if (line.length === 0) continue;
-        if (!line.startsWith("{")) continue;
-
-        try {
-          result = JSON.parse(line);
-          jsonLineIndex = i;
-          break;
-        } catch {
-          // Looks like JSON but doesn't parse — could be an incomplete
-          // final line still being chunked.  Keep collecting.
-          continue;
-        }
-      }
-
-      if (jsonLineIndex < 0) {
-        // No parseable JSON line found yet.  Either only preamble has
-        // arrived, or the JSON line is split across the last \n boundary
-        // and is still incomplete.  Keep collecting.
-        return;
-      }
-
-      // Log any preceding non-JSON lines as preamble
-      const preambleLines = lines.slice(0, jsonLineIndex).filter((l) => l.trim().length > 0);
-      if (preambleLines.length > 0) {
-        logger.warn(
-          `Stripped non-JSON preamble from Python response: ${preambleLines.join(" | ")}`,
-        );
-      }
-    }
-
-    // If we get here, we have a valid JSON response
-    logger.debug(`Completed KiCAD command with result: ${result.success ? "success" : "failure"}`);
-
-    // Clear the timeout since we got a response
-    if (this.currentRequestHandler.timeoutHandle) {
-      clearTimeout(this.currentRequestHandler.timeoutHandle);
-    }
-
-    // Get the handler before clearing
-    const handler = this.currentRequestHandler;
-
-    // Clear state
-    this.responseBuffer = "";
-    this.currentRequestHandler = null;
-    this.processingRequest = false;
-
-    // Resolve the promise with the result
-    handler.resolve(result);
-
-    // Process next request if any
-    setTimeout(() => this.processNextRequest(), 0);
+  private allocateInternalRequestId(): number {
+    return this.nextInternalRequestId++;
   }
 
   /**
@@ -891,17 +869,18 @@ export class KiCADMcpServer {
       // Format the command and parameters as JSON
       const requestStr = JSON.stringify(request);
 
-      // Clear response buffer for new request
-      this.responseBuffer = "";
-
       // Set a timeout (use command-specific timeout or default)
       const timeoutDuration = request.timeout || 30000;
       const timeoutHandle = setTimeout(() => {
+        // The response may have arrived between the timer firing and this
+        // callback running; only abandon our own request (#373).
+        if (this.currentRequestHandler?.requestId !== request.requestId) return;
         logger.error(`Command timeout after ${timeoutDuration / 1000}s: ${request.command}`);
         logger.error(`Buffer contents: ${this.responseBuffer.substring(0, 200)}...`);
 
-        // Clear state
-        this.responseBuffer = "";
+        // Clear state. The buffer is left alone: a partial frame from the
+        // timed-out command completes on the next data chunk and is then
+        // discarded by ID, not delivered to the next request.
         this.currentRequestHandler = null;
         this.processingRequest = false;
 
@@ -913,7 +892,7 @@ export class KiCADMcpServer {
       }, timeoutDuration);
 
       // Store the current request handler
-      this.currentRequestHandler = { resolve, reject, timeoutHandle };
+      this.currentRequestHandler = { requestId: request.requestId, resolve, reject, timeoutHandle };
 
       // Write the request to the Python process
       logger.debug(`Sending request: ${requestStr}`);

--- a/tests-ts/request-correlation.test.ts
+++ b/tests-ts/request-correlation.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import { KiCADMcpServer } from "../src/server.js";
+
+const pythonBridge = fileURLToPath(new URL("../python/kicad_interface.py", import.meta.url));
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Python bridge response correlation", () => {
+  it("discards a late response and resolves only the matching request", () => {
+    vi.useFakeTimers();
+    const server = new KiCADMcpServer(pythonBridge, "error") as any;
+    const resolve = vi.fn();
+    const timeoutHandle = setTimeout(() => undefined, 30_000);
+
+    server.processingRequest = true;
+    server.currentRequestHandler = {
+      requestId: 2,
+      resolve,
+      reject: vi.fn(),
+      timeoutHandle,
+    };
+    server.responseBuffer =
+      `${JSON.stringify({ success: true, value: "stale", _requestId: 1 })}\n` +
+      `${JSON.stringify({ success: true, value: "current", _requestId: 2 })}\n`;
+
+    server.tryParseResponse();
+
+    expect(resolve).toHaveBeenCalledOnce();
+    expect(resolve).toHaveBeenCalledWith({ success: true, value: "current" });
+    expect(server.currentRequestHandler).toBeNull();
+    expect(server.processingRequest).toBe(false);
+    expect(server.responseBuffer).toBe("");
+  });
+
+  it("waits for a complete newline-delimited response", () => {
+    vi.useFakeTimers();
+    const server = new KiCADMcpServer(pythonBridge, "error") as any;
+    const resolve = vi.fn();
+
+    server.processingRequest = true;
+    server.currentRequestHandler = {
+      requestId: 7,
+      resolve,
+      reject: vi.fn(),
+      timeoutHandle: setTimeout(() => undefined, 30_000),
+    };
+
+    server.handlePythonResponse(Buffer.from('{"success":true,"_request'));
+    expect(resolve).not.toHaveBeenCalled();
+
+    server.handlePythonResponse(Buffer.from('Id":7}\n'));
+    expect(resolve).toHaveBeenCalledWith({ success: true });
+  });
+});

--- a/tests/test_internal_request_correlation.py
+++ b/tests/test_internal_request_correlation.py
@@ -1,0 +1,18 @@
+"""Tests for request correlation on the TypeScript/Python bridge."""
+
+from kicad_interface import _attach_internal_request_id
+
+
+def test_attach_internal_request_id_returns_a_decorated_copy():
+    response = {"success": True, "value": "ok"}
+
+    decorated = _attach_internal_request_id(response, 42)
+
+    assert decorated == {"success": True, "value": "ok", "_requestId": 42}
+    assert response == {"success": True, "value": "ok"}
+
+
+def test_attach_internal_request_id_leaves_uncorrelated_responses_unchanged():
+    response = {"type": "ready"}
+
+    assert _attach_internal_request_id(response, None) is response


### PR DESCRIPTION
Fixes #373 by extracting the request-correlation slice from #371 (@kerby2000), adapted onto the current SDK1 server, with credit via Co-authored-by.

## The bug — worse than reported
The reporter's diagnosis was exactly right, and the mechanism is nastier than the visible symptom. The bridge was a single-slot, ID-free protocol:

1. Request A hits its timeout; the handler slot is cleared and A rejects.
2. Request B dispatches; the slot now holds B's handler.
3. Python finishes A and writes A's response — which resolves **B's** handler with **A's result**. No ID existed to catch it.
4. B's own response then arrives with the slot empty: `Received data with no pending request` — the warning in the report.

One timeout desynced every subsequent response until another timeout happened to resynchronize. The reported symptoms (`get_backend_state`'s payload visible under the warning; `get_board_2d_view` returning in 3.6s yet timing out) are steps 3 and 4 exactly.

## The fix
- Node sends `requestId` with every bridge request (warmup included); Python echoes it back as `_requestId` via one chokepoint in the legacy branch of `main()`.
- `tryParseResponse` consumes newline-delimited frames and discards any response whose ID doesn't match the pending request, with a log line naming both IDs.
- Timeout callbacks abandon only their own request (guarded by ID), and the response buffer is never cleared on dispatch/timeout — a partial frame from a timed-out command completes and is discarded by ID instead of corrupting the next response.
- Serial dispatch is kept: the ID is for identification, not concurrency.

## Second finding from the same report
Six concurrent server pairs rotating one shared `kicad_interface.log` collide on Windows (`WinError 32`), killing rotation. Logs are now per-PID (`kicad_interface-<pid>.log`) with a best-effort 7-day sweep so per-PID naming can't accumulate unbounded (the concern that motivated #181's rotation).

## Why not merge #371 itself
#371 carries this fix inside a 74-file MCP SDK 2.0 migration that is CONFLICTING and a separate decision (tracking issue to follow). The correlation slice stands alone; kerby2000's tests are kept as written (`tests-ts/request-correlation.test.ts`, `tests/test_internal_request_correlation.py`).

Also effectively resolves the concern behind #275 (stefangordon): the danger of overlapping operations was precisely this cross-talk; with correlation, overlap is queued and identified rather than mis-delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)