### PR TITLE
fix(schematic): guard kicad-skip imports so one missing package can't kill all 216 tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **A missing kicad-skip no longer kills all 216 tools at startup** (#389).
+  Six modules imported `from skip import Schematic` at their own top level.
+  Two of them sit on the import chain `kicad_interface` -> `schematic_handlers`
+  -> `library_schematic`/`schematic`, which runs before the process reaches
+  its own try/except import guard, so a missing kicad-skip raised an
+  unhandled `ModuleNotFoundError` at startup instead of the intended clean
+  JSON error. Three of the six modules never actually used the import and
+  had it removed; the other three guard it now. `create_schematic` and
+  `load_schematic`, the two tools that genuinely need kicad-skip, raise a
+  `SchematicLoadError` naming the exact `pip install kicad-skip` command
+  instead of taking the rest of the server down with them.
+
 ## [2.7.0] - 2026-08-20
 
 ### New Tools

--- a/python/commands/component_schematic.py
+++ b/python/commands/component_schematic.py
@@ -3,7 +3,11 @@ import uuid
 from pathlib import Path
 from typing import Any, List, Optional
 
-from skip import Schematic
+try:
+    from skip import Schematic
+except ImportError:
+    # kicad-skip is optional; fall back to Any so these type hints stay valid.
+    Schematic = Any
 
 logger = logging.getLogger(__name__)
 

--- a/python/commands/connection_schematic.py
+++ b/python/commands/connection_schematic.py
@@ -3,7 +3,11 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from skip import Schematic
+try:
+    from skip import Schematic
+except ImportError:
+    # kicad-skip is optional; fall back to Any so these type hints stay valid.
+    Schematic = Any
 
 logger = logging.getLogger(__name__)
 

--- a/python/commands/library_schematic.py
+++ b/python/commands/library_schematic.py
@@ -5,8 +5,6 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
-from skip import Schematic
-
 logger = logging.getLogger(__name__)
 
 

--- a/python/commands/pin_locator.py
+++ b/python/commands/pin_locator.py
@@ -15,7 +15,11 @@ from typing import Any, Dict, List, Optional, Tuple
 import sexpdata
 from commands.schematic import SchematicLoadError, SchematicManager
 from sexpdata import Symbol
-from skip import Schematic
+
+try:
+    from skip import Schematic  # noqa: F401 (unused here, but tests patch this name)
+except ImportError:
+    Schematic = None
 
 logger = logging.getLogger("kicad_interface")
 

--- a/python/commands/schematic.py
+++ b/python/commands/schematic.py
@@ -1,13 +1,18 @@
 import logging
 import os
 import shutil
+import sys
 import traceback
 import uuid
 from typing import Any, List, Optional
 
 import sexpdata
-from skip import Schematic
 from utils.sexpr_format import prettify
+
+try:
+    from skip import Schematic
+except ImportError:
+    Schematic = None
 
 logger = logging.getLogger("kicad_interface")
 
@@ -17,9 +22,10 @@ class SchematicLoadError(Exception):
 
     Carries a structured diagnosis so every schematic tool can fail loudly
     and actionably instead of returning plausible-looking empty results.
