### PR TITLE
perf: batch net connectivity per sheet — list_schematic_nets O(nets × sheet) → one pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`list_schematic_nets` and `generate_netlist` no longer scale as
+  O(nets × sheet size)** — net connectivity was recomputed from scratch for
+  every net in the list: each per-net query re-parsed the schematic
+  s-expression tree (dozens of `sexpdata.loads` calls per net), rebuilt the
+  wire adjacency graph, and re-located every component pin through a fresh
+  `PinLocator`, whose caches died with it. On a flat 119-component, 44-net
+  schematic, `list_schematic_nets` took over 90 seconds. The per-sheet work is
+  now done once per request and shared across all nets
+  (`get_connections_for_nets`), `_load_sexp` actually caches the parsed tree
+  (keyed by file mtime and size, as its docstring always claimed), and
+  `PinLocator.get_all_symbol_pins` memoises per (schematic, reference). The
+  same schematic now lists in under 3 seconds, with identical results —
+  `get_connections_for_net` remains as a single-net wrapper for existing
+  callers.
+
 ## [2.7.0] - 2026-08-20
 
 ### New Tools

--- a/python/commands/connection_schematic.py
+++ b/python/commands/connection_schematic.py
@@ -420,7 +420,7 @@ class ConnectionManager:
             }
         """
         try:
-            from commands.wire_connectivity import get_connections_for_net
+            from commands.wire_connectivity import get_connections_for_nets
 
             netlist: Dict[str, Any] = {"nets": [], "components": []}
 
@@ -449,8 +449,12 @@ class ConnectionManager:
                             net_names.add(label.value)
 
             sch_path_str = str(schematic_path) if schematic_path else ""
-            for net_name in net_names:
-                connections = get_connections_for_net(schematic, sch_path_str, net_name)
+            # Batched: every sheet is parsed and pin-located once for the whole
+            # net list, instead of once per net.
+            connections_by_net = get_connections_for_nets(
+                schematic, sch_path_str, sorted(net_names)
+            )
+            for net_name, connections in connections_by_net.items():
                 if connections:
                     netlist["nets"].append({"name": net_name, "connections": connections})
 

--- a/python/commands/pin_locator.py
+++ b/python/commands/pin_locator.py
@@ -28,6 +28,10 @@ class PinLocator:
         self.pin_definition_cache = {}  # Cache: "lib_id:symbol_name" -> pin_data
         self._schematic_cache: Dict[str, object] = {}  # Cache: path -> loaded Schematic
         self._sexp_cache: Dict[str, Any] = {}  # Cache: path -> parsed sexpdata (mirror-aware)
+        # Cache: (path, reference) -> get_all_symbol_pins result. Consistent
+        # with _schematic_cache: results reflect the schematic as first loaded
+        # by this locator instance.
+        self._all_pins_cache: Dict[Tuple[str, str], Dict[str, List[float]]] = {}
 
     @staticmethod
     def parse_symbol_definition(symbol_def: list) -> Dict[str, Dict]:
@@ -575,11 +579,15 @@ class PinLocator:
             symbol_reference: Symbol reference designator (e.g., "R1", "U1")
 
         Returns:
-            Dictionary mapping pin number -> [x, y] coordinates
+            Dictionary mapping pin number -> [x, y] coordinates.
+            The returned dict is cached and shared — treat it as read-only.
         """
         try:
             # Load schematic (use cache)
             sch_key = str(schematic_path)
+            cache_key = (sch_key, symbol_reference)
+            if cache_key in self._all_pins_cache:
+                return self._all_pins_cache[cache_key]
             if sch_key not in self._schematic_cache:
                 self._schematic_cache[sch_key] = SchematicManager.load_schematic(sch_key)
             sch = self._schematic_cache[sch_key]
@@ -593,17 +601,20 @@ class PinLocator:
 
             if not target_symbol:
                 logger.error(f"Symbol {symbol_reference} not found")
+                self._all_pins_cache[cache_key] = {}
                 return {}
 
             # Get lib_id
             lib_id = target_symbol.lib_id.value if hasattr(target_symbol, "lib_id") else None
             if not lib_id:
                 logger.error(f"Symbol {symbol_reference} has no lib_id")
