### PR TITLE
fix(schematic): make placement, labelling and dragging match eeschema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,64 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Placed symbols lost the library's field visibility.** `Reference` and
+  `Value` were written visible unconditionally, ignoring the `(hide yes)` the
+  library symbol carries. Power symbols hide `Reference` by convention — a
+  `#PWR101` designator tells a reader nothing — so every ground and rail symbol
+  placed through the API printed one. A sheet with 26 grounds came out with 26
+  stray designators over the wiring, and the only way back was hand-editing the
+  file. Visibility is now read from the injected `lib_symbols` definition
+  alongside the position and effects that were already inherited. The marker is
+  matched as a token, so a field whose *value* contains the word "hide" is not
+  mistaken for a hidden field.
+
+- **Net labels snapped to a pin faced the wrong way.** KiCad pairs label angle
+  0/90 with `justify left` and 180/270 with `justify right`; a label anchored at
+  a pin endpoint has to run along the pin's outward direction or its text lies
+  across the symbol body. `add_schematic_net_label` defaulted to angle 0
+  regardless of the pin, and `batch_connect` went further and turned the label
+  around (a right-facing pin got 180), which put the net name over the body on
+  every right-hand pin of every part. Since `justify` is not separately
+  settable through the API, callers could not repair it without editing the
+  file. Both now orient the label along the pin's outward bearing, snapped to
+  the four orientations KiCad allows. An explicit `orientation` still wins.
+
+- **Dragging a component broke its routing and left its no-connect flags
+  behind.** Moving or rotating a symbol updated only the wire endpoint touching
+  each pin. A trace routed pin → corner → corner → pin is a chain of separate
+  two-point segments, so the first segment came out diagonal and its bend landed
+  off-grid — reported afterwards as `endpoint_off_grid` on a trace nobody
+  touched. A no-connect flag on a moved pin stayed at the old coordinate,
+  turning into a dangling flag plus an unconnected pin.
+
+  `move_schematic_component` and `rotate_schematic_component` now carry the
+  neighbouring bend along with the pin, cascading through the chain until the
+  routing settles, and move no-connect flags with the pins they mark. A corner
+  is left alone — and the segment left diagonal — when an explicit junction, a
+  fork of three or more segments, or another component's pin holds it: moving
+  those would drag unrelated wiring or tear a connection apart. The response
+  counts both outcomes (`wiresStraightened`, `wiresLeftDiagonal`,
+  `noConnectsMoved`); `straightenWires: false` opts out.
+
+- **A single unit of a multi-unit part could not be addressed.** Every unit of
+  a multi-unit symbol is placed as its own `(symbol ...)` block under one shared
+  reference, so `move_schematic_component`, `rotate_schematic_component` and
+  `delete_schematic_component` acted on whichever block came first in the file —
+  not predictable from the outside — and `delete` took the whole part. All three
+  now accept an optional `unit`. Naming a unit that is not placed reports which
+  ones are, rather than failing as "not found". Wire dragging follows: pins are
+  filtered to the moved unit, and the part's other units count as stationary,
+  so their wiring is left where it is.
+
+### Improvements
+
+- **`batch_add_components` accepts `unit`.** `add_schematic_component` had it,
+  the batch did not, so a five-unit FPGA had to be placed one call per unit —
+  the round-trips the batch exists to avoid. Each entry now names its unit;
+  entries sharing a reference are the units of one part.
+
 ## [2.7.0] - 2026-08-20
 
 ### New Tools

--- a/python/commands/dynamic_symbol_loader.py
+++ b/python/commands/dynamic_symbol_loader.py
@@ -653,10 +653,14 @@ class DynamicSymbolLoader:
         symbol_name: str,
     ) -> dict:
         """
-        Return {prop_name: (dx, dy, text_angle, effects_str)} from the lib_symbols
-        section of the schematic (which must already have the symbol injected).
+        Return {prop_name: (dx, dy, text_angle, effects_str, hidden)} from the
+        lib_symbols section of the schematic (which must already have the symbol
+        injected).
         effects_str is the full '(effects ...)' string to be reused in the placed
-        instance so that justify, font size, hide etc. are preserved.
+        instance so that justify, font size etc. are preserved; ``hidden`` carries
+        the library's field visibility separately, because the hide marker is
+        stripped out of effects_str (KiCad 10 records visibility as a top-level
+        ``(hide yes)`` on the property, not inside ``(effects ...)``).
         Returns an empty dict on failure.
         """
         try:
@@ -700,16 +704,28 @@ class DynamicSymbolLoader:
                 eff_pos = prop_block.find("(effects")
                 if eff_pos != -1:
                     effects_str = self._extract_paren_block(prop_block, eff_pos)
-                    # Strip (hide ...) sub-expressions — visibility will be set
-                    # separately by the caller
+                    # Strip (hide ...) sub-expressions — visibility travels
+                    # separately in the `hidden` flag below
                     effects_str = re.sub(r"\s*\(hide\s+[^)]+\)", "", effects_str)
                     effects_str = effects_str.strip()
                 else:
                     effects_str = "(effects (font (size 1.27 1.27)))"
 
+                # Library field visibility. Both spellings occur in the wild:
+                # KiCad 10 writes a top-level (hide yes) on the property, older
+                # libraries put `hide` (bare token or parenthesised) inside
+                # (effects ...). Either means "don't draw this field".
+                # Blank the quoted values first: a field whose *value* contains
+                # the word "hide" must not be mistaken for a hidden field.
+                prop_tokens = re.sub(QUOTED_VALUE, '""', prop_block)
+                hidden = bool(
+                    re.search(r"\(hide\s+yes\)", prop_tokens)
+                    or re.search(r"\s+hide(?=[\s)])", prop_tokens)
+                )
+
                 # Only store the first occurrence (top-level lib property, not sub-symbol)
                 if name not in result:
-                    result[name] = (dx, dy, angle, effects_str)
+                    result[name] = (dx, dy, angle, effects_str, hidden)
 
                 search_pos = abs_start + 1
 
@@ -977,19 +993,26 @@ class DynamicSymbolLoader:
         def _prop_at(
             name: str, fallback_dx: float, fallback_dy: float, fallback_angle: float = 0
         ) -> tuple:
-            """Return (abs_x, abs_y, text_angle, effects_str) for a property."""
+            """Return (abs_x, abs_y, text_angle, effects_str, hidden) for a property."""
             if name in lib_props:
-                dx, dy, text_ang, eff = lib_props[name]
+                dx, dy, text_ang, eff, hidden = lib_props[name]
             else:
                 dx, dy, text_ang, eff = fallback_dx, fallback_dy, fallback_angle, _DEFAULT_EFFECTS
+                hidden = False
             rdx, rdy = self._rotate_offset(dx, dy, angle)
-            return round(x + rdx, 3), round(y + rdy, 3), text_ang, eff
+            return round(x + rdx, 3), round(y + rdy, 3), text_ang, eff, hidden
 
-        ref_x, ref_y, ref_a, ref_eff = _prop_at("Reference", 2.032, 0, 0)
-        val_x, val_y, val_a, val_eff = _prop_at("Value", 0, 2.54, 0)
-        fp_x, fp_y, fp_a, fp_eff = _prop_at("Footprint", 0, 0, 0)
-        ds_x, ds_y, ds_a, ds_eff = _prop_at("Datasheet", 0, 0, 0)
-        desc_x, desc_y, desc_a, desc_eff = _prop_at("Description", 0, 0, 0)
+        # Reference/Value inherit the library's visibility. Power symbols
+        # (power:GND, power:+3V3, …) hide Reference by convention — the #PWR101
+        # designators are meaningless to a reader — and losing that flag on
+        # placement printed one stray designator beside every ground symbol.
+        # Footprint/Datasheet/Description stay hidden unconditionally, matching
+        # what eeschema writes on placement.
+        ref_x, ref_y, ref_a, ref_eff, ref_hide = _prop_at("Reference", 2.032, 0, 0)
+        val_x, val_y, val_a, val_eff, val_hide = _prop_at("Value", 0, 2.54, 0)
+        fp_x, fp_y, fp_a, fp_eff, _ = _prop_at("Footprint", 0, 0, 0)
+        ds_x, ds_y, ds_a, ds_eff, _ = _prop_at("Datasheet", 0, 0, 0)
+        desc_x, desc_y, desc_a, desc_eff, _ = _prop_at("Description", 0, 0, 0)
 
         def _fmt(n: float) -> str:
             """Format a coordinate the way KiCad does: integral values without a
@@ -1065,8 +1088,8 @@ class DynamicSymbolLoader:
 
         properties_str = "\n".join(
             [
-                _property("Reference", reference, ref_x, ref_y, ref_a, ref_eff, False),
-                _property("Value", value or symbol_name, val_x, val_y, val_a, val_eff, False),
+                _property("Reference", reference, ref_x, ref_y, ref_a, ref_eff, ref_hide),
+                _property("Value", value or symbol_name, val_x, val_y, val_a, val_eff, val_hide),
                 _property("Footprint", footprint, fp_x, fp_y, fp_a, fp_eff, True),
                 _property("Datasheet", ds_val, ds_x, ds_y, ds_a, ds_eff, True),
                 _property("Description", desc_val, desc_x, desc_y, desc_a, desc_eff, True),

--- a/python/commands/schematic_batch.py
+++ b/python/commands/schematic_batch.py
@@ -134,6 +134,11 @@ class SchematicBatchCommands:
                 y = (pos.get("y", 0) if isinstance(pos, dict) else 0) + origin_y
                 rotation = comp.get("rotation", 0)
                 include_pins = comp.get("includePins", False)
+                # Multi-unit parts place one unit per entry, all sharing the
+                # reference. Without this the batch could only ever place unit 1,
+                # so an FPGA split into five units had to go in one call per unit
+                # — exactly the round-trips the batch exists to avoid.
+                unit = int(comp.get("unit", 1) or 1)
 
                 try:
                     loader.add_component(
@@ -145,6 +150,7 @@ class SchematicBatchCommands:
                         footprint=footprint,
                         x=x,
                         y=y,
+                        unit=unit,
                         angle=rotation,
                         project_path=project_path,
                     )
@@ -152,6 +158,7 @@ class SchematicBatchCommands:
                     entry: Dict[str, Any] = {
                         "reference": reference,
                         "symbol": symbol,
+                        "unit": unit,
                         "snapped_position": {"x": _snap(x), "y": _snap(y)},
                     }
 
@@ -168,7 +175,7 @@ class SchematicBatchCommands:
                     block_text = None
                     raw_content = schematic_file.read_text(encoding="utf-8")
                     block_text, block_start, block_end = _find_placed_symbol_block(
-                        raw_content, reference
+                        raw_content, reference, unit
                     )
                     if auto_position_fields and block_text:
                         cx, cy = _snap(x), _snap(y)
@@ -595,9 +602,18 @@ class SchematicBatchCommands:
                             )
                             continue
 
+                        # Orient the label along the pin's OUTWARD direction, the
+                        # way eeschema does: the label is anchored at the pin
+                        # endpoint and its text runs away from the body. KiCad
+                        # pairs angle 0/90 with `justify left` (text grows right/
+                        # up) and 180/270 with `justify right` (text grows left/
+                        # down) — WireManager.add_label follows the same pairing.
+                        # Turning the label back on itself (the old 0->180 map)
+                        # laid every right-hand pin's net name across the symbol
+                        # body, and since `justify` is not separately settable it
+                        # could not be corrected without hand-editing the file.
                         raw_angle = locator.get_pin_angle(sch_path, ref, resolved_pin) or 0
-                        cardinal = round(raw_angle / 90) * 90 % 360
-                        orientation = {0: 180, 90: 270, 180: 0, 270: 90}.get(cardinal, 0)
+                        orientation = int(round(raw_angle / 90) * 90) % 360
 
                         # Facing-label auto-wiring is only meaningful for local labels;
                         # global labels join their net by name (one placed per pin).

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -333,6 +333,7 @@ class SchematicHandlersMixin:
             schematic_path = params.get("schematicPath")
             reference = params.get("reference")
             delete_attached_labels = bool(params.get("deleteAttachedLabels", False))
+            unit = params.get("unit")
 
             if not schematic_path:
                 return {"success": False, "message": "schematicPath is required"}
@@ -392,10 +393,27 @@ class SchematicHandlersMixin:
                     r'\(property\s+"Reference"\s+"' + re.escape(reference) + r'"',
                     block_text,
                 ):
+                    # A multi-unit part places each unit as its own block under
+                    # the same reference, so deleting by reference alone takes
+                    # the whole part. `unit` narrows it to one placement.
+                    if unit is not None:
+                        um = re.search(r"\(unit\s+(\d+)\)", block_text)
+                        if not um or int(um.group(1)) != int(unit):
+                            search_start = end + 1
+                            continue
                     blocks_to_delete.append((pos, end))
                 search_start = end + 1
 
             if not blocks_to_delete:
+                if unit is not None:
+                    return {
+                        "success": False,
+                        "message": (
+                            f"Component '{reference}' has no unit {unit} in this schematic "
+                            "(note: this tool removes schematic symbols, use delete_component "
+                            "for PCB footprints)"
+                        ),
+                    }
                 return {
                     "success": False,
                     "message": f"Component '{reference}' not found in schematic (note: this tool removes schematic symbols, use delete_component for PCB footprints)",
@@ -407,7 +425,9 @@ class SchematicHandlersMixin:
             label_cleanup_warning: Optional[str] = None
             if delete_attached_labels:
                 try:
-                    target_pin_positions = self._pin_positions_for_reference(content, reference)
+                    target_pin_positions = self._pin_positions_for_reference(
+                        content, reference, unit
+                    )
                     if not target_pin_positions:
                         logger.warning(
                             "deleteAttachedLabels: no pin positions resolvable "
@@ -459,9 +479,14 @@ class SchematicHandlersMixin:
             return {"success": False, "message": str(e)}
 
     @staticmethod
-    def _pin_positions_for_reference(content: str, reference: str) -> List[Tuple[float, float]]:
+    def _pin_positions_for_reference(
+        content: str, reference: str, unit: Optional[int] = None
+    ) -> List[Tuple[float, float]]:
         """World (x, y) positions of every pin of every placed instance whose
         Reference property equals ``reference``.
