### PR TITLE
refactor: share KiCad text file helpers

### DIFF
--- a/python/commands/add_symbol_property.py
+++ b/python/commands/add_symbol_property.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-import os
 import re
 from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Any
 
-from utils.sexpr_format import escape_sexpr_string
+from utils.file_io import read_text_preserve_newline as _read_text
+from utils.file_io import write_text_atomic as _write_text
+from utils.sexpr_format import escape_sexpr_string, iter_child_offsets
+from utils.sexpr_format import match_paren as _match_paren
 
 # A property belongs to the symbol itself, so it has to sit at the same nesting
 # level as (property "Reference" ...). Inside the parent block that is depth 2:
@@ -20,60 +22,6 @@ _CHILD_DEPTH = 2
 _AT_HEAD = re.compile(r"\(at\s")
 
 _HIDE_LIST = re.compile(r"\(hide\s+(yes|no)\s*\)")
-
-
-def _read_text(path: Path) -> tuple[str, str]:
-    """File text with LF newlines, plus the newline style to write back.
-
-    ``Path.read_text``/``write_text`` apply universal-newline translation, so on
-    Windows a CRLF library round-tripped through them keeps its line endings by
-    luck and an LF one silently gains a ``\\r`` on every line -- turning a
-    one-property edit into a whole-file diff.
-    """
-    with open(path, "r", encoding="utf-8", newline="") as fh:
-        raw = fh.read()
-    return raw.replace("\r\n", "\n"), ("\r\n" if "\r\n" in raw else "\n")
-
-
-def _write_text(path: Path, text: str, newline: str) -> None:
-    """Atomic write that keeps the file's original newline style.
-
-    ``write_text`` truncates in place, so a failure part-way through the write
-    leaves a 2 MB library half-written with no copy of the original anywhere.
-    """
-    tmp = path.with_name(path.name + ".mcp-tmp")
-    with open(tmp, "w", encoding="utf-8", newline=newline) as fh:
-        fh.write(text)
-    os.replace(tmp, path)
-
-
-def _match_paren(content: str, open_idx: int) -> int:
-    """Index of the ``)`` closing the ``(`` at *open_idx*, or -1 if unbalanced.
-
-    Parentheses inside quoted tokens are literal text -- a Description of
-    ``"Cap (X7R)"`` must not be read as a nested list.
-    """
-    depth = 0
-    in_string = False
-    i = open_idx
-    while i < len(content):
-        ch = content[i]
-        if in_string:
-            if ch == "\\":
-                i += 2
-                continue
-            if ch == '"':
-                in_string = False
-        elif ch == '"':
-            in_string = True
-        elif ch == "(":
-            depth += 1
-        elif ch == ")":
-            depth -= 1
-            if depth == 0:
-                return i
-        i += 1
-    return -1
 
 
 def _paren_balance(content: str) -> int:
@@ -101,26 +49,7 @@ def _paren_balance(content: str) -> int:
 
 def _iter_children(block: str) -> Iterator[int]:
     """Yield the offset of every direct child list inside a symbol *block*."""
-    depth = 0
-    in_string = False
-    i = 0
-    while i < len(block):
-        ch = block[i]
-        if in_string:
-            if ch == "\\":
-                i += 2
-                continue
-            if ch == '"':
-                in_string = False
-        elif ch == '"':
-            in_string = True
-        elif ch == "(":
-            depth += 1
-            if depth == _CHILD_DEPTH:
-                yield i
-        elif ch == ")":
-            depth -= 1
-        i += 1
+    yield from iter_child_offsets(block, depth=_CHILD_DEPTH)
 
 
 def _iter_bare_atoms(block: str) -> Iterator[tuple[int, int]]:

--- a/python/commands/backannotate_footprints.py
+++ b/python/commands/backannotate_footprints.py
@@ -45,6 +45,8 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple
 