+                self._all_pins_cache[cache_key] = {}
                 return {}
 
             # Get pin definitions
             pins = self.get_symbol_pins(schematic_path, lib_id)
             if not pins:
+                self._all_pins_cache[cache_key] = {}
                 return {}
 
             # Calculate location for each pin
@@ -614,6 +625,7 @@ class PinLocator:
                     result[pin_num] = location
 
             logger.info(f"Located {len(result)} pins on {symbol_reference}")
+            self._all_pins_cache[cache_key] = result
             return result
 
         except SchematicLoadError:

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -1660,6 +1660,7 @@ class SchematicHandlersMixin:
         """List all nets in a schematic with their connections"""
         logger.info("Listing schematic nets")
         try:
+            from commands.pin_locator import PinLocator
             from commands.wire_connectivity import (
                 _build_adjacency,
                 _discover_sub_sheets,
@@ -1668,7 +1669,7 @@ class SchematicHandlersMixin:
                 _parse_virtual_connections,
                 _parse_wires,
                 count_pins_on_net,
-                get_connections_for_net,
+                get_connections_for_nets,
             )
 
             schematic_path = params.get("schematicPath")
@@ -1722,9 +1723,19 @@ class SchematicHandlersMixin:
                 adjacency, iu_to_wires = [], {}
             point_to_label, label_to_points = _parse_virtual_connections(schematic, schematic_path)
 
+            # One shared locator + one batched connectivity pass: every sheet
+            # is parsed and pin-located once for the whole net list, instead of
+            # once per net (which made this handler O(nets × sheet size) and
+            # took minutes on large flat schematics).
+            sorted_net_names = sorted(net_names)
+            locator = PinLocator()
+            connections_by_net = get_connections_for_nets(
+                schematic, schematic_path, sorted_net_names, locator=locator
+            )
+
             nets = []