+
+        ``unit`` restricts this to one placement of a multi-unit part, matching
+        the units the caller actually deleted.
 
         Builds a mini document of [lib_symbols] + [matching placed symbols]
         and reuses WireManager._collect_pin_positions, which applies the
@@ -471,6 +496,16 @@ class SchematicHandlersMixin:
         sym = sexpdata.Symbol("symbol")
         lib_symbols = sexpdata.Symbol("lib_symbols")
         prop = sexpdata.Symbol("property")
+        unit_sym = sexpdata.Symbol("unit")
+
+        def _instance_unit(instance: list) -> Optional[int]:
+            for part in instance[1:]:
+                if isinstance(part, list) and len(part) >= 2 and part[0] == unit_sym:
+                    try:
+                        return int(part[1])
+                    except (TypeError, ValueError):
+                        return None
+            return None
 
         data = sexpdata.loads(content)
         mini_doc: list = []
@@ -491,7 +526,8 @@ class SchematicHandlersMixin:
                     and str(part[1]) == "Reference"
                     and str(part[2]) == reference
                 ):
-                    mini_doc.append(item)
+                    if unit is None or _instance_unit(item) == int(unit):
+                        mini_doc.append(item)
                     break
         return WireManager._collect_pin_positions(mini_doc)
 
@@ -1305,7 +1341,8 @@ class SchematicHandlersMixin:
             net_name = params.get("netName")
             position = params.get("position")
             label_type = params.get("labelType", "label")
-            orientation = params.get("orientation", 0)
+            orientation_param = params.get("orientation")
+            orientation = 0 if orientation_param is None else orientation_param
             component_ref = params.get("componentRef")
             pin_number = params.get("pinNumber")
 
@@ -1338,6 +1375,26 @@ class SchematicHandlersMixin:
                 logger.info(
                     f"Snapped label '{net_name}' to pin {component_ref}/{pin_number} at {position}"
                 )
+
+                # Orient the label along the pin unless the caller asked for a
+                # specific angle. A label inherits its text direction from its
+                # angle: 0 grows right, 180 grows left (WireManager.add_label
+                # pairs the matching justify). Defaulting to 0 on a left-facing
+                # pin — or 180 on a right-facing one — lays the text back over
+                # the symbol body, and since `justify` is not separately
+                # settable, callers could not fix it without editing the file.
+                if orientation_param is None:
+                    pin_angle = locator.get_pin_angle(
+                        Path(schematic_path), component_ref, str(pin_number)
+                    )
+                    if pin_angle is not None:
+                        # Snap the outward bearing (0=right, 90=up, 180=left,
+                        # 270=down) to the four orientations KiCad allows.
+                        orientation = int(round(pin_angle / 90.0) * 90) % 360
+                        logger.info(
+                            f"Derived label orientation {orientation}° from pin "
+                            f"{component_ref}/{pin_number} outward angle {pin_angle:.1f}°"
+                        )
             elif position is None:
                 return {
                     "success": False,
@@ -1390,6 +1447,7 @@ class SchematicHandlersMixin:
                 "success": True,
                 "message": f"Added net label '{net_name}' at {position}",
                 "actual_position": position,
+                "orientation": orientation,
             }
             if snapped_to_pin:
                 response["snapped_to_pin"] = snapped_to_pin
@@ -1889,6 +1947,19 @@ class SchematicHandlersMixin:
             logger.error(traceback.format_exc())
             return {"success": False, "message": str(e)}
 
