### PR TITLE
fix(jlcpcb): degrade gracefully when the parts database is unavailable (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,15 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **An unwritable JLCPCB data directory no longer crashes the whole server**
+  (#264 by @fage2022). `JLCPCBPartsManager` raised `PermissionError` at
+  construction -- which happens at import time, so one broken directory took
+  down all tools with `ModuleNotFoundError`-adjacent startup failures. The
+  manager now disables itself with a logged warning and every operation
+  returns an empty result. Taken from PR #264 with credit; that PR's
+  unrelated `_fix_perms.py` helper and `sys.path` change are deliberately
+  not included.
+
 - **`add_symbol_property` corrupted `.kicad_sym` libraries**. Every call dropped
   one closing paren, so the library stopped loading in eeschema. Eight defects,
   all in the same write path:

--- a/python/commands/jlcpcb_parts.py
+++ b/python/commands/jlcpcb_parts.py
@@ -65,14 +65,34 @@ class JLCPCBPartsManager:
                 user data directory, e.g. ~/.local/share/kicad-mcp/jlcpcb_parts.db
                 on Linux). See PlatformHelper.get_data_dir() for platform paths.
         """
+        self.conn: Optional[sqlite3.Connection] = None
+        self.db_path = db_path or ""
+
         if db_path is None:
             data_dir = PlatformHelper.get_data_dir()
-            data_dir.mkdir(parents=True, exist_ok=True)
-            db_path = str(data_dir / "jlcpcb_parts.db")
+            try:
+                data_dir.mkdir(parents=True, exist_ok=True)
+            except (PermissionError, OSError) as exc:
+                logger.warning(
+                    "Cannot create JLCPCB data directory %s: %s. "
+                    "JLCPCB parts database will be disabled.",
+                    data_dir,
+                    exc,
+                )
+                return  # self.conn stays None — disabled
 
-        self.db_path = db_path
-        self.conn: Optional[sqlite3.Connection] = None
-        self._init_database()
+            db_path = str(data_dir / "jlcpcb_parts.db")
+            self.db_path = db_path
+
+        try:
+            self._init_database()
+        except sqlite3.OperationalError as exc:
+            logger.warning(
+                "Cannot open JLCPCB parts database at %s: %s. "
+                "JLCPCB parts database will be disabled.",
+                self.db_path,
+                exc,
+            )
 
     def _init_database(self) -> None:
         """Initialize SQLite database with schema"""
@@ -133,6 +153,9 @@ class JLCPCBPartsManager:
             parts: List of part dicts from JLCPCB API
             progress_callback: Optional callback(current, total, message)
         """
+        if self.conn is None:
+            logger.warning("JLCPCB database not available — skipping import_parts")
+            return
         cursor = self.conn.cursor()
         imported = 0
         skipped = 0
@@ -212,6 +235,9 @@ class JLCPCBPartsManager:
             parts: List of part dicts from JLCSearch API
             progress_callback: Optional callback(current, total, message)
         """
+        if self.conn is None:
+            logger.warning("JLCPCB database not available — skipping import_jlcsearch_parts")
+            return
         cursor = self.conn.cursor()
         imported = 0
         skipped = 0
@@ -317,6 +343,9 @@ class JLCPCBPartsManager:
         Returns:
             List of matching parts
         """
+        if self.conn is None:
+            logger.warning("JLCPCB database not available — skipping search_parts")
+            return []
         cursor = self.conn.cursor()
 
         # Build query
@@ -380,6 +409,8 @@ class JLCPCBPartsManager:
         Returns:
             Part info dict or None if not found
         """
+        if self.conn is None:
+            return None
         cursor = self.conn.cursor()
         cursor.execute("SELECT * FROM components WHERE lcsc = ?", (lcsc_number,))
         row = cursor.fetchone()
@@ -397,6 +428,14 @@ class JLCPCBPartsManager:
 
     def get_database_stats(self) -> Dict:
         """Get statistics about the database"""
+        if self.conn is None:
+            return {
+                "total_parts": 0,
+                "basic_parts": 0,
+                "extended_parts": 0,
+                "in_stock": 0,
+                "db_path": self.db_path,
+            }
         cursor = self.conn.cursor()
 
         cursor.execute("SELECT COUNT(*) as total FROM components")
@@ -508,6 +547,7 @@ class JLCPCBPartsManager:
         """Close database connection"""
         if self.conn:
             self.conn.close()
+            self.conn = None
 
 
 if __name__ == "__main__":

--- a/tests/test_jlcpcb_parts_degraded.py
+++ b/tests/test_jlcpcb_parts_degraded.py
@@ -1,0 +1,48 @@
+"""JLCPCBPartsManager degrades gracefully when its database is unavailable.
+
+Regression guard for #264: an unwritable data directory (or database file)
+raised PermissionError during construction, which happened at server import
+time -- one broken directory took down all 216 tools. The manager now
+disables itself with a warning and every operation returns an empty result
+instead of raising.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.unit
+
+from commands.jlcpcb_parts import JLCPCBPartsManager  # noqa: E402
+
+
+def _disabled_manager():
+    with patch("commands.jlcpcb_parts.PlatformHelper.get_data_dir") as get_dir:
+        get_dir.return_value.mkdir.side_effect = PermissionError("denied")
+        return JLCPCBPartsManager()
+
+
+def test_unwritable_data_dir_disables_instead_of_raising():
+    mgr = _disabled_manager()
+    assert mgr.conn is None
+
+
+def test_disabled_manager_operations_return_empty_results():
+    mgr = _disabled_manager()
+    assert mgr.search_parts(query="R0402") == []
+    assert mgr.get_part_info("C12345") is None
+    stats = mgr.get_database_stats()
+    assert stats["total_parts"] == 0
+    mgr.import_parts([])  # must not raise
+    mgr.close()  # must not raise
+
+
+def test_unopenable_database_file_disables_instead_of_raising(tmp_path):
+    # Point db_path at a directory -- sqlite cannot open that as a database.
+    mgr = JLCPCBPartsManager(db_path=str(tmp_path))
+    assert mgr.conn is None
+    assert mgr.search_parts(query="x") == []


### PR DESCRIPTION
Takes over the useful core of #264 (@fage2022, silent since 06-29 past the announced grace period), with credit via Co-authored-by.

`JLCPCBPartsManager` raised from its constructor when the platform data directory was unwritable (`PermissionError`) or the database file unopenable (`sqlite3.OperationalError`). Construction happens at server import time, so one broken directory prevented the entire backend from starting — the first crash in their report.

With this change the manager disables itself with a logged warning: `conn` stays `None`, searches return `[]`, lookups return `None`, stats return zeros, imports skip. Three regression tests pin the behavior (unwritable dir, unopenable file, and the disabled-operations contract).

Per the review on the original PR, two of its hunks are deliberately **not** taken: `python/_fix_perms.py` (a chmod helper unrelated to the fix, and the wrong direction — the server should not modify permissions) and the `sys.path.insert` change in `kicad_interface.py` (cannot resolve a missing site-packages distribution, which was the report's *other* crash — that one is environment-setup, tracked in #361's guidance instead).

Closes #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)