### PR TITLE
fix(schematic): declare pymupdf so schematic renders always rasterize (#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,17 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`get_schematic_view` renders always have a working SVG-to-PNG converter**
+  (#274 by @stefangordon, adjusted per review). The converter chain had no
+  declared dependency, so a stock install silently fell back to the raw
+  full-sheet SVG -- which ignores the requested width/height and easily
+  exceeds an MCP client's inline size cap. `pymupdf` is now declared in
+  requirements.txt as the first-priority converter (binary wheels on all
+  three platforms; cairosvg, the PR's original choice, needs a native cairo
+  runtime that stock Windows lacks), with cairosvg second and the
+  Inkscape/ImageMagick fallbacks unchanged. Regression tests pin the
+  stock-install invariant.
+
 - **`add_symbol_property` corrupted `.kicad_sym` libraries**. Every call dropped
   one closing paren, so the library stopped loading in eeschema. Eight defects,
   all in the same write path:

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -78,13 +78,24 @@ def _pick_root_svg(svg_dir: str, schematic_path: str) -> Optional[str]:
 
 
 def _svg_to_png(svg_path: str, width: int, height: int) -> Optional[bytes]:
-    """Convert SVG to PNG. No cffi dependency.
+    """Convert SVG to PNG at the requested pixel dimensions.
 
     Priority:
-      1. pymupdf (fitz) — bundled MuPDF renderer, pure Python, no system deps
-      2. Inkscape CLI — accurate KiCAD SVG rendering
-      3. ImageMagick convert — broad availability fallback
+      1. pymupdf (fitz) — the declared dependency (see requirements.txt).
+         Bundles the MuPDF renderer with binary wheels on all three
+         platforms, so `pip install -r requirements.txt` alone guarantees a
+         working converter — cairosvg cannot promise that on Windows, where
+         the native cairo runtime is typically absent (#274 review).
+      2. cairosvg — honors output_width/output_height; fine wherever the
+         cairo runtime exists.
+      3. Inkscape CLI — accurate KiCAD SVG rendering, if installed.
+      4. ImageMagick convert — broad availability fallback.
     Returns PNG bytes or None if all converters fail.
+
+    Rasterizing here is essential (#274): returning the raw KiCAD SVG
+    instead produces a full-sheet vector document (title block, grid, every
+    path and font) whose text easily exceeds an MCP client's inline size
+    cap, and width/height have no effect on it.
     """
     import subprocess
     import tempfile
@@ -96,6 +107,17 @@ def _svg_to_png(svg_path: str, width: int, height: int) -> Optional[bytes]:
         page = doc[0]
         mat = fitz.Matrix(width / page.rect.width, height / page.rect.height)
         return page.get_pixmap(matrix=mat).tobytes("png")
+    except Exception:
+        pass
+
+    try:
+        import cairosvg
+
+        return cairosvg.svg2png(
+            url=svg_path,
+            output_width=int(width),
+            output_height=int(height),
+        )
     except Exception:
         pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,11 @@ kicad-skip>=0.1.0
 Pillow>=9.0.0
 
 # SVG rendering
+# Declared rasterizer for schematic/board view PNGs (#274): ships binary
+# wheels on Windows/macOS/Linux, so a stock pip install always has a working
+# SVG->PNG converter. cairosvg stays as the second choice -- its native cairo
+# runtime cannot be assumed on Windows.
+pymupdf>=1.24
 cairosvg>=2.7.0
 
 # Colored logging

--- a/tests/test_svg_to_png_render.py
+++ b/tests/test_svg_to_png_render.py
@@ -1,0 +1,78 @@
+"""Tests for ``_svg_to_png`` used by ``get_schematic_view``.
+
+Regression guard for the bug where the converter chain had no *declared*
+backend, so on a stock install the function returned ``None`` and the
+handler silently fell back to emitting the raw full-sheet SVG — which
+ignores width/height and blows past MCP clients' inline size cap.
+
+pymupdf is the declared dependency (it ships binary wheels everywhere,
+unlike cairosvg whose native cairo runtime is absent on stock Windows —
+see the #274 review), so a stock ``pip install -r requirements.txt`` must
+always yield a working converter. That invariant is what these tests pin.
+
+conftest.py pre-installs a MagicMock for ``pcbnew`` so the module imports
+without a real KiCAD install.
+"""
+
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.unit
+
+from commands.schematic_handlers import _svg_to_png  # noqa: E402
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+SAMPLE_SVG = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="80mm" '
+    'viewBox="0 0 100 80">'
+    '<rect x="10" y="10" width="60" height="40" fill="none" stroke="black" '
+    'stroke-width="1"/>'
+    '<line x1="10" y1="30" x2="70" y2="30" stroke="black" stroke-width="0.5"/>'
+    "</svg>"
+)
+
+
+def _png_dimensions(png: bytes) -> tuple[int, int]:
+    """Read width/height from a PNG's IHDR chunk (bytes 16:24, big-endian)."""
+    width, height = struct.unpack(">II", png[16:24])
+    return width, height
+
+
+@pytest.fixture()
+def svg_file(tmp_path: Path) -> str:
+    path = tmp_path / "sample.svg"
+    path.write_text(SAMPLE_SVG, encoding="utf-8")
+    return str(path)
+
+
+def test_returns_png_bytes_not_none(svg_file: str) -> None:
+    """A converter must be available on a stock install (cairosvg) — never None."""
+    png = _svg_to_png(svg_file, 200, 150)
+    assert png is not None, "no SVG->PNG converter available; would fall back to oversized SVG"
+    assert png.startswith(PNG_MAGIC)
+
+
+def test_honors_requested_dimensions(svg_file: str) -> None:
+    """width/height must control the raster size (they were previously ignored)."""
+    png = _svg_to_png(svg_file, 200, 150)
+    assert png is not None
+    assert _png_dimensions(png) == (200, 150)
+
+    smaller = _svg_to_png(svg_file, 80, 60)
+    assert smaller is not None
+    assert _png_dimensions(smaller) == (80, 60)
+
+
+def test_smaller_dimensions_shrink_payload(svg_file: str) -> None:
+    """Shrinking dimensions must shrink the payload — the core promise to callers."""
+    big = _svg_to_png(svg_file, 1200, 900)
+    small = _svg_to_png(svg_file, 300, 225)
+    assert big is not None and small is not None
+    assert len(small) < len(big)


### PR DESCRIPTION
Takes over #274 (@stefangordon, silent since 07-01 past the announced grace period). Their diagnosis was exactly right — the converter chain had no declared dependency, so a stock install silently returned the raw full-sheet SVG, which ignores width/height and blows past inline size caps. Their size table on the original PR made the impact concrete.

The one change requested in that PR's review is applied here: the declared first-priority converter is **pymupdf**, not cairosvg — cairosvg's pip package wraps the native cairo runtime, which stock Windows lacks (`cannot load library 'libcairo-2.dll'`, reproduced during the original review), while pymupdf ships complete binary wheels on Windows/macOS/Linux. cairosvg becomes the second choice where cairo exists; the Inkscape/ImageMagick CLI fallbacks are unchanged.

Stefan Gordon's regression tests are kept as written (credited via Co-authored-by) — they pin the invariant that `pip install -r requirements.txt` alone always yields a working converter, which is the most valuable part of the original PR.

Closes #274. Closes #277 — its part 1 (the `--layers` fix) was already cherry-picked into #337 with authorship preserved, and its remaining cairosvg question is resolved by this converter ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)