-    ``kind`` is ``"not_found"`` or ``"parse_error"``; ``flat_symbols`` names
-    embedded lib symbols with no sub-units (the SnapEDA/SamacSys pattern
-    that crashes kicad-skip's LibSymbol parser).
+    ``kind`` is ``"not_found"``, ``"parse_error"``, or ``"dependency_missing"``
+    (kicad-skip itself is not installed); ``flat_symbols`` names embedded lib
+    symbols with no sub-units (the SnapEDA/SamacSys pattern that crashes
+    kicad-skip's LibSymbol parser).
     """
 
     def __init__(
@@ -38,6 +44,11 @@ class SchematicLoadError(Exception):
     def _message(self) -> str:
         if self.kind == "not_found":
             return f"Schematic file not found: {self.path}"
+        if self.kind == "dependency_missing":
+            return (
+                f"Cannot load {self.path}: kicad-skip is not installed. "
+                f"Install it with: {sys.executable} -m pip install kicad-skip"
+            )
         if self.flat_symbols:
             names = ", ".join(self.flat_symbols)
             return (
@@ -110,6 +121,8 @@ class SchematicManager:
         name: str, metadata: Optional[Any] = None, *, path: Optional[str] = None
     ) -> Any:
         """Create a new empty schematic from template"""
+        if Schematic is None:
+            raise SchematicLoadError(path or name, kind="dependency_missing")
         try:
             # Determine template path. New schematics start from a blank KiCad 10
             # file (empty lib_symbols, no placed symbols) rather than the seeded
@@ -196,6 +209,8 @@ class SchematicManager:
         if not os.path.exists(file_path):
             logger.error(f"Schematic file not found at {file_path}")
             raise SchematicLoadError(file_path, kind="not_found")
+        if Schematic is None:
+            raise SchematicLoadError(file_path, kind="dependency_missing")
         try:
             sch = Schematic(file_path)
             logger.info(f"Loaded schematic from: {file_path}")

--- a/python/commands/schematic_analysis.py
+++ b/python/commands/schematic_analysis.py
@@ -15,7 +15,6 @@ import sexpdata
 from commands.pin_locator import PinLocator
 from commands.wire_connectivity import _parse_virtual_connections, _to_iu
 from sexpdata import Symbol
-from skip import Schematic
 
 logger = logging.getLogger("kicad_interface")
 

--- a/tests/test_kicad_skip_import_guard.py
+++ b/tests/test_kicad_skip_import_guard.py
@@ -1,0 +1,97 @@
+"""Regression tests for #389: kicad-skip missing must not take down the server.
+
+Six modules imported ``from skip import Schematic`` at their own top level.
+Two of them (``library_schematic.py``, ``schematic.py``) sit on the import
+chain ``kicad_interface`` -> ``schematic_handlers`` -> ``library_schematic``/
+``schematic``, which runs before kicad_interface.py's own try/except block
+even starts, so a missing kicad-skip raised an unhandled ModuleNotFoundError
+at process startup instead of the intended structured JSON error.
+
+These run kicad-skip absence in a genuinely separate subprocess
+(``sys.modules["skip"] = None`` forces every import of it to fail) rather
+than relying on conftest's session-wide stub, which would otherwise make
+``from skip import Schematic`` succeed against the fake module and never
+exercise the guard this issue is about.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PYTHON_DIR = Path(__file__).resolve().parent.parent / "python"
+
+_PREAMBLE = f"""
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, {str(PYTHON_DIR)!r})
+
+# Force every import of kicad-skip to fail, regardless of whether it is
+# actually installed in this interpreter.
+sys.modules["skip"] = None
+
+pcbnew = MagicMock(name="pcbnew")
+pcbnew.__file__ = "/fake/pcbnew.py"
+pcbnew.__spec__ = None
+pcbnew.GetBuildVersion.return_value = "9.0.0-stub"
+sys.modules["pcbnew"] = pcbnew
+"""
+
+
+def _run(body: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", _PREAMBLE + body],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_kicad_interface_imports_without_kicad_skip():
+    result = _run("import kicad_interface\nprint('OK')")
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_schematic_manager_raises_actionable_error_without_kicad_skip():
+    result = _run(
+        "from commands.schematic import SchematicManager, SchematicLoadError\n"
+        "try:\n"
+        "    SchematicManager.load_schematic('/nonexistent-but-checked-second.kicad_sch')\n"
+        "except SchematicLoadError as e:\n"
+        "    assert e.kind == 'not_found', e.kind\n"
+        "try:\n"
+        "    SchematicManager.create_schematic('t', path='/tmp/does-not-matter.kicad_sch')\n"
+        "except SchematicLoadError as e:\n"
+        "    assert e.kind == 'dependency_missing', e.kind\n"
+        "    assert 'pip install kicad-skip' in str(e), str(e)\n"
+        "    print('OK')\n"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_component_and_connection_schematic_import_without_kicad_skip():
+    result = _run(
+        "import commands.component_schematic\n"
+        "import commands.connection_schematic\n"
+        "print('OK')"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_unrelated_tool_still_works_without_kicad_skip():
+    result = _run(
+        "import kicad_interface\n"
+        "from commands.board.layers import BoardLayerCommands\n"
+        "import sys\n"
+        "BoardLayerCommands(board=sys.modules['pcbnew'].GetBoard())\n"
+        "print('OK')"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout


### PR DESCRIPTION
Six modules import `from skip import Schematic` at their own top level. Two of them, `library_schematic.py` and `schematic.py`, sit on the import chain `kicad_interface` -> `schematic_handlers` -> `library_schematic`/`schematic`, which runs at `kicad_interface.py:39`, before the file's own try/except import guard at line 335 is even reached. So a missing kicad-skip did not hit the intended `sys.exit(1)` with a clean JSON error at all: it raised an unhandled `ModuleNotFoundError` straight out of the module-level import, taking down every one of the 216 tools including the 210 that never touch kicad-skip.

Invariant: importing `kicad_interface` (or any of its command modules) must not require kicad-skip to be installed. Only the handful of tools that actually call into it may fail, and only with a structured, actionable error.

Fix, by module:

- `library_schematic.py`, `schematic_analysis.py`: `Schematic` was imported but never referenced anywhere in the file. Removed.
- `pin_locator.py`: same, never referenced in production code, but the existing test suite patches `commands.pin_locator.Schematic` as a seam, so the import is guarded (falls back to `None`) instead of removed.
- `component_schematic.py`, `connection_schematic.py`: `Schematic` is used only as a parameter type hint, never instantiated. Guarded with a fallback to `typing.Any`, matching this file's own existing `WIRE_MANAGER_AVAILABLE` pattern for `PinLocator`/`WireManager`.
- `schematic.py`: the one module that actually calls `Schematic(...)`. `create_schematic` and `load_schematic` now raise the existing `SchematicLoadError` with a new `dependency_missing` kind, naming the exact `pip install kicad-skip` command, instead of failing at import time.

Verification (clean container, kicad-skip genuinely absent via `sys.modules["skip"] = None`, checked on Python 3.9 and 3.12):
- New test file added: 4 tests fail on main with the unhandled `ModuleNotFoundError` above, pass on this branch. Covers the full `kicad_interface` import, the actionable error from `SchematicManager`, and that a tool needing no kicad-skip still works.
- Full existing suite: 2154 passed, 47 skipped (unchanged from main; skips are all pre-existing environment gates like `kicad-cli`/real `pcbnew`).
- `black --check` and `mypy` both clean.
- Not verified: real kicad-skip behavior end to end (this fix only concerns what happens when the package is absent).

Fixes #389.