+    @staticmethod
+    def _unit_not_found_message(sch_data: list, reference: str, unit: Any) -> str:
+        """Explain a failed symbol lookup, naming the units that do exist."""
+        from commands.wire_dragger import WireDragger
+
+        if unit is None:
+            return f"Component {reference} not found"
+        units = WireDragger.list_symbol_units(sch_data, reference)
+        if not units:
+            return f"Component {reference} not found"
+        placed = ", ".join(str(u) for u in sorted(set(units)))
+        return f"Component {reference} has no unit {unit}; units placed here: {placed}"
+
     def _handle_move_schematic_component(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Move a schematic component to a new position, dragging connected wires."""
         logger.info("Moving schematic component")
@@ -1901,6 +1972,8 @@ class SchematicHandlersMixin:
             new_x = position.get("x")
             new_y = position.get("y")
             preserve_wires = params.get("preserveWires", True)
+            straighten = params.get("straightenWires", True)
+            unit = params.get("unit")
 
             if not schematic_path or not reference:
                 return {
@@ -1917,9 +1990,12 @@ class SchematicHandlersMixin:
                 sch_data = sexpdata.loads(f.read())
 
             # Find symbol and record old position
-            found = WireDragger.find_symbol(sch_data, reference)
+            found = WireDragger.find_symbol(sch_data, reference, unit)
             if found is None:
-                return {"success": False, "message": f"Component {reference} not found"}
+                return {
+                    "success": False,
+                    "message": self._unit_not_found_message(sch_data, reference, unit),
+                }
             _, old_x, old_y = found[0], found[1], found[2]
             old_position = {"x": old_x, "y": old_y}
 
@@ -1927,7 +2003,7 @@ class SchematicHandlersMixin:
             if preserve_wires:
                 # Compute pin world positions before and after the move
                 pin_positions = WireDragger.compute_pin_positions(
-                    sch_data, reference, float(new_x), float(new_y)
+                    sch_data, reference, float(new_x), float(new_y), unit
                 )
                 # Build old→new coordinate map (deduplicate coincident pins)
                 old_to_new = {}
@@ -1941,17 +2017,29 @@ class SchematicHandlersMixin:
                         continue
                     old_to_new[old_xy] = new_xy
 
-                drag_summary = WireDragger.drag_wires(sch_data, old_to_new)
+                # Everything that must stay put while bends are straightened:
+                # the pins of every other symbol, plus this symbol's own pins at
+                # their new positions (they are the ends we just dragged).
+                anchors = set(
+                    WireDragger.get_all_stationary_pin_positions(sch_data, reference, unit).keys()
+                )
+                anchors.update(new_xy for (_old, new_xy) in pin_positions.values())
+
+                drag_summary = WireDragger.drag_wires(
+                    sch_data, old_to_new, anchor_points=anchors, straighten=straighten
+                )
 
                 # Synthesize wires for touching-pin connections after dragging,
                 # so drag_wires doesn't accidentally move and collapse the new wire.
                 wires_synthesized = WireDragger.synthesize_touching_pin_wires(
-                    sch_data, reference, pin_positions
+                    sch_data, reference, pin_positions, moved_unit=unit
                 )
                 drag_summary["wires_synthesized"] = wires_synthesized
 
             # Update symbol position
-            WireDragger.update_symbol_position(sch_data, reference, float(new_x), float(new_y))
+            WireDragger.update_symbol_position(
+                sch_data, reference, float(new_x), float(new_y), unit
+            )
 
             WireManager.sync_junctions(sch_data)
 
@@ -1962,10 +2050,14 @@ class SchematicHandlersMixin:
                 "success": True,
                 "oldPosition": old_position,
                 "newPosition": {"x": new_x, "y": new_y},
+                "unit": unit,
                 "wiresMoved": drag_summary.get("endpoints_moved", 0),
                 "wiresRemoved": drag_summary.get("wires_removed", 0),
                 "wiresSynthesized": drag_summary.get("wires_synthesized", 0),
                 "labelsMoved": drag_summary.get("labels_moved", 0),
+                "noConnectsMoved": drag_summary.get("no_connects_moved", 0),
+                "wiresStraightened": drag_summary.get("wires_straightened", 0),
+                "wiresLeftDiagonal": drag_summary.get("wires_left_diagonal", 0),
             }
 
         except Exception as e:
@@ -1986,6 +2078,8 @@ class SchematicHandlersMixin:
             reference = params.get("reference")
             angle = params.get("angle", 0)
             mirror = params.get("mirror")  # "x", "y", or None
+            straighten = params.get("straightenWires", True)
+            unit = params.get("unit")
 
             if not schematic_path or not reference:
                 return {
@@ -1996,9 +2090,12 @@ class SchematicHandlersMixin:
             with open(schematic_path, "r", encoding="utf-8") as f:
                 sch_data = _sexpdata.loads(f.read())
 
-            found = WireDragger.find_symbol(sch_data, reference)
+            found = WireDragger.find_symbol(sch_data, reference, unit)
             if found is None:
-                return {"success": False, "message": f"Component {reference} not found"}
+                return {
+                    "success": False,
+                    "message": self._unit_not_found_message(sch_data, reference, unit),
+                }
 
             # Determine new mirror state: explicit param overrides; None preserves existing
             _, _, _, _, _, old_mirror_x, old_mirror_y = found
@@ -2013,7 +2110,7 @@ class SchematicHandlersMixin:
 
             # Compute pin world positions before and after the transform
             pin_positions = WireDragger.compute_pin_positions_for_rotation(
-                sch_data, reference, float(angle), new_mirror_x, new_mirror_y
+                sch_data, reference, float(angle), new_mirror_x, new_mirror_y, unit
             )
 
             # Build old→new map (skip pins that don't move)
@@ -2030,11 +2127,17 @@ class SchematicHandlersMixin:
                 old_to_new[old_xy] = new_xy
 
             # Drag connected wires to follow pins
-            drag_summary = WireDragger.drag_wires(sch_data, old_to_new)
+            anchors = set(
+                WireDragger.get_all_stationary_pin_positions(sch_data, reference, unit).keys()
+            )
+            anchors.update(new_xy for (_old, new_xy) in pin_positions.values())
+            drag_summary = WireDragger.drag_wires(
+                sch_data, old_to_new, anchor_points=anchors, straighten=straighten
+            )
 
             # Update the symbol's rotation and mirror token in sexpdata
             WireDragger.update_symbol_rotation_mirror(
-                sch_data, reference, float(angle), effective_mirror
+                sch_data, reference, float(angle), effective_mirror, unit
             )
 
             WireManager.sync_junctions(sch_data)
@@ -2045,11 +2148,15 @@ class SchematicHandlersMixin:
             return {
                 "success": True,
                 "reference": reference,
+                "unit": unit,
                 "angle": angle,
                 "mirror": effective_mirror,
                 "wiresMoved": drag_summary.get("endpoints_moved", 0),
                 "wiresRemoved": drag_summary.get("wires_removed", 0),
                 "labelsMoved": drag_summary.get("labels_moved", 0),
+                "noConnectsMoved": drag_summary.get("no_connects_moved", 0),
+                "wiresStraightened": drag_summary.get("wires_straightened", 0),
+                "wiresLeftDiagonal": drag_summary.get("wires_left_diagonal", 0),
             }
 
         except Exception as e:

--- a/python/commands/schematic_text_utils.py
+++ b/python/commands/schematic_text_utils.py
@@ -45,8 +45,14 @@ def _find_matching_paren(s: str, start: int) -> int:
     return -1
 
 
-def _find_placed_symbol_block(content: str, reference: str) -> Tuple[Optional[str], int, int]:
-    """Find the placed symbol block for *reference*. Returns (block, start, end) or (None, -1, -1)."""
+def _find_placed_symbol_block(
+    content: str, reference: str, unit: Optional[int] = None
+) -> Tuple[Optional[str], int, int]:
+    """Find the placed symbol block for *reference*. Returns (block, start, end) or (None, -1, -1).
+
+    ``unit`` picks one placement of a multi-unit part, whose units all carry the
+    same reference; without it the first block in file order wins.
+    """
     lib_sym_pos = content.find("(lib_symbols")
     lib_sym_end = _find_matching_paren(content, lib_sym_pos) if lib_sym_pos >= 0 else -1
     pattern = re.compile(r'\(symbol\s+\(lib_id\s+"')
@@ -65,7 +71,11 @@ def _find_placed_symbol_block(content: str, reference: str) -> Tuple[Optional[st
             continue
         block_text = content[pos : end + 1]
         if re.search(r'\(property\s+"Reference"\s+"' + re.escape(reference) + r'"', block_text):
-            return block_text, pos, end
+            if unit is None:
+                return block_text, pos, end
+            um = re.search(r"\(unit\s+(\d+)\)", block_text)
+            if um and int(um.group(1)) == int(unit):
+                return block_text, pos, end
         search_start = end + 1
     return None, -1, -1
 

--- a/python/commands/wire_dragger.py
+++ b/python/commands/wire_dragger.py
@@ -7,7 +7,7 @@ All methods operate on in-memory sexpdata lists (no disk I/O).
 import logging
 import math
 import uuid
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import sexpdata
 from sexpdata import Symbol
@@ -30,7 +30,9 @@ _K = {
         "label",
         "global_label",
         "hierarchical_label",
+        "no_connect",
         "property",
+        "unit",
         "stroke",
         "width",
         "type",
@@ -58,12 +60,18 @@ class WireDragger:
     """Pure-logic helpers for wire-endpoint dragging during component moves."""
 
     @staticmethod
-    def find_symbol(sch_data: list, reference: str) -> Any:
+    def find_symbol(sch_data: list, reference: str, unit: Optional[int] = None) -> Any:
         """
         Find a placed symbol by reference designator.
 
         Returns (symbol_item, old_x, old_y, rotation, lib_id, mirror_x, mirror_y)
         or None if the reference is not found.
+
+        unit: for a multi-unit part every unit is placed as its own (symbol ...)
+            block under one shared reference (U201 A-E), so a bare reference is
+            ambiguous — which block you get depends on file order. Passing the
+            unit number selects a specific one; None keeps the historical
+            first-match behaviour, which is exact for single-unit parts.
 
         mirror_x=True means the symbol has (mirror x) — flips the X local axis.
         mirror_y=True means the symbol has (mirror y) — flips the Y local axis.
@@ -89,6 +97,9 @@ class WireDragger:
                         ref_val = str(sub[2]).strip('"')
                         break
             if ref_val is None or ref_val.rstrip("_") != reference:
+                continue
+
+            if unit is not None and WireDragger._symbol_unit(item) != int(unit):
                 continue
 
             old_x = old_y = rotation = 0.0
@@ -119,12 +130,55 @@ class WireDragger:
         return None
 
     @staticmethod
-    def get_pin_defs(sch_data: list, lib_id: str) -> Dict:
+    def _symbol_unit(item: list) -> Optional[int]:
+        """Return the (unit N) of a placed symbol block, or None if absent."""
+        unit_k = _K["unit"]
+        for sub_item in item[1:]:
+            if isinstance(sub_item, list) and sub_item and sub_item[0] == unit_k:
+                if len(sub_item) >= 2:
+                    try:
+                        return int(sub_item[1])
+                    except (TypeError, ValueError):
+                        return None
+        return None
+
+    @staticmethod
+    def list_symbol_units(sch_data: list, reference: str) -> List[int]:
+        """Return the units placed for *reference*, in file order.
+
+        Used to tell a caller which units exist when it has to pick one.
+        """
+        sym_k = _K["symbol"]
+        prop_k = _K["property"]
+        units: List[int] = []
+        for item in sch_data:
+            if not (isinstance(item, list) and item and item[0] == sym_k):
+                continue
+            ref_val = None
+            for sub_item in item[1:]:
+                if isinstance(sub_item, list) and len(sub_item) >= 3 and sub_item[0] == prop_k:
+                    if str(sub_item[1]).strip('"') == "Reference":
+                        ref_val = str(sub_item[2]).strip('"')
+                        break
+            if ref_val is None or ref_val.rstrip("_") != reference:
+                continue
+            u = WireDragger._symbol_unit(item)
+            if u is not None:
+                units.append(u)
+        return units
+
+    @staticmethod
+    def get_pin_defs(sch_data: list, lib_id: str, unit: Optional[int] = None) -> Dict:
         """
         Get pin definitions from lib_symbols for the given lib_id.
 
         Returns the same dict format as PinLocator.parse_symbol_definition:
         {pin_num: {"x": ..., "y": ..., ...}}.
+
+        unit: keep only the pins belonging to that unit (plus unit 0, which is
+            common to every unit). Without it a multi-unit part reports all its
+            pins for one placement, and the caller would drag wires attached to
+            units that never moved.
         """
         from commands.pin_locator import PinLocator
 
@@ -141,7 +195,14 @@ class WireDragger:
                     continue
                 name = str(sym_def[1]).strip('"')
                 if name == lib_id:
-                    return PinLocator.parse_symbol_definition(sym_def)
+                    pins = PinLocator.parse_symbol_definition(sym_def)
+                    if unit is None:
+                        return pins
+                    return {
+                        num: pin
+                        for num, pin in pins.items()
+                        if pin.get("unit") in (0, None, int(unit))
+                    }
             break  # only one lib_symbols section
         return {}
 
@@ -187,6 +248,7 @@ class WireDragger:
         reference: str,
         new_x: float,
         new_y: float,
+        unit: Optional[int] = None,
     ) -> Dict[str, Tuple[Tuple[float, float], Tuple[float, float]]]:
         """
         Compute world pin positions before and after a component move.
@@ -194,12 +256,12 @@ class WireDragger:
         Returns {pin_num: (old_world_xy, new_world_xy)}.
         old_world_xy uses the symbol's current position; new_world_xy uses (new_x, new_y).
         """
-        found = WireDragger.find_symbol(sch_data, reference)
+        found = WireDragger.find_symbol(sch_data, reference, unit)
         if found is None:
             return {}
         _, old_x, old_y, rotation, lib_id, mirror_x, mirror_y = found
 
-        pins = WireDragger.get_pin_defs(sch_data, lib_id)
+        pins = WireDragger.get_pin_defs(sch_data, lib_id, unit)
         result: Dict[str, Tuple] = {}
         for pin_num, pin in pins.items():
             px, py = pin["x"], pin["y"]
@@ -222,6 +284,7 @@ class WireDragger:
         new_rotation: float,
         new_mirror_x: bool,
         new_mirror_y: bool,
+        unit: Optional[int] = None,
     ) -> Dict[str, Tuple[Tuple[float, float], Tuple[float, float]]]:
         """
         Compute world pin positions before and after a rotation/mirror change.
@@ -229,12 +292,12 @@ class WireDragger:
         The symbol stays at the same (x, y); only the rotation and mirror state change.
         Returns {pin_num: (old_world_xy, new_world_xy)}.
         """
-        found = WireDragger.find_symbol(sch_data, reference)
+        found = WireDragger.find_symbol(sch_data, reference, unit)
         if found is None:
             return {}
         _, sym_x, sym_y, old_rotation, lib_id, old_mirror_x, old_mirror_y = found
 
