### PR TITLE
Name five schema parameters the way the handlers read them

### DIFF
--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -457,12 +457,12 @@ BOARD_TOOLS = [
         "inputSchema": {
             "type": "object",
             "properties": {
-                "layerName": {
+                "layer": {
                     "type": "string",
                     "description": "Name of the layer to make active (e.g., F.Cu, B.Cu, Edge.Cuts)",
                 }
             },
-            "required": ["layerName"],
+            "required": ["layer"],
         },
     },
     {
@@ -1373,17 +1373,17 @@ ROUTING_TOOLS = [
         "inputSchema": {
             "type": "object",
             "properties": {
-                "netName": {
+                "name": {
                     "type": "string",
                     "description": "Name of the net (e.g., VCC, GND, SDA)",
                     "minLength": 1,
                 },
-                "netClass": {
+                "class": {
                     "type": "string",
                     "description": "Optional net class to assign (must exist first)",
                 },
             },
-            "required": ["netName"],
+            "required": ["name"],
         },
     },
     {
@@ -1453,7 +1453,7 @@ ROUTING_TOOLS = [
         "inputSchema": {
             "type": "object",
             "properties": {
-                "uuid": {
+                "traceUuid": {
                     "type": "string",
                     "description": "UUID of a specific trace to delete",
                 },
@@ -1782,7 +1782,7 @@ ROUTING_TOOLS = [
         "inputSchema": {
             "type": "object",
             "properties": {
-                "netName": {
+                "net": {
                     "type": "string",
                     "description": "Net to connect this copper pour to (e.g., GND, VCC)",
                 },
@@ -1813,7 +1813,7 @@ ROUTING_TOOLS = [
                     "minItems": 3,
                 },
             },
-            "required": ["netName", "layer", "outline"],
+            "required": ["net", "layer", "outline"],
         },
     },
     {
@@ -2200,7 +2200,7 @@ EXPORT_TOOLS = [
         "inputSchema": {
             "type": "object",
             "properties": {
-                "outputPath": {
+                "outputDir": {
                     "type": "string",
                     "description": "Directory path for output files",
                 },
@@ -2215,7 +2215,7 @@ EXPORT_TOOLS = [
                     "default": True,
                 },
             },
-            "required": ["outputPath"],
+            "required": ["outputDir"],
         },
     },
     {


### PR DESCRIPTION
Five tools declare a parameter under a name the handler never reads, so a client that follows the schema gets an error back.

`set_active_layer` is the clearest one. The schema requires `layerName`; `commands/board/layers.py:147` does:

```python
layer = params.get("layer")
if not layer:
    return {"success": False, "message": "No layer specified",
            "errorDetails": "layer parameter is required"}
```

So the caller sends exactly what the schema asks for and is told that `layer` is required.

| tool | schema required | handler reads |
|---|---|---|
| `set_active_layer` | `layerName` | `layer` (`board/layers.py:147`) |
| `add_net` | `netName`, `netClass` | `name`, `class` (`routing.py:221`) |
| `add_copper_pour` | `netName` | `net` (`routing.py:1615`) |
| `export_gerber` | `outputPath` | `outputDir` (`export.py:25`) |
| `delete_trace` | `uuid` | `traceUuid` (`routing.py:731`) |

This renames the schema side rather than the handler side, because the rest of the server already agrees with the handlers: across the 86 tools whose schema and handler do match, the names in use are `layer` (7 tools), `position` (7), `net` (5), `reference` (9). `layerName` and `netName` appear only in the tools that are broken.

`export_gerber` is worth a second look on its own: it is the tool that produces the fabrication output, and it currently cannot run.

There are eleven more tools with the same class of mismatch, but those need the argument shape changed rather than a rename (the handler takes `position` as an object where the schema promises `x` and `y`). I left them out of this PR since that is a design call. Say the word and I will send them the same way.
