### PR TITLE
fix(sync): match board footprints by symbol UUID, not just refdes (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,17 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`sync_schematic_to_board` no longer duplicates footprints when reference
+  designators diverge** (#250, reported by @Dewieinns). Sync matched purely on
+  reference strings, so a schematic re-annotated after layout made every
+  component look "missing" and added a second copy of the whole board at the
+  origin. Board footprints are now also matched by their schematic symbol
+  UUID (the last segment of `GetPath()`, which kicad-cli's netlist reports as
+  `<tstamps>` -- format verified against real KiCad 10): a comp whose UUID is
+  already bound to a board footprint under a different name is skipped with
+  an explanatory reason instead of duplicated. Reused-sheet instances share a
+  symbol UUID; each unmatched comp claims one unclaimed footprint.
+
 - **`add_symbol_property` corrupted `.kicad_sym` libraries**. Every call dropped
   one closing paren, so the library stopped loading in eeschema. Eight defects,
   all in the same write path:

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -3058,11 +3058,17 @@ class SchematicHandlersMixin:
             root = tree.getroot()
             components = []
             for comp in root.findall("./components/comp"):
+                # <tstamps> carries the schematic symbol UUID -- verified
+                # against kicad-cli 10.0: a bare UUID with no sheet path
+                # (instances of a reused sheet share it). Legacy exports
+                # could comma-join several; keep the first.
+                tstamps = (comp.findtext("tstamps") or "").replace(",", " ").split()
                 components.append(
                     {
                         "reference": comp.get("ref", ""),
                         "value": comp.findtext("value", ""),
                         "footprint": comp.findtext("footprint", ""),
+                        "uuid": tstamps[0] if tstamps else "",
                     }
                 )
             return components
@@ -3132,6 +3138,23 @@ class SchematicHandlersMixin:
             self._sync_library_manager_state = self._fp_lib_tables_state(project_dir, cached)
         return cached
 
+    @staticmethod
+    def _board_symbol_uuid(fp: Any) -> str:
+        """The schematic symbol UUID a board footprint is bound to, or "".
+
+        ``GetPath().AsString()`` is ``/sheet-uuid/.../symbol-uuid`` (verified
+        against real KiCad 10); the last segment is the symbol UUID that
+        kicad-cli's netlist reports in ``<tstamps>``. Footprints placed by
+        hand have an empty path. Tolerant of test doubles without GetPath.
+        """
+        try:
+            path = fp.GetPath().AsString()
+        except Exception:
+            return ""
+        if not isinstance(path, str) or not path:
+            return ""
+        return path.rstrip("/").rsplit("/", 1)[-1]
+
     def _add_missing_footprints_from_schematic(
         self, board: Any, schematic_path: str
     ) -> Tuple[List[Dict[str, str]], List[Dict[str, str]]]:
@@ -3154,6 +3177,21 @@ class SchematicHandlersMixin:
             return added, skipped
 
         existing_refs = {fp.GetReference() for fp in board.GetFootprints()}
+
+        # Board footprints bound (by symbol UUID) to a schematic symbol whose
+        # reference no netlist comp claims: the #250 shape. A schematic that
+        # was re-annotated after layout matches nothing by reference, and
+        # adding a second copy of every such part duplicates the board. The
+        # UUID says "same symbol, different name" -- skip the add and say so.
+        # Reused-sheet instances share a symbol UUID, hence the list: each
+        # unmatched comp claims one unclaimed footprint.
+        sch_refs = {c["reference"] for c in components if c.get("reference")}
+        unclaimed_by_uuid: Dict[str, List[Any]] = {}
+        for fp in board.GetFootprints():
+            fp_uuid = self._board_symbol_uuid(fp)
+            if fp_uuid and fp.GetReference() not in sch_refs:
+                unclaimed_by_uuid.setdefault(fp_uuid, []).append(fp)
+
         project_dir = Path(schematic_path).parent
         library_manager = self._get_project_library_manager(project_dir)
 
@@ -3173,6 +3211,29 @@ class SchematicHandlersMixin:
                 continue
             if ref in existing_refs:
                 continue
+
+            claimed = unclaimed_by_uuid.get(comp.get("uuid", ""))
+            if claimed:
+                board_fp = claimed.pop(0)
+                board_ref = board_fp.GetReference()
+                logger.warning(
+                    f"sync: schematic '{ref}' is already on the board as "
+                    f"'{board_ref}' (same symbol UUID, references diverged) "
+                    "-- not adding a duplicate footprint (#250)"
+                )
+                skipped.append(
+                    {
+                        "reference": ref,
+                        "footprint": fp_str,
+                        "reason": (
+                            f"already on board as '{board_ref}' (same schematic "
+                            "symbol, references diverged -- re-annotate or rename "
+                            "to reconcile; no duplicate added)"
+                        ),
+                    }
+                )
+                continue
+
             if not fp_str or ":" not in fp_str:
                 skipped.append(
                     {

--- a/tests/test_sync_schematic_to_board_footprints.py
+++ b/tests/test_sync_schematic_to_board_footprints.py
@@ -326,3 +326,108 @@ class TestExtractComponentsFromSchematic:
             comps = iface._extract_components_from_schematic(str(sch))
 
         assert comps == []
+
+
+@pytest.mark.unit
+class TestRefdesMismatchDoesNotDuplicate:
+    """#250: a re-annotated schematic must not duplicate the whole board.
+
+    sync matched purely on reference strings, so when schematic and PCB
+    reference designators diverged (re-annotation after layout), every
+    component looked "missing" and was added again at the origin. The board
+    footprint's path (its schematic symbol UUID) identifies the symbol
+    regardless of its current name.
+    """
+
+    @staticmethod
+    def _fp_with_path(reference, symbol_uuid):
+        fp = MagicMock(name=f"fp_{reference}")
+        fp.GetReference.return_value = reference
+        path = MagicMock()
+        path.AsString.return_value = f"/{symbol_uuid}"
+        fp.GetPath.return_value = path
+        return fp
+
+    def _run(self, board, components, tmp_path):
+        sch = tmp_path / "t.kicad_sch"
+        sch.write_text("(kicad_sch)\n")
+        with (
+            patch.object(
+                _interface().__class__,
+                "_extract_components_from_schematic",
+                return_value=components,
+            ),
+            patch("commands.schematic_handlers.pcbnew") as mock_pcbnew,
+            patch("commands.library.LibraryManager") as mock_lm_cls,
+        ):
+            mock_pcbnew.FootprintLoad.return_value = MagicMock(name="proto")
+            lm = MagicMock()
+            lm.libraries = {"Resistor_SMD": "/fake/Resistor_SMD.pretty"}
+            mock_lm_cls.return_value = lm
+            iface = _interface()
+            return iface._add_missing_footprints_from_schematic(board, str(sch))
+
+    def test_same_symbol_uuid_is_not_added_again(self, tmp_path):
+        # Board has R1 bound to symbol uuid AAA; schematic renamed it to R5.
+        board = MagicMock(name="board")
+        board.GetFootprints.return_value = [self._fp_with_path("R1", "aaa-uuid")]
+        added, skipped = self._run(
+            board,
+            [
+                {
+                    "reference": "R5",
+                    "value": "10k",
+                    "footprint": "Resistor_SMD:R_0603_1608Metric",
+                    "uuid": "aaa-uuid",
+                }
+            ],
+            tmp_path,
+        )
+        assert added == [], "re-annotated symbol must not be re-added"
+        assert len(skipped) == 1
+        assert "already on board as 'R1'" in skipped[0]["reason"]
+
+    def test_genuinely_new_symbol_is_still_added(self, tmp_path):
+        board = MagicMock(name="board")
+        board.GetFootprints.return_value = [self._fp_with_path("R1", "aaa-uuid")]
+        added, skipped = self._run(
+            board,
+            [
+                {
+                    "reference": "R9",
+                    "value": "1k",
+                    "footprint": "Resistor_SMD:R_0603_1608Metric",
+                    "uuid": "bbb-uuid",
+                }
+            ],
+            tmp_path,
+        )
+        assert len(added) == 1 and added[0]["reference"] == "R9"
+
+    def test_reused_sheet_instances_claim_one_footprint_each(self, tmp_path):
+        # Two sheet instances share the symbol uuid; two comps, two boards fps.
+        board = MagicMock(name="board")
+        board.GetFootprints.return_value = [
+            self._fp_with_path("Q101", "shared-uuid"),
+            self._fp_with_path("Q201", "shared-uuid"),
+        ]
+        comps = [
+            {"reference": "Q5", "value": "", "footprint": "X:Y", "uuid": "shared-uuid"},
+            {"reference": "Q6", "value": "", "footprint": "X:Y", "uuid": "shared-uuid"},
+        ]
+        added, skipped = self._run(board, comps, tmp_path)
+        assert added == []
+        assert len(skipped) == 2
+        claimed = {s["reason"].split("'")[1] for s in skipped}
+        assert claimed == {"Q101", "Q201"}, "each comp claims a distinct footprint"
+
+    def test_reference_match_takes_priority_over_uuid(self, tmp_path):
+        # Same ref on both sides: today's behavior (silent skip) is preserved.
+        board = MagicMock(name="board")
+        board.GetFootprints.return_value = [self._fp_with_path("R1", "aaa-uuid")]
+        added, skipped = self._run(
+            board,
+            [{"reference": "R1", "value": "", "footprint": "X:Y", "uuid": "aaa-uuid"}],
+            tmp_path,
+        )
+        assert added == [] and skipped == []


### PR DESCRIPTION
Fixes #250 (@Dewieinns). `sync_schematic_to_board`'s add-missing pass matched purely on reference strings, so schematic/PCB refdes divergence (re-annotation after layout) made every component look missing — and a duplicate of the whole design was added at the origin.

## The matcher
A board footprint's `GetPath()` ends in the schematic symbol UUID it was placed from; kicad-cli's kicadxml netlist reports the same UUID as `<tstamps>`. Both formats were verified against real KiCad 10 before implementation (the `complex_hierarchy` demo):

- `<tstamps>` = bare symbol UUID, **no** sheet path — and reused-sheet instances share it (29 duplicated tstamps in that demo)
- `GetPath().AsString()` = `/sheet-uuid/symbol-uuid`

So the comparison takes the path's last segment, and shared UUIDs are handled by letting each unmatched comp claim one *unclaimed* board footprint (one whose reference no netlist comp owns). A claimed match is skipped with a reason naming the board footprint (`already on board as 'R1' — references diverged`) plus a warning log; a genuinely new symbol still adds; identical references keep today's silent-skip; hand-placed footprints (empty path) keep refdes-only behavior.

Four regression tests: renamed symbol not re-added, new symbol still added, reused-sheet instances claim distinct footprints, refdes match takes priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)