-        pins = WireDragger.get_pin_defs(sch_data, lib_id)
+        pins = WireDragger.get_pin_defs(sch_data, lib_id, unit)
         result: Dict[str, Tuple] = {}
         for pin_num, pin in pins.items():
             px, py = pin["x"], pin["y"]
@@ -256,6 +319,7 @@ class WireDragger:
         reference: str,
         new_rotation: float,
         new_mirror: Optional[str],
+        unit: Optional[int] = None,
     ) -> bool:
         """
         Update the rotation in (at x y rot) and the (mirror x/y) token for a symbol.
@@ -263,7 +327,7 @@ class WireDragger:
         new_mirror: "x", "y", or None (removes any existing mirror token).
         Returns True if the symbol was found and updated.
         """
-        found = WireDragger.find_symbol(sch_data, reference)
+        found = WireDragger.find_symbol(sch_data, reference, unit)
         if found is None:
             return False
         item = found[0]
@@ -297,22 +361,41 @@ class WireDragger:
         sch_data: list,
         old_to_new: Dict[Tuple[float, float], Tuple[float, float]],
         eps: float = EPS,
+        anchor_points: Optional[Set[Tuple[float, float]]] = None,
+        straighten: bool = True,
     ) -> Dict:
         """
-        Move wire endpoints and junctions from old positions to new positions.
+        Move wire endpoints, junctions, net labels and no-connect flags from old
+        positions to new positions.
         Removes zero-length wires that result from the move.
         Modifies sch_data in place.
 
         old_to_new: {(old_x, old_y): (new_x, new_y)}
+        anchor_points: coordinates that must not be shifted by the orthogonality
+            pass — typically the pins of stationary symbols plus the moved
+            symbol's own new pin positions.
+        straighten: restore right angles on segments that the move turned
+            diagonal (see :meth:`_straighten_bent_wires`).
 
-        Returns {'endpoints_moved': N, 'wires_removed': M, 'labels_moved': L}.
+        Returns {'endpoints_moved': N, 'wires_removed': M, 'labels_moved': L,
+        'no_connects_moved': K, 'wires_straightened': S, 'wires_left_diagonal': D}.
         """
         wire_k = _K["wire"]
         pts_k = _K["pts"]
         xy_k = _K["xy"]
         junction_k = _K["junction"]
         at_k = _K["at"]
+        no_connect_k = _K["no_connect"]
         label_ks = (_K["label"], _K["global_label"], _K["hierarchical_label"])
+
+        # Snapshot every wire's endpoints before anything moves. The
+        # orthogonality pass below needs to know which segments *used* to be
+        # axis-aligned; once the first pass has run, that information is gone.
+        pre_move: Dict[int, Tuple[Tuple[float, float], Tuple[float, float]]] = {}
+        for item in sch_data:
+            seg = WireDragger._wire_endpoints(item)
+            if seg is not None:
+                pre_move[id(item)] = seg
 
         def find_new(x: float, y: float) -> Optional[Tuple[float, float]]:
             for (ox, oy), (nx, ny) in old_to_new.items():
@@ -386,19 +469,234 @@ class WireDragger:
                         labels_moved += 1
                     break
 
+        # Fourth pass: drag no-connect flags sitting on a moved pin. A flag left
+        # behind reads to KiCad as two separate errors — a dangling no-connect
+        # where the flag stayed and an unconnected pin where the symbol went —
+        # neither of which describes anything the user did.
+        no_connects_moved = 0
+        for item in sch_data:
+            if not (isinstance(item, list) and item and item[0] == no_connect_k):
+                continue
+            for sub in item[1:]:
+                if isinstance(sub, list) and sub and sub[0] == at_k and len(sub) >= 3:
+                    nc = find_new(float(sub[1]), float(sub[2]))
+                    if nc is not None:
+                        sub[1] = nc[0]
+                        sub[2] = nc[1]
+                        no_connects_moved += 1
+                    break
+
+        straighten_summary = {"wires_straightened": 0, "wires_left_diagonal": 0}
+        if straighten:
+            straighten_summary = WireDragger._straighten_bent_wires(
+                sch_data, pre_move, anchor_points or set(), eps
+            )
+
         return {
             "endpoints_moved": endpoints_moved,
             "wires_removed": len(zero_length_indices),
             "labels_moved": labels_moved,
+            "no_connects_moved": no_connects_moved,
+            **straighten_summary,
         }
 
     @staticmethod
-    def update_symbol_position(sch_data: list, reference: str, new_x: float, new_y: float) -> bool:
+    def _wire_endpoints(item):
+        """Return ((x1, y1), (x2, y2)) for a wire s-expression, or None.
+
+        Only two-point segments are considered: that is what eeschema writes for
+        a wire, and the orthogonality logic below is defined for a segment.
+        """
+        if not (isinstance(item, list) and item and item[0] == _K["wire"]):
+            return None
+        for sub in item[1:]:
+            if isinstance(sub, list) and sub and sub[0] == _K["pts"]:
+                xy_items = [
+                    q for q in sub[1:] if isinstance(q, list) and len(q) >= 3 and q[0] == _K["xy"]
+                ]
+                if len(xy_items) != 2:
+                    return None
+                return (
+                    (float(xy_items[0][1]), float(xy_items[0][2])),
+                    (float(xy_items[1][1]), float(xy_items[1][2])),
+                )
+        return None
+
+    @staticmethod
+    def _wire_xy_nodes(item) -> List[list]:
+        """Return the mutable (xy ...) sub-lists of a wire, in file order."""
+        for sub in item[1:]:
+            if isinstance(sub, list) and sub and sub[0] == _K["pts"]:
+                return [
+                    q for q in sub[1:] if isinstance(q, list) and len(q) >= 3 and q[0] == _K["xy"]
+                ]
+        return []
+
+    @staticmethod
+    def _move_point(
+        sch_data: list,
+        old_pt: Tuple[float, float],
+        new_pt: Tuple[float, float],
+        eps: float = EPS,
+    ) -> int:
+        """Move every item anchored at *old_pt* to *new_pt*.
+
+        Wire endpoints, junctions, labels and no-connect flags all move together,
+        so whatever met at that coordinate still meets after the move.
+        Returns the number of coordinates updated.
+        """
+        at_k = _K["at"]
+        moved = 0
+        for item in sch_data:
+            if not (isinstance(item, list) and item):
+                continue
+            if item[0] == _K["wire"]:
+                for xy_item in WireDragger._wire_xy_nodes(item):
+                    if _coords_match(
+                        float(xy_item[1]), float(xy_item[2]), old_pt[0], old_pt[1], eps
+                    ):
+                        xy_item[1], xy_item[2] = new_pt
+                        moved += 1
+            elif item[0] in (
+                _K["junction"],
+                _K["no_connect"],
+                _K["label"],
+                _K["global_label"],
+                _K["hierarchical_label"],
+            ):
+                for sub in item[1:]:
+                    if isinstance(sub, list) and sub and sub[0] == at_k and len(sub) >= 3:
+                        if _coords_match(float(sub[1]), float(sub[2]), old_pt[0], old_pt[1], eps):
+                            sub[1], sub[2] = new_pt
+                            moved += 1
+                        break
+        return moved
+
+    @staticmethod
+    def _straighten_bent_wires(
+        sch_data: list,
+        pre_move: Dict[int, Tuple[Tuple[float, float], Tuple[float, float]]],
+        anchor_points: Set[Tuple[float, float]],
+        eps: float = EPS,
+        max_passes: int = 8,
+    ) -> Dict:
+        """Restore right angles on segments the drag turned diagonal.
+
+        Dragging a pin moves only the endpoint that touches it. A wire routed
+        pin -> corner -> corner -> pin is a chain of separate segments, so the
+        first segment ends up diagonal while the corner it leads to stays put --
+        the trace stops being orthogonal and its bend lands off-grid, which is
+        what eeschema then reports as endpoint_off_grid.
+
+        The fix is what dragging in eeschema does: carry the corner along. For
+        each segment that *was* axis-aligned, had exactly one endpoint dragged
+        and is now diagonal, the free end is shifted onto the dragged end's axis.
+        That shift moves everything meeting at the corner, which can bend the
+        next segment in the chain -- hence the repeat passes, which settle once
+        nothing else needs straightening.
+
+        A free end is left alone (and the segment left diagonal) when it is a
+        pin of a stationary symbol, an explicit junction, or a fork where three
+        or more wire ends meet: moving those would drag unrelated wiring or tear
+        a connection apart. Those cases are counted, not silently reshaped.
+        """
+        wires = [item for item in sch_data if WireDragger._wire_endpoints(item) is not None]
+        junction_points = set()
+        for item in sch_data:
+            if not (isinstance(item, list) and item and item[0] == _K["junction"]):
+                continue
+            for sub in item[1:]:
+                if isinstance(sub, list) and sub and sub[0] == _K["at"] and len(sub) >= 3:
+                    junction_points.add((round(float(sub[1]), 6), round(float(sub[2]), 6)))
+                    break
+
+        def is_anchored(pt: Tuple[float, float]) -> bool:
+            if (round(pt[0], 6), round(pt[1], 6)) in junction_points:
+                return True
+            if any(_coords_match(pt[0], pt[1], ax, ay, eps) for (ax, ay) in anchor_points):
+                return True
+            # Fork: three or more wire ends meeting here.
+            touching = 0
+            for w in wires:
+                ends = WireDragger._wire_endpoints(w)
+                if ends is None:
+                    continue
+                for end in ends:
+                    if _coords_match(pt[0], pt[1], end[0], end[1], eps):
+                        touching += 1
+            return touching >= 3
+
+        straightened = 0
+        left_diagonal = 0
+
+        for _pass in range(max_passes):
+            changed = False
+            left_diagonal = 0
+            for wire in wires:
+                orig = pre_move.get(id(wire))
+                cur = WireDragger._wire_endpoints(wire)
+                if orig is None or cur is None:
+                    continue
+
+                was_h = abs(orig[0][1] - orig[1][1]) < eps
+                was_v = abs(orig[0][0] - orig[1][0]) < eps
+                if not (was_h or was_v):
+                    continue  # deliberately diagonal before the move; leave it
+                if abs(cur[0][0] - cur[1][0]) < eps or abs(cur[0][1] - cur[1][1]) < eps:
+                    continue  # still axis-aligned
+
+                dragged = [
+                    i
+                    for i in (0, 1)
+                    if not _coords_match(cur[i][0], cur[i][1], orig[i][0], orig[i][1], eps)
+                ]
+                if len(dragged) != 1:
+                    continue  # both ends moved (or neither): not ours to fix
+                m = dragged[0]
+                free_pt = cur[1 - m]
+                if is_anchored(free_pt):
+                    left_diagonal += 1
+                    continue
+
+                # A horizontal segment keeps its X span and follows the dragged
+                # end's Y; a vertical one mirrors that.
+                target = (free_pt[0], cur[m][1]) if was_h else (cur[m][0], free_pt[1])
+                if _coords_match(target[0], target[1], free_pt[0], free_pt[1], eps):
+                    continue
+
+                WireDragger._move_point(sch_data, free_pt, target, eps)
+                straightened += 1
+                changed = True
+            if not changed:
+                break
+        else:
+            logger.warning(
+                "Orthogonality pass hit its %d-pass limit; some segments may still be diagonal",
+                max_passes,
+            )
+
+        if left_diagonal:
+            logger.info(
+                "%d segment(s) left diagonal: the free end is pinned by a "
+                "junction, a fork, or another component's pin",
+                left_diagonal,
+            )
+
+        return {"wires_straightened": straightened, "wires_left_diagonal": left_diagonal}
+
+    @staticmethod
+    def update_symbol_position(
+        sch_data: list,
+        reference: str,
+        new_x: float,
+        new_y: float,
+        unit: Optional[int] = None,
+    ) -> bool:
         """
         Update the (at x y rot) of the named symbol in sch_data.
         Returns True if the symbol was found and updated.
         """