+from utils.file_io import read_text_preserve_newline as _read_text
+from utils.file_io import write_text_atomic as _write_text
 from utils.sexpr_format import (
     QUOTED_VALUE,
     escape_sexpr_string,
@@ -72,21 +74,6 @@ _REFERENCE_TOKEN = re.compile(rf"\(reference\s+{QUOTED_VALUE}")
 
 # KiCad 6+ stores a footprint's designator as a property; KiCad 5 used fp_text.
 _FP_TEXT_REFERENCE = re.compile(rf"\(fp_text\s+reference\s+{QUOTED_VALUE}")
-
-
-def _read_text(path: Path) -> Tuple[str, str]:
-    """File text with LF newlines, plus the newline style to write back."""
-    with open(path, "r", encoding="utf-8", newline="") as fh:
-        raw = fh.read()
-    return raw.replace("\r\n", "\n"), ("\r\n" if "\r\n" in raw else "\n")
-
-
-def _write_text(path: Path, text: str, newline: str) -> None:
-    """Atomic write that keeps the file's original newline style."""
-    tmp = path.with_name(path.name + ".mcp-tmp")
-    with open(tmp, "w", encoding="utf-8", newline=newline) as fh:
-        fh.write(text)
-    os.replace(tmp, path)
 
 
 def _read(path: Path, kind: str) -> Tuple[Optional[str], str, Optional[Dict[str, Any]]]:

--- a/python/commands/library_tables.py
+++ b/python/commands/library_tables.py
@@ -43,8 +43,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
+from utils.file_io import read_text_preserve_newline as _read_text
+from utils.file_io import write_text_atomic as _write_text
 from utils.platform_helper import PlatformHelper
-from utils.sexpr_format import escape_sexpr_string, unescape_sexpr_string
+from utils.sexpr_format import escape_sexpr_string
+from utils.sexpr_format import match_paren as _match_paren
+from utils.sexpr_format import unescape_sexpr_string
 
 logger = logging.getLogger("kicad_interface")
 
@@ -94,29 +98,6 @@ def _kicad_config_dirs() -> List[Path]:
     return [root / version for version in _KICAD_VERSIONS for root in roots]
 
 
-def _read_text(path: Path) -> Tuple[str, str]:
-    """File text with LF newlines, plus the newline style to write back."""
-    with open(path, "r", encoding="utf-8", newline="") as fh:
-        raw = fh.read()
-    return raw.replace("\r\n", "\n"), ("\r\n" if "\r\n" in raw else "\n")
-
-
-def _write_text(path: Path, text: str, newline: str) -> None:
-    """Atomic write that keeps the file's original newline style."""
-    tmp = path.with_name(path.name + ".mcp-tmp")
-    try:
-        with open(tmp, "w", encoding="utf-8", newline=newline) as fh:
-            fh.write(text)
-        os.replace(tmp, path)
-    except OSError:
-        # Never leave a half-written scratch file beside a live KiCad config.
-        try:
-            tmp.unlink()
-        except OSError:
-            pass
-        raise
-
-
 def _backup(path: Path) -> Optional[str]:
     """Copy the table into a sibling ``.mcp-backups/`` before it is rewritten.
 
@@ -136,31 +117,6 @@ def _backup(path: Path) -> Optional[str]:
     except OSError as exc:
         logger.warning(f"Library-table backup failed (continuing): {exc}")
         return None
-
-
-def _match_paren(content: str, open_idx: int) -> int:
-    """Index of the ``)`` closing the ``(`` at *open_idx*, or -1 if unbalanced."""
-    depth = 0
-    in_string = False
-    i = open_idx
-    while i < len(content):
-        ch = content[i]
-        if in_string:
-            if ch == "\\":
-                i += 2
-                continue
-            if ch == '"':
-                in_string = False
-        elif ch == '"':
-            in_string = True
-        elif ch == "(":
-            depth += 1
-        elif ch == ")":
-            depth -= 1
-            if depth == 0:
-                return i
-        i += 1
-    return -1
 
 
 def _child_spans(content: str, open_idx: int) -> List[Tuple[int, int]]:

--- a/python/commands/set_symbol_pin_type.py
+++ b/python/commands/set_symbol_pin_type.py
@@ -44,13 +44,14 @@ nobody.
 from __future__ import annotations
 
 import logging
-import os
 import re
 import shutil
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
+from utils.file_io import read_text_preserve_newline as _read_text
+from utils.file_io import write_text_atomic as _write_text
 from utils.pin_types import PIN_STYLES, PIN_TYPES
 from utils.sexpr_format import match_paren
 
@@ -106,32 +107,6 @@ def _backup(path: Path) -> Optional[Path]:
         return None
     _prune_backups(backup_dir, path.name)
     return dest
-
-
-def _read_text(path: Path) -> Tuple[str, str]:
-    """File text with LF newlines, plus the newline style to write back."""
-    with open(path, "r", encoding="utf-8", newline="") as fh:
-        raw = fh.read()
-    return raw.replace("\r\n", "\n"), ("\r\n" if "\r\n" in raw else "\n")
-
-
-def _write_text(path: Path, text: str, newline: str) -> None:
-    """Atomic write that keeps the file's original newline style.
-
-    The temporary file is removed on failure so a full disk does not leave a
-    second copy of the library beside the first.
-    """
-    tmp = path.with_name(path.name + ".mcp-tmp")
-    try:
-        with open(tmp, "w", encoding="utf-8", newline=newline) as fh:
-            fh.write(text)
-        os.replace(tmp, path)
-    except OSError:
-        try:
-            os.remove(tmp)
-        except OSError:
-            pass
-        raise
 
 
 def _read_string(text: str, i: int) -> Tuple[Optional[str], int]:

--- a/python/utils/file_io.py
+++ b/python/utils/file_io.py
@@ -1,0 +1,28 @@
+"""File I/O helpers for KiCad text files."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def read_text_preserve_newline(path: Path) -> tuple[str, str]:
+    """Read UTF-8 text as LF internally and return the original newline style."""
+    with open(path, "r", encoding="utf-8", newline="") as fh:
+        raw = fh.read()
+    return raw.replace("\r\n", "\n"), ("\r\n" if "\r\n" in raw else "\n")
+
+
+def write_text_atomic(path: Path, text: str, newline: str) -> None:
+    """Atomically write UTF-8 text while preserving the caller's newline style."""
+    tmp = path.with_name(path.name + ".mcp-tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8", newline=newline) as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise

--- a/tests/test_add_symbol_property.py
+++ b/tests/test_add_symbol_property.py
@@ -1,5 +1,6 @@
 """Tests for add_symbol_property — add custom properties to .kicad_sym library files."""
 
+import os
 import shutil
 import subprocess
 import sys
@@ -888,15 +889,13 @@ def test_write_leaves_no_temp_file(tmp_path):
 
 def test_failed_write_leaves_original_intact(tmp_path, monkeypatch):
     """The rename is the commit point: a failure before it cannot truncate."""
-    import commands.add_symbol_property as mod
-
     p = tmp_path / "atomic.kicad_sym"
     p.write_bytes(_NEWLINE_LIB.encode("utf-8"))
 
     def boom(src, dst):
         raise OSError("disk full")
 
-    monkeypatch.setattr(mod.os, "replace", boom)
+    monkeypatch.setattr(os, "replace", boom)
     with pytest.raises(OSError):
         add_symbol_property(
             {


### PR DESCRIPTION
## What
Fixes #380. Consolidates the duplicated KiCad text read/write helpers used by the Python file-editing tools.

## Fix
Adds `utils.file_io` for newline-preserving reads and atomic writes, then points the four private helper copies at it while keeping the shared paren walkers in `utils.sexpr_format`.

## Test
No new cases; existing add-symbol-property, backannotation, library-table, and pin-type regression tests cover the moved helpers.