-            for net_name in sorted(net_names):
-                connections = get_connections_for_net(schematic, schematic_path, net_name)
+            for net_name in sorted_net_names:
+                connections = connections_by_net[net_name]
                 pin_count = count_pins_on_net(
                     schematic,
                     schematic_path,
@@ -1734,6 +1745,7 @@ class SchematicHandlersMixin:
                     adjacency,
                     point_to_label,
                     label_to_points,
+                    locator=locator,
                 )
                 nets.append(
                     {

--- a/python/commands/wire_connectivity.py
+++ b/python/commands/wire_connectivity.py
@@ -10,6 +10,7 @@ sub-sheet files and bridging nets via hierarchical labels / sheet pins.
 """
 
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -28,10 +29,29 @@ def _to_iu(x_mm: float, y_mm: float) -> Tuple[int, int]:
     return (round(x_mm * _IU_PER_MM), round(y_mm * _IU_PER_MM))
 
 
+# path -> ((mtime_ns, size), parsed tree). Invalidated when the file changes
+# on disk, so repeated per-net/per-tool queries against the same schematic
+# don't re-read and re-parse it (sexpdata.loads on a multi-hundred-KB sheet
+# costs ~50 ms, and net tracing used to trigger it dozens of times per call).
+_SEXP_CACHE: Dict[str, Tuple[Tuple[int, int], list]] = {}
+
+
 def _load_sexp(schematic_path: str) -> list:
-    """Load and cache the raw sexpdata tree for a schematic file."""
-    with open(schematic_path, "r", encoding="utf-8") as f:
-        return sexpdata.loads(f.read())
+    """Load and cache the raw sexpdata tree for a schematic file.
+
+    Callers must treat the returned tree as read-only: it is shared across
+    all callers until the file's mtime/size changes.
+    """
+    key = str(schematic_path)
+    st = os.stat(key)
+    stamp = (st.st_mtime_ns, st.st_size)
+    cached = _SEXP_CACHE.get(key)
+    if cached is not None and cached[0] == stamp:
+        return cached[1]
+    with open(key, "r", encoding="utf-8") as f:
+        sexp = sexpdata.loads(f.read())
+    _SEXP_CACHE[key] = (stamp, sexp)
+    return sexp
 
 
 def _parse_wires_sexp(sexp: list) -> List[List[Tuple[int, int]]]:
@@ -576,12 +596,16 @@ def count_pins_on_net(
     adjacency: List[Set[int]],
     point_to_label: Dict[Tuple[int, int], str],
     label_to_points: Dict[str, List[Tuple[int, int]]],
+    locator: Optional[PinLocator] = None,
 ) -> int:
     """Count the number of component pins connected to the named net.
 
     A pin is counted if its IU coordinate falls on the wire-network reachable
     from any label anchor for *net_name*, or directly on a label anchor of that
     net (pin directly touching a label with no intervening wire).
+
+    Callers that query many nets should pass a shared ``locator`` so its
+    per-schematic caches survive across calls instead of being rebuilt per net.
 
     Returns the count of distinct (component, pin_num) pairs on this net.
     """
@@ -612,7 +636,8 @@ def count_pins_on_net(
     if not hasattr(schematic, "symbol"):
         return 0
 
-    locator = PinLocator()
+    if locator is None:
+        locator = PinLocator()
     seen: Set[Tuple[str, str]] = set()
     ref = None
     for symbol in schematic.symbol:
@@ -795,9 +820,7 @@ def _discover_sub_sheets(schematic_path: str) -> List[str]:
     parent_dir = Path(schematic_path).parent
     result: List[str] = []
     try:
-        with open(schematic_path, "r", encoding="utf-8") as f:
-            content = f.read()
-        sexp = sexpdata.loads(content)
+        sexp = _load_sexp(schematic_path)
     except Exception as e:
         logger.warning(f"Could not parse {schematic_path} for sub-sheets: {e}")
         return result
@@ -833,9 +856,7 @@ def _parse_hierarchical_labels_sexp(
     """
     result: Dict[str, List[Tuple[int, int]]] = {}
     try:
-        with open(schematic_path, "r", encoding="utf-8") as f:
-            content = f.read()
-        sexp = sexpdata.loads(content)
+        sexp = _load_sexp(schematic_path)
     except Exception as e:
         logger.warning(f"Could not parse {schematic_path} for hierarchical labels: {e}")
         return result
@@ -856,22 +877,99 @@ def _parse_hierarchical_labels_sexp(
     return result
 
 
-def _process_single_sheet(
+def _build_sheet_pin_index(
+    sexp: list, schematic_path: str, locator: PinLocator
+) -> List[Tuple[str, str, Tuple[int, int]]]:
+    """Compute the world IU position of every component pin on a sheet, once.
+
+    Applies the same instance filtering as per-net pin matching (skips
+    ``_TEMPLATE``/power symbols, restricts multi-unit instances to their own
+    unit's pins plus unit 0) so a per-net membership test against the returned
+    index is equivalent to a full per-net scan.
+
+    Returns a list of (ref, pin_num, (ix, iy)) tuples.
+    """
+    index: List[Tuple[str, str, Tuple[int, int]]] = []
+    instances = _parse_symbol_instances_sexp(sexp)
+    logger.debug(f"Found {len(instances)} symbol instances via sexpdata")
+
+    for inst in instances:
+        ref = inst["ref"]
+        try:
+            if ref.startswith("_TEMPLATE") or ref.startswith("#"):
+                continue
+
+            lib_id = inst["lib_id"]
+            pin_defs = locator.get_symbol_pins(Path(schematic_path), lib_id)
+            if not pin_defs:
+                logger.debug(f"  {ref}: no pin definitions for lib_id={lib_id}")
+                continue
+
+            # For a multi-unit component, each placed instance carries a single
+            # (unit N) and only owns the pins defined in that unit's sub-symbol
+            # (plus unit 0, which is common to every unit). Without this filter,
+            # every unit's pins are transformed against every instance's
+            # position, so a sibling unit's pin can land on this instance's wire
+            # and be reported as a phantom member of the net (#293).
+            inst_unit = inst["unit"]
+            if inst_unit:
+                pin_defs = {
+                    num: pdata
+                    for num, pdata in pin_defs.items()
+                    if pdata.get("unit", 0) in (0, inst_unit)
+                }
+                if not pin_defs:
+                    continue
+
+            for pin_num, pdata in pin_defs.items():
+                # Use the shared symbol->world transform so pin geometry matches
+                # eeschema (Y-flip -> rotate -> mirror -> translate). A local copy
+                # of this math applied mirror before rotation, which disagrees with
+                # pin_world_xy for 90/270 rotations and mislocated pins on rotated
+                # symbols, dropping them from their own net's pin list.
+                abs_x, abs_y = WireDragger.pin_world_xy(
+                    pdata["x"],
+                    pdata["y"],
+                    inst["x"],
+                    inst["y"],
+                    inst["rotation"],
+                    inst["mirror_x"],
+                    inst["mirror_y"],
+                )
+                index.append((ref, pin_num, _to_iu(abs_x, abs_y)))
+        except Exception as e:
+            logger.warning(f"Error checking pins for {ref}: {e}")
+
+    return index
+
+
+def _process_single_sheet_nets(
     schematic: Any,
     schematic_path: str,
-    net_name: str,
-) -> List[Dict]:
-    """Find pins connected to *net_name* on a single schematic sheet.
+    net_names: List[str],
+    locator: Optional[PinLocator] = None,
+) -> Dict[str, List[Dict]]:
+    """Find pins connected to each of *net_names* on a single schematic sheet.
 
     Handles label, global_label, hierarchical_label, and power symbols.
     All wire and label data is parsed directly from the raw .kicad_sch file
     via sexpdata for maximum reliability.
+
+    The sheet-wide work (sexp parse, wire graph, virtual connections, pin
+    world positions) is done once and shared by every requested net, so
+    resolving N nets costs one sheet scan plus N cheap BFS+membership passes
+    instead of N full scans.
+
+    Returns {net_name: [{"component": ref, "pin": pin_num}, ...]}.
     """
+    if locator is None:
+        locator = PinLocator()
+
     try:
         sexp = _load_sexp(schematic_path)
     except Exception as e:
         logger.warning(f"Could not load sexp for {schematic_path}: {e}")
-        return []
+        return {net_name: [] for net_name in net_names}
 
     all_wires = _parse_wires_sexp(sexp)
     logger.debug(f"Parsed {len(all_wires)} wires from {schematic_path}")
@@ -885,70 +983,120 @@ def _process_single_sheet(
         schematic, schematic_path, sexp=sexp
     )
 
-    seed_positions = label_to_points.get(net_name, [])
-    if not seed_positions:
-        logger.debug(f"No label positions found for net '{net_name}' in {schematic_path}")
-        return []
+    # Built lazily: sheets where none of the requested nets have labels
+    # (common for sub-sheets) never pay for pin location.
+    pin_index: Optional[List[Tuple[str, str, Tuple[int, int]]]] = None
 
-    logger.debug(
-        f"Net '{net_name}': {len(seed_positions)} seed position(s) — "
-        f"{[f'({p[0]/10000},{p[1]/10000})' for p in seed_positions]}"
-    )
-
-    net_points: Set[Tuple[int, int]] = set()
-
-    for seed_pt in seed_positions:
-        net_points.add(seed_pt)
-        if not all_wires:
+    results: Dict[str, List[Dict]] = {}
+    for net_name in net_names:
+        seed_positions = label_to_points.get(net_name, [])
+        if not seed_positions:
+            logger.debug(f"No label positions found for net '{net_name}' in {schematic_path}")
+            results[net_name] = []
             continue
-        visited, pts = _find_connected_wires(
-            seed_pt[0] / _IU_PER_MM,
-            seed_pt[1] / _IU_PER_MM,
-            all_wires,
-            iu_to_wires,
-            adjacency,
-            point_to_label=point_to_label,
-            label_to_points=label_to_points,
+
+        logger.debug(
+            f"Net '{net_name}': {len(seed_positions)} seed position(s) — "
+            f"{[f'({p[0]/10000},{p[1]/10000})' for p in seed_positions]}"
         )
-        if pts:
-            logger.debug(
-                f"BFS from seed ({seed_pt[0]/10000},{seed_pt[1]/10000}) "
-                f"found {len(pts)} points via {len(visited) if visited else 0} wires"
+
+        net_points: Set[Tuple[int, int]] = set()
+
+        for seed_pt in seed_positions:
+            net_points.add(seed_pt)
+            if not all_wires:
+                continue
+            visited, pts = _find_connected_wires(
+                seed_pt[0] / _IU_PER_MM,
+                seed_pt[1] / _IU_PER_MM,
+                all_wires,
+                iu_to_wires,
+                adjacency,
+                point_to_label=point_to_label,
+                label_to_points=label_to_points,
             )
-            net_points.update(pts)
-        else:
-            logger.debug(
-                f"BFS from seed ({seed_pt[0]/10000},{seed_pt[1]/10000}) "
-                f"found NO connected wires"
+            if pts:
+                logger.debug(
+                    f"BFS from seed ({seed_pt[0]/10000},{seed_pt[1]/10000}) "
+                    f"found {len(pts)} points via {len(visited) if visited else 0} wires"
+                )
+                net_points.update(pts)
+            else:
+                logger.debug(
+                    f"BFS from seed ({seed_pt[0]/10000},{seed_pt[1]/10000}) "
+                    f"found NO connected wires"
+                )
+
+        logger.debug(f"Net '{net_name}': total {len(net_points)} IU points in net after BFS")
+
+        if pin_index is None:
+            pin_index = _build_sheet_pin_index(sexp, schematic_path, locator)
+
+        # Exact IU match first, then ±1 IU tolerance for floating-point
+        # rounding edge cases (same policy as _find_pins_on_net).
+        pins: List[Dict] = []
+        seen: Set[Tuple[str, str]] = set()
+        for ref, pin_num, (ix, iy) in pin_index:
+            on_net = (ix, iy) in net_points or any(
+                (ix + dx, iy + dy) in net_points
+                for dx in (-1, 0, 1)
+                for dy in (-1, 0, 1)
             )
+            if on_net:
+                key = (ref, pin_num)
+                if key not in seen:
+                    seen.add(key)
+                    pins.append({"component": ref, "pin": pin_num})
+        results[net_name] = pins
 
-    logger.debug(f"Net '{net_name}': total {len(net_points)} IU points in net after BFS")
-
-    return _find_pins_on_net(net_points, schematic_path, schematic, sexp=sexp)
+    return results
 
 
-def get_connections_for_net(schematic: Any, schematic_path: str, net_name: str) -> List[Dict]:
-    """Find all component pins connected to a named net across all schematic sheets.
+def _process_single_sheet(
+    schematic: Any,
+    schematic_path: str,
+    net_name: str,
+) -> List[Dict]:
+    """Find pins connected to *net_name* on a single schematic sheet.
+
+    Single-net convenience wrapper around :func:`_process_single_sheet_nets`.
+    """
+    return _process_single_sheet_nets(schematic, schematic_path, [net_name])[net_name]
+
+
+def get_connections_for_nets(
+    schematic: Any,
+    schematic_path: str,
+    net_names: List[str],
+    locator: Optional[PinLocator] = None,
+) -> Dict[str, List[Dict]]:
+    """Find all component pins connected to each named net across all sheets.
 
     Recursively discovers sub-sheets, processes each sheet independently, and
     merges results. Handles label, global_label, hierarchical_label, and
     power symbol connections.
 
-    Returns a list of {"component": ref, "pin": pin_num} dicts.
+    Every sheet (including each sub-sheet) is loaded and scanned exactly once
+    for the whole batch of nets — callers listing many nets should use this
+    instead of calling :func:`get_connections_for_net` in a loop.
+
+    Returns {net_name: [{"component": ref, "pin": pin_num}, ...]}.
     """
-    from skip import Schematic as SkipSchematic
+    if locator is None:
+        locator = PinLocator()
 
-    seen: Set[Tuple[str, str]] = set()
-    all_pins: List[Dict] = []
+    seen: Dict[str, Set[Tuple[str, str]]] = {net_name: set() for net_name in net_names}
+    results: Dict[str, List[Dict]] = {net_name: [] for net_name in net_names}
 
-    def _collect(pins: List[Dict]) -> None:
-        for pin in pins:
-            key = (pin["component"], pin["pin"])
-            if key not in seen:
-                seen.add(key)
-                all_pins.append(pin)
+    def _collect(sheet_results: Dict[str, List[Dict]]) -> None:
+        for net_name, pins in sheet_results.items():
+            for pin in pins:
+                key = (pin["component"], pin["pin"])
+                if key not in seen[net_name]:
+                    seen[net_name].add(key)
+                    results[net_name].append(pin)
 
-    _collect(_process_single_sheet(schematic, schematic_path, net_name))
+    _collect(_process_single_sheet_nets(schematic, schematic_path, net_names, locator))
 
     sub_sheets = _discover_sub_sheets(schematic_path)
     for sub_path in sub_sheets:
@@ -956,7 +1104,7 @@ def get_connections_for_net(schematic: Any, schematic_path: str, net_name: str) 
             from commands.schematic import SchematicLoadError, SchematicManager
 
             sub_sch = SchematicManager.load_schematic(sub_path)
-            _collect(_process_single_sheet(sub_sch, sub_path, net_name))
+            _collect(_process_single_sheet_nets(sub_sch, sub_path, net_names, locator))
         except SchematicLoadError:
             # A broken sub-sheet must fail the hierarchical traversal loudly
             # instead of silently omitting that sheet's pins from the net.
@@ -964,4 +1112,14 @@ def get_connections_for_net(schematic: Any, schematic_path: str, net_name: str) 
         except Exception as e:
             logger.warning(f"Error processing sub-sheet {sub_path}: {e}")
 
-    return all_pins
+    return results
+
+
+def get_connections_for_net(schematic: Any, schematic_path: str, net_name: str) -> List[Dict]:
+    """Find all component pins connected to a named net across all schematic sheets.
+
+    Single-net convenience wrapper around :func:`get_connections_for_nets`.
+
+    Returns a list of {"component": ref, "pin": pin_num} dicts.
+    """
+    return get_connections_for_nets(schematic, schematic_path, [net_name])[net_name]


### PR DESCRIPTION
## Problem

`list_schematic_nets` recomputes connectivity from scratch for every net in the schematic. On a flat 119-component / 44-net schematic it ran for **90+ seconds** (and was cancelled by the user before finishing).

Profiling one `get_connections_for_net('GND')` call (2.1 s total) showed where it goes:

- `sexpdata.loads` runs **23 times per net** — `_load_sexp`'s docstring says "Load and cache" but there was no cache, and every per-net call re-parsed the same 384 KB `.kicad_sch`
- `pin_locator.get_symbol_pins` runs 155× per net, re-locating all pins for all components — every call site constructs a fresh `PinLocator()`, so its instance caches die between nets
- the handler loop then repeats all of this once per net; `generate_netlist` in `connection_schematic.py` has the identical loop

## Fix

- **`_load_sexp` now actually caches** the parsed tree, keyed by `(mtime_ns, size)` so on-disk edits still invalidate. `_discover_sub_sheets` and `_parse_hierarchical_labels_sexp` now go through it too.
- **New `get_connections_for_nets(schematic, path, net_names, locator=None)`** resolves a batch of nets with one pass per sheet: sexp parse, wire graph, virtual connections, and component pin world positions (`_build_sheet_pin_index`) are computed once and shared; each net then costs only its BFS + a membership check against the pin index. Sub-sheets are also loaded once per batch instead of once per net. `get_connections_for_net` / `_process_single_sheet` remain as single-net wrappers, so existing callers and behavior (multi-unit filtering per #293, ±1 IU tolerance, `SchematicLoadError` propagation) are unchanged.
- **`count_pins_on_net` accepts an optional shared `locator`**, and **`PinLocator.get_all_symbol_pins` memoises per `(schematic, reference)`** — it previously re-found the symbol and re-ran the per-pin transform on every call (44 nets × 119 symbols in the handler loop).
- `_handle_list_schematic_nets` and `generate_netlist` use the batched API with one shared locator. Netlist net order is now sorted (previously set-iteration order).

## Results

On the 119-component / 44-net schematic (KiCad bundled Python 3.9):

| | before | after |
|---|---|---|
| per-net connections loop | 62.1 s | 1.31 s (**47×**) |
| full `list_schematic_nets` handler path | ~75 s | **2.81 s** |

A/B equivalence check against the pre-fix implementation on the same schematic: all 44 nets return **identical** `(component, pin)` sets, and pin counts are unchanged.

## Testing

- Full Python suite: **2159 passed**, 38 skipped (environmental: missing 7-Zip/kicad-cli/Linux library paths)
- A/B comparison script (old module loaded side-by-side) confirming identical output on a real 384 KB production schematic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvUVwFTAdx3z4gW7jnY5w9