-        found = WireDragger.find_symbol(sch_data, reference)
+        found = WireDragger.find_symbol(sch_data, reference, unit)
         if found is None:
             return False
         item = found[0]
@@ -444,13 +742,18 @@ class WireDragger:
     def get_all_stationary_pin_positions(
         sch_data: list,
         moved_reference: str,
+        moved_unit: Optional[int] = None,
     ) -> Dict[Tuple[float, float], str]:
         """
         Return a map of {world_xy: reference} for every pin of every symbol
-        in sch_data *except* moved_reference.
+        in sch_data *except* the one that moved.
 
         This is used to detect pins of stationary components that coincide
         with pins of the moved component (touching-pin connections).
+
+        moved_unit: when a single unit of a multi-unit part moved, the part's
+            other units did not — they are stationary and their pins belong in
+            the map.
         """
         sym_k = _K["symbol"]
         prop_k = _K["property"]
@@ -466,17 +769,20 @@ class WireDragger:
                     if str(sub[1]).strip('"') == "Reference":
                         ref_val = str(sub[2]).strip('"')
                         break
-            if ref_val is None or ref_val == moved_reference:
+            item_unit = WireDragger._symbol_unit(item)
+            if ref_val is None:
+                continue
+            if ref_val == moved_reference and (moved_unit is None or item_unit == moved_unit):
                 continue
             # Skip template / power symbols whose references start with special chars
             # but we still want to handle them — no filtering needed here.
 
             # Find lib_id and position for this symbol
-            found = WireDragger.find_symbol(sch_data, ref_val)
+            found = WireDragger.find_symbol(sch_data, ref_val, item_unit)
             if found is None:
                 continue
             _, sx, sy, rotation, lib_id, mirror_x, mirror_y = found
