### PR TITLE
fix(autoroute): stage artifacts in a temp dir, guard stale SES, decode kill codes (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,19 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`autoroute` no longer litters the project directory or trusts stale
+  output** (#249, scope defined by @Dewieinns' traces). Every run staged its
+  `.dsn`/`.ses`/`_best.ses` in the board directory with no cleanup on any of
+  its twelve failure exits -- and a leftover `.ses` from an earlier run could
+  satisfy the output check and be imported as if freshly routed. Artifacts now
+  stage in a per-run temporary directory removed on every exit
+  (`keepArtifacts: true` copies them next to the board for debugging), each
+  attempt deletes its predecessor's SES before launching so an attempt that
+  exits cleanly without writing cannot re-score the previous file, a killed
+  subprocess is reported as "terminated externally" instead of raw
+  `exit code 4294967295`, and Freerouting's own shared DEBUG log is truncated
+  past 5 MB after each run.
+
 - **`add_symbol_property` corrupted `.kicad_sym` libraries**. Every call dropped
   one closing paren, so the library stopped loading in eeschema. Eight defects,
   all in the same write path:

--- a/python/commands/freerouting.py
+++ b/python/commands/freerouting.py
@@ -178,6 +178,57 @@ def _build_freerouting_cmd(
 _SES_NET_RE = re.compile(r"\(net\s+(\S+)\s*\n\s*\(wire")
 
 
+def _describe_exit(code: Any) -> str:
+    """Human-readable suffix for a Freerouting exit code (#249).
+
+    A user cancelling the run (or an OOM killer, or a console close) surfaces
+    as a raw process exit code -- on Windows a force-killed JVM reports
+    4294967295 (0xFFFFFFFF), which reads like a Java failure rather than
+    "someone stopped it". Decode the known shapes so the error message says
+    what actually happened; return "" when the code carries no extra meaning.
+    """
+    if not isinstance(code, int):
+        return ""
+    # Windows NTSTATUS-shaped codes and POSIX negative-signal codes cannot
+    # collide (POSIX exit codes are 0..255 or small negatives), so decode
+    # both unconditionally rather than gating on os.name -- that also lets
+    # the Linux CI exercise the Windows decodings.
+    known_nt = {
+        0xFFFFFFFF: "process was terminated externally (force-kill)",
+        0xC000013A: "process was interrupted (Ctrl+C or console closed)",
+        0xC0000005: "JVM crashed with an access violation",
+    }
+    desc = known_nt.get(code & 0xFFFFFFFF)
+    if desc:
+        return f" -- {desc}"
+    if code < 0:
+        import signal
+
+        try:
+            name = signal.Signals(-code).name
+        except ValueError:
+            name = str(-code)
+        return f" -- process was killed by signal {name}"
+    return ""
+
+
+def _trim_shared_freerouting_log(max_bytes: int = 5 * 1024 * 1024) -> None:
+    """Best-effort cap on Freerouting's own shared DEBUG log (#249).
+
+    Freerouting 2.x writes an unbounded DEBUG log to a fixed path shared by
+    every run (observed growing to 9+ MB in three runs). We cannot pass it a
+    log level across all bundled JAR versions, so truncate the file when it
+    exceeds the cap after a run. Failures (file locked, absent) are ignored.
+    """
+    try:
+        log_path = Path(tempfile.gettempdir()) / "freerouting" / "freerouting.log"
+        if log_path.is_file() and log_path.stat().st_size > max_bytes:
+            with open(log_path, "w", encoding="utf-8"):
+                pass
+    except OSError:
+        pass
+
+
 def _score_ses(ses_text: str, target_nets: Iterable[str]) -> Dict[str, Any]:
     """Score a Specctra SES file by routing completeness.
 
@@ -433,12 +484,78 @@ class FreeroutingCommands:
 
         use_docker = exec_mode["use_docker"]
 
-        # Set up file paths
+        # Set up file paths. Artifacts are staged in a fresh per-run temp
+        # directory instead of the user's project directory (#249): every
+        # failure exit used to leave .dsn/.ses/_best.ses litter next to the
+        # board, and a stale .ses from an earlier run could satisfy the
+        # exists-check below and be imported as if it were this run's output.
+        # A fresh directory makes cross-run staleness structurally impossible;
+        # keepArtifacts=true copies the files back out for debugging.
+        keep_artifacts = bool(params.get("keepArtifacts", False))
         board_dir = os.path.dirname(board_path)
         board_stem = Path(board_path).stem
-        dsn_path = os.path.join(board_dir, f"{board_stem}.dsn")
-        ses_path = os.path.join(board_dir, f"{board_stem}.ses")
-        best_ses_path = os.path.join(board_dir, f"{board_stem}_best.ses")
+        staging_dir = tempfile.mkdtemp(prefix="kicad-mcp-autoroute-")
+        dsn_path = os.path.join(staging_dir, f"{board_stem}.dsn")
+        ses_path = os.path.join(staging_dir, f"{board_stem}.ses")
+        best_ses_path = os.path.join(staging_dir, f"{board_stem}_best.ses")
+        kept_paths: Dict[str, str] = {}
+
+        try:
+            return self._autoroute_staged(
+                params,
+                board_path=board_path,
+                board_dir=board_dir,
+                board_stem=board_stem,
+                dsn_path=dsn_path,
+                ses_path=ses_path,
+                best_ses_path=best_ses_path,
+                keep_artifacts=keep_artifacts,
+                kept_paths=kept_paths,
+                jar_path=jar_path,
+                timeout=timeout,
+                passes=passes,
+                attempts=attempts,
+                target_nets=target_nets,
+                pass_schedule=pass_schedule,
+                use_docker=use_docker,
+            )
+        finally:
+            # Runs on every exit -- success, failure return, or exception --
+            # so no artefact can outlive the run unless explicitly kept.
+            if keep_artifacts:
+                for src in (dsn_path, ses_path, best_ses_path):
+                    try:
+                        if os.path.isfile(src):
+                            dest = os.path.join(board_dir, os.path.basename(src))
+                            shutil.copy2(src, dest)
+                            kept_paths[os.path.basename(src)] = dest
+                    except OSError as copy_err:
+                        logger.warning(f"Could not keep artifact {src}: {copy_err}")
+            shutil.rmtree(staging_dir, ignore_errors=True)
+            _trim_shared_freerouting_log()
+
+    def _autoroute_staged(
+        self,
+        params: Dict[str, Any],
+        *,
+        board_path: str,
+        board_dir: str,
+        board_stem: str,
+        dsn_path: str,
+        ses_path: str,
+        best_ses_path: str,
+        keep_artifacts: bool,
+        kept_paths: Dict[str, str],
+        jar_path: str,
+        timeout: Any,
+        passes: Any,
+        attempts: int,
+        target_nets: List[Any],
+        pass_schedule: List[Any],
+        use_docker: bool,
+    ) -> Dict[str, Any]:
+        """Body of autoroute, running against a staged artifact directory."""
+        import pcbnew
 
         # Apply the project's net classes so the DSN carries per-class
         # width/clearance rules instead of routing everything at Default (#302)
@@ -507,6 +624,14 @@ class FreeroutingCommands:
                 f"(mp={attempt_passes}, mode={mode_label})"
             )
 
+            # Remove the previous attempt's SES before launching: an attempt
+            # that exits 0 without writing output must read as "no SES", not
+            # silently re-score its predecessor's file (#249).
+            try:
+                os.remove(ses_path)
+            except FileNotFoundError:
+                pass
+
             attempt_start = time.time()
             try:
                 proc = subprocess.run(
@@ -514,7 +639,7 @@ class FreeroutingCommands:
                     capture_output=True,
                     text=True,
                     timeout=timeout,
-                    cwd=board_dir,
+                    cwd=os.path.dirname(dsn_path),
                 )
                 attempt_elapsed = round(time.time() - attempt_start, 1)
             except subprocess.TimeoutExpired:
@@ -535,6 +660,7 @@ class FreeroutingCommands:
             if proc.returncode != 0:
                 # Don't abort the whole best-of-N just because one attempt
                 # exits nonzero — record it and move on.
+                exit_note = _describe_exit(proc.returncode)
                 attempt_results.append(
                     {
                         "attempt": idx + 1,
@@ -542,13 +668,14 @@ class FreeroutingCommands:
                         "elapsed_seconds": attempt_elapsed,
                         "ok": False,
                         "exit_code": proc.returncode,
+                        "exit_reason": exit_note.lstrip(" -") or "nonzero exit",
                         "stderr": (proc.stderr or "")[:200],
                     }
                 )
                 if attempts == 1:
                     return {
                         "success": False,
-                        "message": f"Freerouting exited with code {proc.returncode}",
+                        "message": (f"Freerouting exited with code {proc.returncode}{exit_note}"),
                         "errorDetails": proc.stderr or proc.stdout,
                         "elapsed_seconds": attempt_elapsed,
                         "mode": mode_label,
@@ -665,8 +792,16 @@ class FreeroutingCommands:
             "success": True,
             "message": f"Autoroute completed in {elapsed}s",
             "mode": mode_label,
-            "dsn_path": dsn_path,
-            "ses_path": ses_path,
+            # Artifacts are staged in a temp dir and removed after the run
+            # (#249); with keepArtifacts=true they are copied next to the
+            # board and these fields point at the kept copies.
+            "artifacts_kept": keep_artifacts,
+            "dsn_path": (
+                os.path.join(board_dir, os.path.basename(dsn_path)) if keep_artifacts else None
+            ),
+            "ses_path": (
+                os.path.join(board_dir, os.path.basename(ses_path)) if keep_artifacts else None
+            ),
             "elapsed_seconds": elapsed,
             "board_stats": {
                 "tracks": track_count,
@@ -679,7 +814,9 @@ class FreeroutingCommands:
             response["attempts"] = attempt_results
             response["best_attempt"] = best_attempt_idx + 1
             response["best_score"] = best_score
-            response["best_ses_path"] = best_ses_path
+            response["best_ses_path"] = (
+                os.path.join(board_dir, os.path.basename(best_ses_path)) if keep_artifacts else None
+            )
         return response
 
     def export_dsn(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/tools/freerouting.ts
+++ b/src/tools/freerouting.ts
@@ -55,6 +55,12 @@ export function registerFreeroutingTools(server: McpServer, callKicadScript: Fun
         .describe(
           "Per-attempt `--max-passes` values to cycle through (default: [50, 60, 65, 70, 75, 80, 85, 90, 55, 95]). The list wraps if `attempts` exceeds its length.",
         ),
+      keepArtifacts: z
+        .boolean()
+        .optional()
+        .describe(
+          "Keep the intermediate .dsn/.ses files next to the board after the run (default: false). Artifacts are staged in a temporary directory and removed on every exit — success, failure, or crash — unless this is set.",
+        ),
     },
     async (args: any) => {
       const result = await callKicadScript("autoroute", args);

--- a/tests/test_autoroute_best_of_n.py
+++ b/tests/test_autoroute_best_of_n.py
@@ -70,6 +70,17 @@ def _make_cmds(board_path, dsn_exists=True):
     return cc
 
 
+def _ses_from_cmd(cmd):
+    """The SES output path Freerouting was asked to write (after '-do')."""
+    return Path(cmd[cmd.index("-do") + 1])
+
+
+@pytest.fixture(autouse=True)
+def _java_on_path(monkeypatch):
+    """Tests mock subprocess, so command building must not require a JRE."""
+    monkeypatch.setattr(fr_mod, "_find_java", lambda: "java")
+
+
 @pytest.fixture()
 def workdir(tmp_path):
     # Pretend we have an existing board file
@@ -103,7 +114,7 @@ def test_single_attempt_default_keeps_legacy_response_shape(workdir, fake_jar):
 
     def fake_run(cmd, **kw):
         # Write a one-net SES on each subprocess call
-        ses_path.write_text(_make_ses(num_nets=5))
+        _ses_from_cmd(cmd).write_text(_make_ses(num_nets=5))
         proc = types.SimpleNamespace(returncode=0, stdout="ok", stderr="")
         return proc
 
@@ -138,7 +149,7 @@ def test_best_of_three_picks_highest_scoring_ses(workdir, fake_jar):
 
     def fake_run(cmd, **kw):
         n = next(counts)
-        ses_path.write_text(_make_ses(num_nets=n))
+        _ses_from_cmd(cmd).write_text(_make_ses(num_nets=n))
         return types.SimpleNamespace(returncode=0, stdout=f"n={n}", stderr="")
 
     fake_pcb = _stub_pcbnew()
@@ -151,6 +162,9 @@ def test_best_of_three_picks_highest_scoring_ses(workdir, fake_jar):
                 "boardPath": str(workdir / "test.kicad_pcb"),
                 "freeroutingJar": str(fake_jar),
                 "attempts": 3,
+                # Artifacts are staged in a temp dir since #249; keep them so
+                # this test can assert on the winning SES content on disk.
+                "keepArtifacts": True,
             }
         )
 
@@ -159,10 +173,10 @@ def test_best_of_three_picks_highest_scoring_ses(workdir, fake_jar):
     assert len(out["attempts"]) == 3
     assert out["best_attempt"] == 2, f"attempt 2 has 8 nets, should win; got {out['best_attempt']}"
     assert out["best_score"] == 8 * 1000 + (8 * 2)  # 8 nets, 16 segments
-    # The final ses_path content should match the winning attempt (8 nets)
+    # The kept ses content should match the winning attempt (8 nets)
     final_ses = ses_path.read_text()
     assert final_ses.count("(net ") == 8
-    # The _best.ses snapshot must also exist
+    # The _best.ses snapshot must also be kept
     assert best_path.exists()
 
 
@@ -182,7 +196,7 @@ def test_one_failing_attempt_does_not_abort_best_of_n(workdir, fake_jar):
             return types.SimpleNamespace(returncode=99, stdout="", stderr="boom")
         # First and third produce 5 and 9 nets respectively
         nets = 5 if call_idx["n"] == 1 else 9
-        ses_path.write_text(_make_ses(num_nets=nets))
+        _ses_from_cmd(cmd).write_text(_make_ses(num_nets=nets))
         return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
     fake_pcb = _stub_pcbnew()
@@ -220,7 +234,7 @@ def test_pass_schedule_wraps_when_attempts_exceeds_schedule_length(workdir, fake
         # extract `-mp N` from the command
         mp = int(cmd[cmd.index("-mp") + 1])
         seen_mp.append(mp)
-        ses_path.write_text(_make_ses(num_nets=3))
+        _ses_from_cmd(cmd).write_text(_make_ses(num_nets=3))
         return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
     fake_pcb = _stub_pcbnew()
@@ -252,7 +266,7 @@ def test_target_nets_bonus_wins_against_more_nets_without_targets(workdir, fake_
     # Attempt 2: 4 nets including "CRIT" — hits target, gets 50k bonus
     def fake_run(cmd, **kw):
         attempt = sum(1 for c in cmd if c == "-mp")  # rough counter — patched below
-        ses_path.write_text(fake_run.next_ses)
+        _ses_from_cmd(cmd).write_text(fake_run.next_ses)
         return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
     sess = [
@@ -267,7 +281,7 @@ def test_target_nets_bonus_wins_against_more_nets_without_targets(workdir, fake_
 
     def fake_run(cmd, **kw):
         fake_run.next_ses = next(seq)
-        ses_path.write_text(fake_run.next_ses)
+        _ses_from_cmd(cmd).write_text(fake_run.next_ses)
         return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
     fake_pcb = _stub_pcbnew()
@@ -304,3 +318,152 @@ def test_invalid_attempts_rejected_cleanly(workdir, fake_jar):
     )
     assert out["success"] is False
     assert "Invalid attempts" in out["message"]
+
+
+# ---------------------------------------------------------------------------
+# #249: artifact staging, cleanup, staleness, and exit-code reporting
+# ---------------------------------------------------------------------------
+
+
+def _project_files(workdir):
+    return sorted(f.name for f in workdir.iterdir())
+
+
+@pytest.mark.unit
+def test_no_artifacts_left_in_project_dir_on_success(workdir, fake_jar):
+    """Default run: no .dsn/.ses/_best.ses litter next to the board (#249)."""
+    cc = _make_cmds(workdir / "test.kicad_pcb")
+    _patch_exec_mode(cc)
+
+    def fake_run(cmd, **kw):
+        _ses_from_cmd(cmd).write_text(_make_ses(num_nets=3))
+        return types.SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    before = _project_files(workdir)
+    with (
+        patch.object(fr_mod, "subprocess") as sp,
+        patch.dict(sys.modules, {"pcbnew": _stub_pcbnew()}),
+    ):
+        sp.run.side_effect = fake_run
+        sp.TimeoutExpired = TimeoutError
+        out = cc.autoroute(
+            {"boardPath": str(workdir / "test.kicad_pcb"), "freeroutingJar": str(fake_jar)}
+        )
+
+    assert out["success"], out
+    assert out["artifacts_kept"] is False
+    assert out["dsn_path"] is None and out["ses_path"] is None
+    assert _project_files(workdir) == before, "run must not litter the project directory"
+
+
+@pytest.mark.unit
+def test_no_artifacts_left_in_project_dir_on_failure(workdir, fake_jar):
+    """A failed run cleans up too -- the original #249 complaint (#249)."""
+    cc = _make_cmds(workdir / "test.kicad_pcb")
+    _patch_exec_mode(cc)
+
+    before = _project_files(workdir)
+    with (
+        patch.object(fr_mod, "subprocess") as sp,
+        patch.dict(sys.modules, {"pcbnew": _stub_pcbnew()}),
+    ):
+        sp.run.side_effect = lambda cmd, **kw: types.SimpleNamespace(
+            returncode=1, stdout="", stderr="boom"
+        )
+        sp.TimeoutExpired = TimeoutError
+        out = cc.autoroute(
+            {"boardPath": str(workdir / "test.kicad_pcb"), "freeroutingJar": str(fake_jar)}
+        )
+
+    assert not out["success"]
+    assert _project_files(workdir) == before, "failure exits must not leave .dsn litter"
+
+
+@pytest.mark.unit
+def test_keep_artifacts_copies_them_next_to_the_board(workdir, fake_jar):
+    """keepArtifacts=true: .dsn and .ses are kept and reported (#249)."""
+    cc = _make_cmds(workdir / "test.kicad_pcb")
+    _patch_exec_mode(cc)
+
+    def fake_run(cmd, **kw):
+        _ses_from_cmd(cmd).write_text(_make_ses(num_nets=3))
+        return types.SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    with (
+        patch.object(fr_mod, "subprocess") as sp,
+        patch.dict(sys.modules, {"pcbnew": _stub_pcbnew()}),
+    ):
+        sp.run.side_effect = fake_run
+        sp.TimeoutExpired = TimeoutError
+        out = cc.autoroute(
+            {
+                "boardPath": str(workdir / "test.kicad_pcb"),
+                "freeroutingJar": str(fake_jar),
+                "keepArtifacts": True,
+            }
+        )
+
+    assert out["success"], out
+    assert out["artifacts_kept"] is True
+    assert Path(out["dsn_path"]) == workdir / "test.dsn"
+    assert Path(out["ses_path"]) == workdir / "test.ses"
+    assert (workdir / "test.dsn").is_file() and (workdir / "test.ses").is_file()
+
+
+@pytest.mark.unit
+def test_attempt_without_output_does_not_rescore_predecessor(workdir, fake_jar):
+    """An attempt exiting 0 without writing an SES reads as 'no SES', not a
+    silent re-score of the previous attempt's file (#249)."""
+    cc = _make_cmds(workdir / "test.kicad_pcb")
+    _patch_exec_mode(cc)
+
+    calls = {"n": 0}
+
+    def fake_run(cmd, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            _ses_from_cmd(cmd).write_text(_make_ses(num_nets=5))
+        # attempt 2: exit 0 but write nothing
+        return types.SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    with (
+        patch.object(fr_mod, "subprocess") as sp,
+        patch.dict(sys.modules, {"pcbnew": _stub_pcbnew()}),
+    ):
+        sp.run.side_effect = fake_run
+        sp.TimeoutExpired = TimeoutError
+        out = cc.autoroute(
+            {
+                "boardPath": str(workdir / "test.kicad_pcb"),
+                "freeroutingJar": str(fake_jar),
+                "attempts": 2,
+            }
+        )
+
+    assert out["success"], out
+    assert out["best_attempt"] == 1
+    second = out["attempts"][1]
+    assert second["ok"] is False
+    assert second.get("error") == "no SES produced", second
+
+
+@pytest.mark.unit
+def test_killed_subprocess_is_reported_as_such(workdir, fake_jar):
+    """Windows force-kill exit code 4294967295 gets a human explanation (#249)."""
+    cc = _make_cmds(workdir / "test.kicad_pcb")
+    _patch_exec_mode(cc)
+
+    with (
+        patch.object(fr_mod, "subprocess") as sp,
+        patch.dict(sys.modules, {"pcbnew": _stub_pcbnew()}),
+    ):
+        sp.run.side_effect = lambda cmd, **kw: types.SimpleNamespace(
+            returncode=4294967295, stdout="", stderr=""
+        )
+        sp.TimeoutExpired = TimeoutError
+        out = cc.autoroute(
+            {"boardPath": str(workdir / "test.kicad_pcb"), "freeroutingJar": str(fake_jar)}
+        )
+
+    assert not out["success"]
+    assert "terminated externally" in out["message"], out["message"]

--- a/tests/test_freerouting.py
+++ b/tests/test_freerouting.py
@@ -62,6 +62,16 @@ def cmds_no_board() -> Any:
     return FreeroutingCommands(board=None)
 
 
+@pytest.fixture(autouse=True)
+def _java_on_path(monkeypatch) -> None:
+    """Tests mock subprocess.run, so building the command must not require a
+    real JRE on the host. Tests that exercise _find_java itself hold their own
+    reference to the original function and are unaffected."""
+    import commands.freerouting as _fr
+
+    monkeypatch.setattr(_fr, "_find_java", lambda: "java")
+
+
 def _patch_direct_java() -> Any:
     """Patch to simulate Java 21+ available locally."""
     return patch.object(
@@ -290,7 +300,7 @@ class TestAutoroute:
 
         cmds.board.GetFileName.return_value = str(board_file)
         pcbnew_mock.ExportSpecctraDSN.side_effect = lambda b, p: (
-            dsn_file.write_text("(pcb)"),
+            Path(p).write_text("(pcb)"),
             True,
         )[1]
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="", timeout=10)
@@ -314,11 +324,15 @@ class TestAutoroute:
         cmds.board.GetFileName.return_value = str(board_file)
 
         pcbnew_mock.ExportSpecctraDSN.side_effect = lambda b, p: (
-            dsn_file.write_text("(pcb)"),
+            Path(p).write_text("(pcb)"),
             True,
         )[1]
-        mock_run.return_value = MagicMock(returncode=0, stdout="Routing completed", stderr="")
-        ses_file.write_text("(session)")
+
+        def _run_writes_ses(cmd, **kw):
+            Path(cmd[cmd.index("-do") + 1]).write_text("(session)")
+            return MagicMock(returncode=0, stdout="Routing completed", stderr="")
+
+        mock_run.side_effect = _run_writes_ses
         pcbnew_mock.ImportSpecctraSES.return_value = True
 
         track = MagicMock()
@@ -349,12 +363,22 @@ class TestAutoroute:
 
         cmds.board.GetFileName.return_value = str(board_file)
 
-        pcbnew_mock.ExportSpecctraDSN.side_effect = lambda b, p: (
-            dsn_file.write_text("(pcb)"),
-            True,
-        )[1]
-        mock_run.return_value = MagicMock(returncode=0, stdout="Routing completed", stderr="")
-        ses_file.write_text("(session)")
+        staged = {}
+
+        def _export(b, p):
+            staged["dsn"] = Path(p)
+            Path(p).write_text("(pcb)")
+            return True
+
+        pcbnew_mock.ExportSpecctraDSN.side_effect = _export
+
+        def _run_writes_ses(cmd, **kw):
+            # Docker maps the staging dir to /work, so the '-do' argument is a
+            # container path; write the SES where the host will look for it.
+            staged["dsn"].with_name("test.ses").write_text("(session)")
+            return MagicMock(returncode=0, stdout="Routing completed", stderr="")
+
+        mock_run.side_effect = _run_writes_ses
         pcbnew_mock.ImportSpecctraSES.return_value = True
 
         cmds.board.GetTracks.return_value = [MagicMock()]
@@ -387,7 +411,7 @@ class TestAutoroute:
 
         cmds.board.GetFileName.return_value = str(board_file)
         pcbnew_mock.ExportSpecctraDSN.side_effect = lambda b, p: (
-            dsn_file.write_text("(pcb)"),
+            Path(p).write_text("(pcb)"),
             True,
         )[1]
         mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="OutOfMemoryError")


### PR DESCRIPTION
Fixes #249, whose remaining scope was defined precisely by @Dewieinns' 2026-07-29 trace — all four findings verified against main before writing this, and each gets a regression test.

## The four fixes

1. **No more litter.** Artifacts stage in a per-run `tempfile.mkdtemp` and a `finally` removes the directory on every exit — success, any of the twelve failure returns, or an exception. `keepArtifacts: true` copies `.dsn`/`.ses`/`_best.ses` next to the board for debugging; the response's `dsn_path`/`ses_path` point at the kept copies, or are `null` with `artifacts_kept: false` otherwise (a response-shape change, called out in the CHANGELOG).

2. **Stale SES can no longer be imported.** The fresh staging directory makes cross-run staleness structurally impossible — no pre-existing file can satisfy the `isfile` gate. The intra-run variant from the trace (attempt 2 exits 0 without writing and re-scores attempt 1's file) is closed by unlinking the SES before each launch: such an attempt now records `no SES produced`.

3. **A killed subprocess says so.** `_describe_exit` decodes Windows `0xFFFFFFFF` (force-kill), `0xC000013A` (Ctrl+C/console close), `0xC0000005` (JVM access violation), and POSIX negative signal codes. Run 2 of the trace now reads `Freerouting exited with code 4294967295 -- process was terminated externally (force-kill)` instead of a bare number with an unrelated JVM warning attached.

4. **Freerouting's own log is contained.** The shared `%TEMP%/freerouting/freerouting.log` (observed at 9.38 MB after three runs) is truncated past 5 MB after each run. A proper log-level flag varies across bundled JAR versions, so truncation is the version-independent fix.

## Test changes
Five new regression tests (no litter on success, no litter on failure, keepArtifacts round-trip, no-output attempt not re-scoring its predecessor, kill-code decoding). Existing tests updated to find the SES via the `-do` argument rather than assuming the project directory. Also fixed in passing: the autoroute test classes mocked `subprocess` but built the real command line, which calls `_find_java()` — so all 8 of them errored on machines without a JRE. An autouse fixture stubs it; the `_find_java` unit tests are unaffected (they hold their own reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)