### PR TITLE
fix(server): connect the MCP transport before spawning Python (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,19 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **The MCP transport connects before Python starts, not up to two minutes
+  after** (#377). Python + pcbnew/wxApp initialisation takes 55-125 s, and
+  the transport only connected afterwards -- so every request a client sent
+  in that window sat unread on the server's stdin. Clients stack one drain
+  listener per unresolved send, which is exactly the reported
+  `MaxListenersExceededWarning (count: 11)` crash in opencode, and is also
+  why clients could hit their connect timeout outright. Tools, resources and
+  prompts are registered in the constructor and need no Python, so
+  `initialize`/`tools/list`/`prompts/get` now answer immediately; tool
+  _calls_ queue behind a ready gate so their timeouts do not run against
+  Python's own startup, and the explicit warm-up skips itself when a queued
+  command is already exercising the backend.
+
 - **`add_symbol_property` corrupted `.kicad_sym` libraries**. Every call dropped
   one closing paren, so the library stopped loading in eeschema. Eight defects,
   all in the same write path:

--- a/src/server.ts
+++ b/src/server.ts
@@ -502,6 +502,24 @@ export class KiCADMcpServer {
     try {
       logger.info("Starting KiCAD MCP server...");
 
+      // ——— Phase 0: connect MCP transport BEFORE anything else ———
+      // Python + pcbnew/wxApp initialisation can take 55-125 s. If the
+      // transport only connects afterwards, every request the client sends
+      // in that window sits unread on our stdin -- clients stack a drain
+      // listener per unresolved send, tripping MaxListenersExceededWarning
+      // (#377) and connect timeouts. Tools, resources and prompts are all
+      // registered in the constructor, so initialize/tools/list/prompts/get
+      // need no Python; tool CALLS queue until the backend is ready (see
+      // processNextRequest's ready gate).
+      logger.info("Connecting MCP server to STDIO transport...");
+      try {
+        await this.server.connect(this.stdioTransport);
+        logger.info("Successfully connected to STDIO transport");
+      } catch (error) {
+        logger.error(`Failed to connect to STDIO transport: ${error}`);
+        throw error;
+      }
+
       // Start the Python process for KiCAD scripting
       logger.info(`Starting Python process with script: ${this.kicadScriptPath}`);
       const pythonExe = findPythonExecutable(this.kicadScriptPath);
@@ -575,6 +593,9 @@ export class KiCADMcpServer {
                     this.handlePythonResponse(Buffer.from(remaining));
                   }
                   this.resolveReady();
+                  // Drain any tool calls that queued while Python was
+                  // initialising (the ready gate in processNextRequest).
+                  setTimeout(() => this.processNextRequest(), 0);
                   return;
                 }
               } catch {
@@ -589,18 +610,7 @@ export class KiCADMcpServer {
       logger.info("Waiting for Python process to be ready...");
       await this.waitForReady(120_000);
       logger.info("Python process is ready.");
-      // ——— Phase 3: connect MCP transport immediately ———
-      // The transport must be live before any client timeout fires,
-      // regardless of how long warm-up takes.
-      logger.info("Connecting MCP server to STDIO transport...");
-      try {
-        await this.server.connect(this.stdioTransport);
-        logger.info("Successfully connected to STDIO transport");
-      } catch (error) {
-        logger.error(`Failed to connect to STDIO transport: ${error}`);
-        throw error;
-      }
-      // ——— Phase 4: background warm-up (does not block MCP) ———
+      // ——— Phase 3: background warm-up (transport already live) ———
       // Warm-up can take 55-125 s (wxApp + symbol library parse), but
       // the MCP transport is already live so the client timeout does not
       // apply.  Tools invoked during warm-up will work; the first
@@ -666,6 +676,16 @@ export class KiCADMcpServer {
     return new Promise<void>((resolve) => {
       if (!this.pythonProcess || !this.pythonProcess.stdin) {
         logger.warn("Python process not running — skipping warm-up");
+        resolve();
+        return;
+      }
+
+      // With the transport connected before Python is up (#377), a tool call
+      // may already have queued and dispatched the moment READY fired. A real
+      // command exercises pcbnew exactly like _warmup would -- and writing
+      // into its handler slot would corrupt the in-flight request.
+      if (this.processingRequest || this.currentRequestHandler) {
+        logger.info("Skipping explicit warm-up — a queued command is already warming the backend");
         resolve();
         return;
       }
@@ -876,6 +896,14 @@ export class KiCADMcpServer {
   private processNextRequest(): void {
     // If no more requests or already processing, return
     if (this.requestQueue.length === 0 || this.processingRequest) {
+      return;
+    }
+
+    // Backend still initialising: hold the queue. Drained when the READY
+    // marker fires (see the startup stdout handler). Without this gate, a
+    // tool called during the 55-125 s init window would start its 30 s
+    // timeout against Python's own startup and always lose (#377).
+    if (!this.readyDetected) {
       return;
     }
 

--- a/tests-ts/startup-ready-gate.test.ts
+++ b/tests-ts/startup-ready-gate.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import { KiCADMcpServer } from "../src/server.js";
+
+const pythonBridge = fileURLToPath(new URL("../python/kicad_interface.py", import.meta.url));
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("startup ready gate (#377)", () => {
+  it("holds queued tool calls until the backend reports READY", () => {
+    vi.useFakeTimers();
+    const server = new KiCADMcpServer(pythonBridge, "error") as any;
+    const stdin = { write: vi.fn() };
+    server.pythonProcess = { stdin };
+    server.readyDetected = false;
+
+    server.requestQueue.push({
+      request: { command: "get_board_info", params: {}, timeout: 30_000 },
+      resolve: vi.fn(),
+      reject: vi.fn(),
+    });
+
+    server.processNextRequest();
+
+    // Held: nothing written, no timeout started against Python's own startup.
+    expect(stdin.write).not.toHaveBeenCalled();
+    expect(server.processingRequest).toBe(false);
+    expect(server.requestQueue.length).toBe(1);
+
+    // READY fires: the queue drains and the request dispatches.
+    server.readyDetected = true;
+    server.processNextRequest();
+    expect(stdin.write).toHaveBeenCalledOnce();
+    expect(server.requestQueue.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #377. The reported crash is client-side — the MCP client SDK's `StdioClientTransport.send()` does `stdin.write(json) || stdin.once('drain', ...)`, stacking one listener per unresolved send, and Bun trips `MaxListenersExceededWarning` at 11 — but the server supplies the stall: the transport only connected **after** `waitForReady(120_000)`, so for up to two minutes every client request sat unread on our stdin. opencode hydrates all 18 registered prompts at startup, which is the burst behind `count: 11`.

## Changes
- **Transport connects first**, before Python is spawned. Everything is registered in the constructor, so `initialize`/`tools/list`/`prompts/get` (all static) answer immediately.
- **Ready gate in `processNextRequest`**: tool calls that arrive during backend init queue without dispatching, so their 30s timeouts don't run against Python's own startup; the queue drains when the READY marker fires.
- **Warm-up self-skips** when a queued command already dispatched at READY — a real command exercises pcbnew exactly like `_warmup`, and writing into its handler slot would corrupt the in-flight request.

Regression test pins the gate (held before READY: nothing written, no timeout started; drained after).

Note: #382 (request correlation, #373) touches the same functions — whichever merges second gets a small conflict; I'll rebase the survivor. Recommended order: #382 first, then this.

A reply on #377 will point the reporter at this and at raising the listener cap on the opencode side, and ask for their `kicad_interface` log to confirm the warning falls inside the pre-connect window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)