-            pins = WireDragger.get_pin_defs(sch_data, lib_id)
+            pins = WireDragger.get_pin_defs(sch_data, lib_id, item_unit)
             for pin_num, pin in pins.items():
                 wx, wy = WireDragger.pin_world_xy(
                     pin["x"], pin["y"], sx, sy, rotation, mirror_x, mirror_y
@@ -492,6 +798,7 @@ class WireDragger:
         moved_reference: str,
         pin_positions: Dict[str, Tuple[Tuple[float, float], Tuple[float, float]]],
         eps: float = EPS,
+        moved_unit: Optional[int] = None,
     ) -> int:
         """
         Detect touching-pin connections and synthesize wire segments to bridge gaps
@@ -509,7 +816,9 @@ class WireDragger:
         if not pin_positions:
             return 0
 
-        stationary_pins = WireDragger.get_all_stationary_pin_positions(sch_data, moved_reference)
+        stationary_pins = WireDragger.get_all_stationary_pin_positions(
+            sch_data, moved_reference, moved_unit
+        )
         if not stationary_pins:
             return 0
 

--- a/src/tools/schematic-batch.ts
+++ b/src/tools/schematic-batch.ts
@@ -10,7 +10,7 @@ export function registerSchematicBatchTools(server: McpServer, callKicadScript: 
   // Add many components at once
   server.tool(
     "batch_add_components",
-    "Add multiple components to a schematic in one call (far fewer round-trips than add_schematic_component). Each component: {symbol:'Library:Name', reference, value?, footprint?, position:{x,y}, rotation?, includePins?}. Reference/Value fields are auto-positioned outside the body (disable with auto_position_fields=false). Returns per-component snapped position, field positions, body_bbox, and an overall placement_bbox.",
+    "Add multiple components to a schematic in one call (far fewer round-trips than add_schematic_component). Each component: {symbol:'Library:Name', reference, value?, footprint?, position:{x,y}, rotation?, includePins?, unit?}. Multi-unit parts are placed one entry per unit, sharing a reference. Reference/Value fields are auto-positioned outside the body (disable with auto_position_fields=false). Returns per-component snapped position, field positions, body_bbox, and an overall placement_bbox.",
     {
       schematicPath: z.string().describe("Path to the .kicad_sch file"),
       components: z
@@ -23,6 +23,14 @@ export function registerSchematicBatchTools(server: McpServer, callKicadScript: 
             position: z.object({ x: z.number(), y: z.number() }).optional(),
             rotation: z.number().optional(),
             includePins: z.boolean().optional(),
+            unit: z
+              .number()
+              .int()
+              .optional()
+              .describe(
+                "Unit of a multi-unit part (1=A, 2=B, …), default 1. Place each unit " +
+                  "as its own entry, all sharing the same reference.",
+              ),
           }),
         )
         .describe("Components to place"),

--- a/src/tools/schematic.ts
+++ b/src/tools/schematic.ts
@@ -153,8 +153,21 @@ To remove a footprint from a PCB, use delete_component instead.`,
           "Also delete net labels sitting on the deleted component's pin positions, " +
             "unless still attached to a wire or another component's pin (default false)",
         ),
+      unit: z
+        .number()
+        .int()
+        .optional()
+        .describe(
+          "Unit of a multi-unit part (1=A, 2=B, …) to remove. Every unit shares one " +
+            "reference, so without this ALL units of the part are deleted.",
+        ),
     },
-    async (args: { schematicPath: string; reference: string; deleteAttachedLabels?: boolean }) => {
+    async (args: {
+      schematicPath: string;
+      reference: string;
+      deleteAttachedLabels?: boolean;
+      unit?: number;
+    }) => {
       const result = await callKicadScript("delete_schematic_component", args);
       if (result.success) {
         const labelNote =
@@ -610,7 +623,14 @@ edit_schematic_component and set its value to an empty string.`,
         .enum(["label", "global_label", "hierarchical_label"])
         .optional()
         .describe("Label type (default: label)"),
-      orientation: z.number().optional().describe("Rotation angle 0/90/180/270 (default: 0)"),
+      orientation: z
+        .number()
+        .optional()
+        .describe(
+          "Rotation angle 0/90/180/270. Omit it when snapping to a pin: the label " +
+            "is then oriented along the pin's outward direction so the text runs " +
+            "away from the symbol body instead of over it. Defaults to 0 otherwise.",
+        ),
     },
     async (args: {
       schematicPath: string;
@@ -1099,7 +1119,7 @@ edit_schematic_component and set its value to an empty string.`,
   // Move a placed symbol, dragging connected wires
   server.tool(
     "move_schematic_component",
-    "Move a placed symbol to a new position in the schematic. By default (preserveWires=true) wire endpoints touching the component's pins are stretched to follow the new position.",
+    "Move a placed symbol to a new position in the schematic. By default (preserveWires=true) wire endpoints touching the component's pins are stretched to follow the new position, no-connect flags and net labels on those pins come along, and bends left diagonal by the stretch are squared up again. For a multi-unit part pass unit to say which placement to move.",
     {
       schematicPath: z.string().describe("Path to the .kicad_sch file"),
       reference: z.string().describe("Reference designator (e.g., R1, U1)"),
@@ -1109,29 +1129,59 @@ edit_schematic_component and set its value to an empty string.`,
       preserveWires: z
         .boolean()
         .optional()
-        .describe("Stretch connected wire endpoints to follow the move (default true)"),
+        .describe(
+          "Stretch connected wire endpoints to follow the move, carrying the " +
+            "attached net labels, no-connect flags and wire bends along so the " +
+            "routing stays orthogonal (default true)",
+        ),
+      straightenWires: z
+        .boolean()
+        .optional()
+        .describe(
+          "Square up wire bends that the stretch turned diagonal, by carrying " +
+            "the neighbouring corner along with the pin (default true). Set false " +
+            "to leave stretched segments exactly as the drag left them.",
+        ),
+      unit: z
+        .number()
+        .int()
+        .optional()
+        .describe(
+          "Unit of a multi-unit part (1=A, 2=B, …). Every unit of a part shares one reference, so without this the tool acts on whichever placement comes first in the file. Omit for single-unit parts.",
+        ),
     },
     async (args: {
       schematicPath: string;
       reference: string;
       position: { x: number; y: number };
       preserveWires?: boolean;
+      straightenWires?: boolean;
+      unit?: number;
     }) => {
       const result = await callKicadScript("move_schematic_component", args);
       if (result.success) {
         const moved = result.wiresMoved ?? 0;
         const removed = result.wiresRemoved ?? 0;
         const labels = result.labelsMoved ?? 0;
+        const noConnects = result.noConnectsMoved ?? 0;
+        const straightened = result.wiresStraightened ?? 0;
+        const diagonal = result.wiresLeftDiagonal ?? 0;
         return {
           content: [
             {
               type: "text",
               text:
-                `Moved ${args.reference} from (${result.oldPosition.x}, ${result.oldPosition.y}) ` +
+                `Moved ${args.reference}${args.unit ? ` unit ${args.unit}` : ""} ` +
+                `from (${result.oldPosition.x}, ${result.oldPosition.y}) ` +
                 `to (${result.newPosition.x}, ${result.newPosition.y})` +
                 (moved > 0 ? `, ${moved} wire endpoint(s) updated` : "") +
                 (removed > 0 ? `, ${removed} zero-length wire(s) removed` : "") +
-                (labels > 0 ? `, ${labels} net label(s) moved to stay attached` : ""),
+                (labels > 0 ? `, ${labels} net label(s) moved to stay attached` : "") +
+                (noConnects > 0 ? `, ${noConnects} no-connect flag(s) moved` : "") +
+                (straightened > 0 ? `, ${straightened} wire bend(s) squared up` : "") +
+                (diagonal > 0
+                  ? `, ${diagonal} segment(s) left diagonal (their far end is held by a junction, a fork, or another component's pin)`
+                  : ""),
             },
           ],
         };
@@ -1151,7 +1201,7 @@ edit_schematic_component and set its value to an empty string.`,
   // Rotate schematic component
   server.tool(
     "rotate_schematic_component",
-    "Rotate a placed symbol in the schematic.",
+    "Rotate a placed symbol in the schematic. For a multi-unit part pass unit to say which placement to rotate.",
     {
       schematicPath: z.string().describe("Path to the .kicad_sch file"),
       reference: z.string().describe("Reference designator (e.g., R1, U1)"),
@@ -1163,25 +1213,42 @@ edit_schematic_component and set its value to an empty string.`,
             "symbol to 90° regardless of its current angle (unlike KiCad's UI 'R' key).",
         ),
       mirror: z.enum(["x", "y"]).optional().describe("Optional mirror axis"),
+      straightenWires: z
+        .boolean()
+        .optional()
+        .describe("Square up wire bends that the rotation turned diagonal (default true)."),
+      unit: z
+        .number()
+        .int()
+        .optional()
+        .describe(
+          "Unit of a multi-unit part (1=A, 2=B, …). Every unit of a part shares one reference, so without this the tool acts on whichever placement comes first in the file. Omit for single-unit parts.",
+        ),
     },
     async (args: {
       schematicPath: string;
       reference: string;
       angle: number;
       mirror?: "x" | "y";
+      straightenWires?: boolean;
+      unit?: number;
     }) => {
       const result = await callKicadScript("rotate_schematic_component", args);
       if (result.success) {
         const moved = result.wiresMoved ?? 0;
         const labels = result.labelsMoved ?? 0;
+        const noConnects = result.noConnectsMoved ?? 0;
+        const straightened = result.wiresStraightened ?? 0;
         return {
           content: [
             {
               type: "text",
               text:
-                `Rotated ${args.reference} to ${args.angle}°${args.mirror ? ` (mirrored ${args.mirror})` : ""}` +
+                `Rotated ${args.reference}${args.unit ? ` unit ${args.unit}` : ""} to ${args.angle}°${args.mirror ? ` (mirrored ${args.mirror})` : ""}` +
                 (moved > 0 ? `, ${moved} wire endpoint(s) updated` : "") +
-                (labels > 0 ? `, ${labels} net label(s) moved to stay attached` : ""),
+                (labels > 0 ? `, ${labels} net label(s) moved to stay attached` : "") +
+                (noConnects > 0 ? `, ${noConnects} no-connect flag(s) moved` : "") +
+                (straightened > 0 ? `, ${straightened} wire bend(s) squared up` : ""),
             },
           ],
         };

--- a/tests/test_multi_unit_targeting.py
+++ b/tests/test_multi_unit_targeting.py
@@ -1,0 +1,171 @@
+"""move / rotate / delete can address a single unit of a multi-unit part.
+
+Every unit of a multi-unit symbol is placed as its own (symbol ...) block under
+one shared reference (U201 A-E). Addressing by reference alone therefore hit
+whichever block came first in the file — which unit that was could not be
+predicted from the outside, and deleting took the whole part. An optional
+`unit` parameter names the placement to act on.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sexpdata import Symbol as S
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.unit
+
+from commands.wire_dragger import WireDragger  # noqa: E402
+
+TEMPLATE_SCH = Path(__file__).parent.parent / "python" / "templates" / "empty.kicad_sch"
+
+
+def _placed_unit(unit: int, x: float, y: float, uid: str) -> str:
+    """A placed unit of the two-unit part U1."""
+    return f"""  (symbol (lib_id "Amplifier_Operational:LM358") (at {x} {y} 0) (unit {unit})
+    (in_bom yes) (on_board yes) (dnp no)
+    (uuid "{uid}")
+    (property "Reference" "U1" (at {x} {y - 5} 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Value" "LM358" (at {x} {y + 5} 0)
+      (effects (font (size 1.27 1.27)))
+    )
+  )
+"""
+
+
+def _schematic(tmp_path: Path) -> Path:
+    dest = tmp_path / "multi.kicad_sch"
+    content = TEMPLATE_SCH.read_text(encoding="utf-8").rstrip()
+    assert content.endswith(")")
+    blocks = _placed_unit(1, 50.8, 50.8, "11111111-1111-1111-1111-111111111111") + _placed_unit(
+        2, 101.6, 50.8, "22222222-2222-2222-2222-222222222222"
+    )
+    dest.write_text(content[:-1] + "\n" + blocks + ")\n", encoding="utf-8")
+    return dest
+
+
+def _iface() -> Any:
+    from kicad_interface import KiCADInterface
+
+    return KiCADInterface.__new__(KiCADInterface)
+
+
+def _units_and_positions(sch: Path):
+    import sexpdata
+
+    data = sexpdata.loads(sch.read_text(encoding="utf-8"))
+    out = {}
+    for item in data:
+        if not (isinstance(item, list) and item and item[0] == S("symbol")):
+            continue
+        unit = WireDragger._symbol_unit(item)
+        if unit is None:
+            continue
+        at = next(p for p in item[1:] if isinstance(p, list) and p[0] == S("at"))
+        out[unit] = (float(at[1]), float(at[2]))
+    return out
+
+
+class TestFindSymbolUnit:
+    def test_unit_selects_the_matching_placement(self, tmp_path: Path) -> None:
+        import sexpdata
+
+        data = sexpdata.loads(_schematic(tmp_path).read_text(encoding="utf-8"))
+        assert WireDragger.find_symbol(data, "U1", 2)[1] == 101.6
+        assert WireDragger.find_symbol(data, "U1", 1)[1] == 50.8
+        assert WireDragger.find_symbol(data, "U1", 3) is None
+
+    def test_list_symbol_units_reports_what_is_placed(self, tmp_path: Path) -> None:
+        import sexpdata
+
+        data = sexpdata.loads(_schematic(tmp_path).read_text(encoding="utf-8"))
+        assert sorted(WireDragger.list_symbol_units(data, "U1")) == [1, 2]
+
+
+class TestMove:
+    def test_moves_only_the_named_unit(self, tmp_path: Path) -> None:
+        sch = _schematic(tmp_path)
+        result = _iface()._handle_move_schematic_component(
+            {
+                "schematicPath": str(sch),
+                "reference": "U1",
+                "unit": 2,
+                "position": {"x": 152.4, "y": 76.2},
+            }
+        )
+        assert result["success"] is True
+        positions = _units_and_positions(sch)
+        assert positions[2] == (152.4, 76.2)
+        assert positions[1] == (50.8, 50.8), "unit A must not have moved"
+
+    def test_unknown_unit_says_which_units_exist(self, tmp_path: Path) -> None:
+        sch = _schematic(tmp_path)
+        result = _iface()._handle_move_schematic_component(
+            {
+                "schematicPath": str(sch),
+                "reference": "U1",
+                "unit": 5,
+                "position": {"x": 152.4, "y": 76.2},
+            }
+        )
+        assert result["success"] is False
+        assert "no unit 5" in result["message"]
+        assert "1, 2" in result["message"]
+
+
+class TestRotate:
+    def test_rotates_only_the_named_unit(self, tmp_path: Path) -> None:
+        sch = _schematic(tmp_path)
+        result = _iface()._handle_rotate_schematic_component(
+            {"schematicPath": str(sch), "reference": "U1", "unit": 2, "angle": 90}
+        )
+        assert result["success"] is True
+
+        import sexpdata
+
+        data = sexpdata.loads(sch.read_text(encoding="utf-8"))
+        angles = {}
+        for item in data:
+            if not (isinstance(item, list) and item and item[0] == S("symbol")):
+                continue
+            unit = WireDragger._symbol_unit(item)
+            if unit is None:
+                continue
+            at = next(p for p in item[1:] if isinstance(p, list) and p[0] == S("at"))
+            angles[unit] = at[3]
+        assert angles[2] == 90
+        assert angles[1] == 0
+
+
+class TestDelete:
+    def test_deletes_only_the_named_unit(self, tmp_path: Path) -> None:
+        sch = _schematic(tmp_path)
+        result = _iface()._handle_delete_schematic_component(
+            {"schematicPath": str(sch), "reference": "U1", "unit": 1}
+        )
+        assert result["success"] is True
+        assert result["deleted_count"] == 1
+        assert sorted(_units_and_positions(sch)) == [2]
+
+    def test_without_unit_the_whole_part_goes(self, tmp_path: Path) -> None:
+        sch = _schematic(tmp_path)
+        result = _iface()._handle_delete_schematic_component(
+            {"schematicPath": str(sch), "reference": "U1"}
+        )
+        assert result["success"] is True
+        assert result["deleted_count"] == 2
+        assert _units_and_positions(sch) == {}
+
+    def test_missing_unit_is_reported_not_silently_ignored(self, tmp_path: Path) -> None:
+        sch = _schematic(tmp_path)
+        result = _iface()._handle_delete_schematic_component(
+            {"schematicPath": str(sch), "reference": "U1", "unit": 4}
+        )
+        assert result["success"] is False
+        assert "unit 4" in result["message"]
+        assert sorted(_units_and_positions(sch)) == [1, 2]

--- a/tests/test_net_label_orientation.py
+++ b/tests/test_net_label_orientation.py
@@ -1,0 +1,115 @@
+"""A net label snapped to a pin faces the way the pin does.
+
+Regression guard: the label was written at angle 0 regardless of the pin, and
+batch_connect went further and turned it around (a right-facing pin got 180).
+KiCad pairs angle 0/90 with `justify left` and 180/270 with `justify right`, so
+a label turned back on itself lays the net name across the symbol body. The
+`justify` half is not separately settable through the API, so callers could not
+repair it without hand-editing the file.
+"""
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.unit
+
+import commands.pin_locator as pin_locator_mod  # noqa: E402
+import commands.schematic_handlers as handlers_mod  # noqa: E402
+
+
+def _iface() -> Any:
+    from kicad_interface import KiCADInterface
+
+    return KiCADInterface.__new__(KiCADInterface)
+
+
+@pytest.fixture()
+def schematic(tmp_path: Path) -> Path:
+    p = tmp_path / "t.kicad_sch"
+    p.write_text(
+        '(kicad_sch (version 20250114) (generator "test")\n  (lib_symbols)\n'
+        '  (sheet_instances (path "/" (page "1")))\n)\n',
+        encoding="utf-8",
+    )
+    return p
+
+
+def _fake_locator(pin_angle: float) -> Any:
+    return types.SimpleNamespace(
+        get_pin_location=lambda p, ref, pin: [100.0, 100.0],
+        get_pin_angle=lambda p, ref, pin: pin_angle,
+    )
+
+
+def _added_labels(monkeypatch) -> list:
+    """Capture (text, orientation) instead of writing to the file."""
+    calls: list = []
+    real_add_label = handlers_mod.WireManager.add_label
+
+    def fake_add_label(path, text, position, label_type="label", orientation=0):
+        calls.append((text, orientation))
+        return True
+
+    monkeypatch.setattr(handlers_mod.WireManager, "add_label", staticmethod(fake_add_label))
+    assert real_add_label is not fake_add_label
+    return calls
+
+
+@pytest.mark.parametrize(
+    "pin_angle,expected",
+    [
+        (0, 0),  # pin points right -> text grows right, clear of the body
+        (180, 180),  # pin points left -> text grows left
+        (90, 90),  # pin points up
+        (270, 270),  # pin points down
+        (359.6, 0),  # bearings are snapped to the four KiCad orientations
+    ],
+)
+def test_orientation_follows_the_pin(monkeypatch, schematic, pin_angle, expected):
+    monkeypatch.setattr(pin_locator_mod, "PinLocator", lambda: _fake_locator(pin_angle))
+    calls = _added_labels(monkeypatch)
+
+    result = _iface()._handle_add_schematic_net_label(
+        {
+            "schematicPath": str(schematic),
+            "netName": "SDA",
+            "componentRef": "U1",
+            "pinNumber": "1",
+        }
+    )
+    assert result["success"] is True
+    assert result["orientation"] == expected
+    assert calls == [("SDA", expected)]
+
+
+def test_explicit_orientation_still_wins(monkeypatch, schematic):
+    monkeypatch.setattr(pin_locator_mod, "PinLocator", lambda: _fake_locator(0))
+    calls = _added_labels(monkeypatch)
+
+    result = _iface()._handle_add_schematic_net_label(
+        {
+            "schematicPath": str(schematic),
+            "netName": "SDA",
+            "componentRef": "U1",
+            "pinNumber": "1",
+            "orientation": 90,
+        }
+    )
+    assert result["success"] is True
+    assert calls == [("SDA", 90)]
+
+
+def test_free_position_label_still_defaults_to_zero(monkeypatch, schematic):
+    calls = _added_labels(monkeypatch)
+
+    result = _iface()._handle_add_schematic_net_label(
+        {"schematicPath": str(schematic), "netName": "SDA", "position": [10.0, 20.0]}
+    )
+    assert result["success"] is True
+    assert calls == [("SDA", 0)]

--- a/tests/test_placed_field_visibility.py
+++ b/tests/test_placed_field_visibility.py
@@ -1,0 +1,96 @@
+"""Placed instances inherit the library symbol's field visibility.
+
+Regression guard: create_component_instance wrote Reference and Value as
+visible unconditionally. Power symbols (power:GND, power:+3V3, …) hide their
+Reference in the library — the #PWR101 designators say nothing to a reader —
+and losing that flag printed one stray designator beside every ground symbol,
+enough to make a dense sheet unreadable.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.unit
+
+from commands.dynamic_symbol_loader import DynamicSymbolLoader  # noqa: E402
+
+# A power symbol the way KiCad ships it: Reference hidden, Value shown.
+_POWER_SCH = """(kicad_sch (version 20231120) (generator test)
+  (lib_symbols
+    (symbol "power:GND" (power) (in_bom no) (on_board yes)
+      (property "Reference" "#PWR" (at 0 -6.35 0)
+        (effects (font (size 1.27 1.27)) (hide yes))
+      )
+      (property "Value" "GND" (at 0 -3.81 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+    )
+  )
+)
+"""
+
+# An ordinary part: both Reference and Value visible.
+_DEVICE_SCH = _POWER_SCH.replace('"power:GND"', '"Device:R"').replace(
+    """      (property "Reference" "#PWR" (at 0 -6.35 0)
+        (effects (font (size 1.27 1.27)) (hide yes))
+      )""",
+    '      (property "Reference" "R" (at 2.032 0 0) (effects (font (size 1.27 1.27))))',
+)
+
+
+def _placed_block(text: str) -> str:
+    return text[text.rfind("(symbol (lib_id") :]
+
+
+def _property_block(text: str, name: str) -> str:
+    """The placed instance's (property "<name>" ...) block, up to the next property."""
+    block = _placed_block(text)
+    m = re.search(
+        r'\(property "' + re.escape(name) + r'".*?(?=\n    \(property |\n    \(pin )', block, re.S
+    )
+    assert m is not None, f"no {name} property in placed instance"
+    return m.group(0)
+
+
+def _is_hidden(text: str, name: str) -> bool:
+    return "(hide yes)" in _property_block(text, name)
+
+
+def test_power_symbol_reference_stays_hidden(tmp_path: Path) -> None:
+    p = tmp_path / "t.kicad_sch"
+    p.write_text(_POWER_SCH, encoding="utf-8")
+    loader = DynamicSymbolLoader(project_path=tmp_path)
+    loader.create_component_instance(
+        p, "power", "GND", reference="#PWR01", value="GND", x=100, y=100
+    )
+
+    text = p.read_text(encoding="utf-8")
+    assert _is_hidden(text, "Reference"), "#PWR designator must not be printed on the sheet"
+    assert not _is_hidden(text, "Value"), "the net name is the whole point of a power symbol"
+
+
+def test_ordinary_symbol_keeps_both_fields_visible(tmp_path: Path) -> None:
+    p = tmp_path / "t.kicad_sch"
+    p.write_text(_DEVICE_SCH, encoding="utf-8")
+    loader = DynamicSymbolLoader(project_path=tmp_path)
+    loader.create_component_instance(p, "Device", "R", reference="R1", value="10k", x=100, y=100)
+
+    text = p.read_text(encoding="utf-8")
+    assert not _is_hidden(text, "Reference")
+    assert not _is_hidden(text, "Value")
+
+
+def test_field_value_containing_the_word_hide_is_not_treated_as_hidden(tmp_path: Path) -> None:
+    """The marker is a token, not a substring of some field's text."""
+    sch = _DEVICE_SCH.replace('(property "Value" "GND"', '(property "Value" "auto hide relay"')
+    p = tmp_path / "t.kicad_sch"
+    p.write_text(sch, encoding="utf-8")
+    loader = DynamicSymbolLoader(project_path=tmp_path)
+    loader.create_component_instance(p, "Device", "R", reference="R1", value="10k", x=100, y=100)
+
+    assert not _is_hidden(p.read_text(encoding="utf-8"), "Value")

--- a/tests/test_schematic_batch.py
+++ b/tests/test_schematic_batch.py
@@ -175,7 +175,11 @@ class TestBatchConnect:
         r = c.batch_connect({"schematicPath": str(f), "connections": {"R1": {"1": "SDA"}}})
         assert r["success"] is True
         assert len(r["placed"]) == 1
-        assert labels == [("SDA", 180)]  # pin angle 0 -> label orientation 180
+        # A pin whose outward direction is 0 (pointing right) gets a label at 0:
+        # KiCad renders angle 0 with `justify left`, i.e. text growing rightwards,
+        # away from the symbol body. The label follows the pin, never turns back
+        # over it.
+        assert labels == [("SDA", 0)]
 
     def test_places_global_label(self, monkeypatch, tmp_path):
         f = tmp_path / "x.kicad_sch"
@@ -223,6 +227,64 @@ class TestBatchConnect:
         )
         assert r["success"] is False
         assert "labelType" in r["message"]
+
+
+class TestBatchAddUnits:
+    """A multi-unit part is placed one entry per unit, all sharing a reference.
+
+    Regression: batch_add_components ignored `unit` and always placed unit 1, so
+    a five-unit FPGA needed five separate add_schematic_component calls — the
+    round-trips the batch exists to avoid.
+    """
+
+    def _stub_loader(self, monkeypatch, tmp_path, calls):
+        sch = tmp_path / "x.kicad_sch"
+        sch.write_text("(kicad_sch)")
+
+        def fake_add_component(self, path, library, name, **kwargs):
+            calls.append((name, kwargs.get("unit"), kwargs.get("reference")))
+            return True
+
+        monkeypatch.setattr(sb.DynamicSymbolLoader, "add_component", fake_add_component)
+        monkeypatch.setattr(
+            sb,
+            "PinLocator",
+            lambda: types.SimpleNamespace(
+                _schematic_cache={},
+                get_all_symbol_pins=lambda p, ref: {},
+            ),
+        )
+        monkeypatch.setattr(sb, "_find_placed_symbol_block", lambda *a, **k: (None, -1, -1))
+        return sch
+
+    def test_unit_is_passed_through(self, monkeypatch, tmp_path):
+        calls = []
+        sch = self._stub_loader(monkeypatch, tmp_path, calls)
+        c = SchematicBatchCommands(types.SimpleNamespace())
+        r = c.batch_add_components(
+            {
+                "schematicPath": str(sch),
+                "components": [
+                    {"symbol": "FPGA:GW2A", "reference": "U201", "unit": 1},
+                    {"symbol": "FPGA:GW2A", "reference": "U201", "unit": 4},
+                ],
+            }
+        )
+        assert r["added_count"] == 2
+        assert calls == [("GW2A", 1, "U201"), ("GW2A", 4, "U201")]
+        assert [e["unit"] for e in r["added"]] == [1, 4]
+
+    def test_unit_defaults_to_one(self, monkeypatch, tmp_path):
+        calls = []
+        sch = self._stub_loader(monkeypatch, tmp_path, calls)
+        c = SchematicBatchCommands(types.SimpleNamespace())
+        c.batch_add_components(
+            {
+                "schematicPath": str(sch),
+                "components": [{"symbol": "Device:R", "reference": "R1"}],
+            }
+        )
+        assert calls == [("R", 1, "R1")]
 
 
 class TestBatchAddAndConnect:

--- a/tests/test_wire_dragger_orthogonality.py
+++ b/tests/test_wire_dragger_orthogonality.py
@@ -1,0 +1,162 @@
+"""Tests for keeping dragged routing orthogonal and no-connect flags attached.
+
+Dragging a symbol used to move only the wire endpoint that touched a pin. A
+trace routed pin -> corner -> corner -> pin is a chain of separate two-point
+segments, so the first segment came out diagonal and its bend landed off-grid —
+eeschema then reported endpoint_off_grid on a trace the user never touched.
+A no-connect flag on a moved pin stayed behind the same way, turning into a
+dangling flag plus an "unconnected pin" on the symbol's new location.
+
+drag_wires must now carry the neighbouring bend along with the pin and move
+no-connect flags with it, while refusing to disturb corners that something else
+holds in place.
+"""
+
+import sys
+from pathlib import Path
+
+from sexpdata import Symbol as S
+
+PYTHON_DIR = Path(__file__).parent.parent / "python"
+sys.path.insert(0, str(PYTHON_DIR))
+
+from commands.wire_dragger import WireDragger  # noqa: E402
+
+
+def _wire(x1, y1, x2, y2):
+    return [S("wire"), [S("pts"), [S("xy"), x1, y1], [S("xy"), x2, y2]]]
+
+
+def _coords(sch):
+    """All wire segments as ((x1,y1),(x2,y2)) tuples, in file order."""
+    return [
+        WireDragger._wire_endpoints(item)
+        for item in sch
+        if WireDragger._wire_endpoints(item) is not None
+    ]
+
+
+class TestNoConnectFlags:
+    def test_no_connect_follows_moved_pin(self):
+        sch = [
+            S("kicad_sch"),
+            [S("no_connect"), [S("at"), 100.0, 100.0]],
+        ]
+        summary = WireDragger.drag_wires(sch, {(100.0, 100.0): (100.0, 90.0)})
+        assert summary["no_connects_moved"] == 1
+        nc = next(i for i in sch if isinstance(i, list) and str(i[0]) == "no_connect")
+        at = next(p for p in nc if isinstance(p, list) and str(p[0]) == "at")
+        assert (at[1], at[2]) == (100.0, 90.0)
+
+    def test_no_connect_elsewhere_is_untouched(self):
+        sch = [
+            S("kicad_sch"),
+            [S("no_connect"), [S("at"), 50.0, 50.0]],
+        ]
+        summary = WireDragger.drag_wires(sch, {(100.0, 100.0): (100.0, 90.0)})
+        assert summary["no_connects_moved"] == 0
+        nc = next(i for i in sch if isinstance(i, list) and str(i[0]) == "no_connect")
+        at = next(p for p in nc if isinstance(p, list) and str(p[0]) == "at")
+        assert (at[1], at[2]) == (50.0, 50.0)
+
+
+class TestOrthogonality:
+    def test_corner_follows_the_pin(self):
+        # Pin at (100,100) -> corner (100,80) -> away to (140,80).
+        sch = [
+            S("kicad_sch"),
+            _wire(100.0, 100.0, 100.0, 80.0),
+            _wire(100.0, 80.0, 140.0, 80.0),
+        ]
+        summary = WireDragger.drag_wires(sch, {(100.0, 100.0): (110.0, 100.0)})
+
+        first, second = _coords(sch)
+        # The vertical segment stays vertical: its corner moved to x=110.
+        assert first == ((110.0, 100.0), (110.0, 80.0))
+        # ...and the horizontal segment it feeds keeps its own axis.
+        assert second == ((110.0, 80.0), (140.0, 80.0))
+        assert summary["wires_straightened"] == 1
+        assert summary["wires_left_diagonal"] == 0
+
+    def test_cascade_through_two_corners(self):
+        # Pin -> corner -> corner -> far end. Moving the pin diagonally has to
+        # settle both bends, not just the first.
+        sch = [
+            S("kicad_sch"),
+            _wire(100.0, 100.0, 100.0, 80.0),
+            _wire(100.0, 80.0, 140.0, 80.0),
+            _wire(140.0, 80.0, 140.0, 60.0),
+        ]
+        WireDragger.drag_wires(sch, {(100.0, 100.0): (110.0, 90.0)})
+
+        for (x1, y1), (x2, y2) in _coords(sch):
+            assert abs(x1 - x2) < 1e-6 or abs(y1 - y2) < 1e-6, "segment left diagonal"
+
+    def test_corner_held_by_a_junction_is_left_alone(self):
+        sch = [
+            S("kicad_sch"),
+            _wire(100.0, 100.0, 100.0, 80.0),
+            _wire(100.0, 80.0, 140.0, 80.0),
+            [S("junction"), [S("at"), 100.0, 80.0]],
+        ]
+        summary = WireDragger.drag_wires(sch, {(100.0, 100.0): (110.0, 100.0)})
+
+        first, second = _coords(sch)
+        assert first == ((110.0, 100.0), (100.0, 80.0))  # left diagonal on purpose
+        assert second == ((100.0, 80.0), (140.0, 80.0))  # junction untouched
+        assert summary["wires_straightened"] == 0
+        assert summary["wires_left_diagonal"] == 1
+
+    def test_corner_held_by_a_stationary_pin_is_left_alone(self):
+        sch = [
+            S("kicad_sch"),
+            _wire(100.0, 100.0, 100.0, 80.0),
+        ]
+        summary = WireDragger.drag_wires(
+            sch,
+            {(100.0, 100.0): (110.0, 100.0)},
+            anchor_points={(100.0, 80.0)},
+        )
+        assert summary["wires_straightened"] == 0
+        assert summary["wires_left_diagonal"] == 1
+        assert _coords(sch) == [((110.0, 100.0), (100.0, 80.0))]
+
+    def test_fork_of_three_segments_is_left_alone(self):
+        sch = [
+            S("kicad_sch"),
+            _wire(100.0, 100.0, 100.0, 80.0),
+            _wire(100.0, 80.0, 140.0, 80.0),
+            _wire(100.0, 80.0, 60.0, 80.0),
+        ]
+        summary = WireDragger.drag_wires(sch, {(100.0, 100.0): (110.0, 100.0)})
+        assert summary["wires_straightened"] == 0
+        assert summary["wires_left_diagonal"] == 1
+
+    def test_label_at_the_corner_travels_with_it(self):
+        sch = [
+            S("kicad_sch"),
+            _wire(100.0, 100.0, 100.0, 80.0),
+            [S("label"), "SDA", [S("at"), 100.0, 80.0, 0]],
+        ]
+        WireDragger.drag_wires(sch, {(100.0, 100.0): (110.0, 100.0)})
+        label = next(i for i in sch if isinstance(i, list) and str(i[0]) == "label")
+        at = next(p for p in label if isinstance(p, list) and str(p[0]) == "at")
+        assert (at[1], at[2]) == (110.0, 80.0)
+
+    def test_deliberately_diagonal_segment_is_preserved(self):
+        sch = [
+            S("kicad_sch"),
+            _wire(100.0, 100.0, 130.0, 70.0),
+        ]
+        summary = WireDragger.drag_wires(sch, {(100.0, 100.0): (110.0, 100.0)})
+        assert summary["wires_straightened"] == 0
+        assert _coords(sch) == [((110.0, 100.0), (130.0, 70.0))]
+
+    def test_straighten_can_be_switched_off(self):
+        sch = [
+            S("kicad_sch"),
+            _wire(100.0, 100.0, 100.0, 80.0),
+        ]
+        summary = WireDragger.drag_wires(sch, {(100.0, 100.0): (110.0, 100.0)}, straighten=False)
+        assert summary["wires_straightened"] == 0
+        assert _coords(sch) == [((110.0, 100.0), (100.0, 80.0))]


### PR DESCRIPTION
Five defects found while drawing a two-sheet nRF52/FPGA design through the schematic
tools, on KiCad 10.0.4 with the SWIG backend. Each one produces a file KiCad loads
but a person then has to repair by hand, and none of them announces itself — the
tool reports success every time.

## What changes

**Placed symbols lost the library's field visibility.** `Reference` and `Value` were
written visible unconditionally, ignoring the `(hide yes)` the library symbol carries.
Power symbols hide `Reference` by convention — a `#PWR101` designator tells a reader
nothing — so every ground and rail symbol placed through the API printed one. A sheet
with 26 grounds came out with 26 stray designators over the wiring. Visibility now
comes from the injected `lib_symbols` definition, alongside the position and effects
that were already inherited. The marker is matched as a token, so a field whose
*value* contains the word "hide" is not mistaken for a hidden field.

**Net labels snapped to a pin faced the wrong way.** KiCad pairs label angle 0/90 with
`justify left` and 180/270 with `justify right`, so a label anchored at a pin endpoint
has to run along the pin's outward direction or its text lies across the symbol body.
`add_schematic_net_label` defaulted to angle 0 regardless of the pin, and
`batch_connect` inverted the pin bearing outright:

```python
orientation = {0: 180, 90: 270, 180: 0, 270: 90}.get(cardinal, 0)
```

which put the net name over the body on every right-hand pin of every part. Since
`justify` is not separately settable through the API, callers could not repair it
without editing the file. Both entry points now orient the label along the pin's
outward bearing, snapped to the four orientations KiCad allows; an explicit
`orientation` still wins. The angle/justify pairing was checked against the
schematics shipped in `share/kicad/demos` (0→left, 180→right, 90→left, 270→right,
no counter-examples).

**Dragging a component broke its routing and left its no-connect flags behind.**
Moving or rotating a symbol updated only the wire endpoint touching each pin. A trace
routed pin → corner → corner → pin is a chain of separate two-point segments, so the
first segment came out diagonal and its bend landed off-grid — reported afterwards as
`endpoint_off_grid` on a trace nobody touched. A no-connect flag on a moved pin stayed
at the old coordinate, becoming a dangling flag plus an unconnected pin.

`move_schematic_component` and `rotate_schematic_component` now carry the neighbouring
bend along with the pin, cascading through the chain until the routing settles, and
move no-connect flags with the pins they mark. A corner is left alone — and the
segment left diagonal — when an explicit junction, a fork of three or more segments,
or another component's pin holds it: moving those would drag unrelated wiring or tear
a connection apart. The response counts both outcomes (`wiresStraightened`,
`wiresLeftDiagonal`, `noConnectsMoved`), and `straightenWires: false` opts out.

**A single unit of a multi-unit part could not be addressed.** Every unit is placed as
its own `(symbol ...)` block under one shared reference, so `move_schematic_component`,
`rotate_schematic_component` and `delete_schematic_component` acted on whichever block
came first in the file — not predictable from the outside — and `delete` took the whole
part. All three now accept an optional `unit`. Naming a unit that is not placed reports
which ones are, rather than failing as "not found". Wire dragging follows: pins are
filtered to the moved unit, and the part's other units count as stationary, so their
wiring stays put.

**`batch_add_components` accepts `unit`.** `add_schematic_component` had it, the batch
did not, so a five-unit FPGA had to be placed one call per unit — the round-trips the
batch exists to avoid.

## Testing

- Full suite: 2190 passed, 36 skipped. The one failure,
  `test_ipc_open_board_path::test_returns_full_path_composed_from_project_and_filename`,
  is a pre-existing Windows path-separator assertion (`/` vs `\`), unrelated to these
  changes and failing on `main` as well.
- 28 new tests in four files, plus two added to `test_schematic_batch.py`. One existing
  assertion changed: `test_places_label` encoded the inverted orientation, and now
  encodes the pin-following one, with the reasoning in a comment.
- `vitest` 73 passed · `tsc --noEmit`, `eslint`, `prettier`, `black`, `isort`,
  `flake8`, `mypy` all clean.
- End-to-end against the built server over stdio (`node dist/index.js`, `KICAD_PYTHON`
  pointed at KiCad 10.0.4's Python): 15 checks covering every fix above — schema
  parameters present, `(hide yes)` written for a placed `power:GND`, label written at
  angle 90 with `justify left` from a pin whose outward bearing is 90°, both FPGA
  units placed by one batch call, move/delete touching only the named unit, and a
  dragged L-route left with no diagonal segment and its no-connect flag on the pin.
- `kicad-cli sch erc` on the dragged schematic reports no `endpoint_off_grid`. The
  remaining messages come from the test fixture itself (a wire deliberately drawn to
  nowhere) and are identical on an equivalent pre-move file.

## Notes

`get_schematic_pin_locations` already reports `unit` and `sexpr_format` already
escapes quoted values, so the two worst problems from the same session — a `power:*`
`Description` containing quotes splitting the S-expression, and multi-unit pin
coordinates computed for one placement — are fixed on `main` and are not part of this
PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
