### PR TITLE
fix: stop discovery tools telling clients to call deleted execute_tool

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -397,7 +397,7 @@ export function searchTools(query: string): SearchResult[] {
       matches.push({
         category: "direct",
         tool: toolName,
-        description: `${toolName} (direct tool — call directly, no execute_tool needed)`,
+        description: `${toolName} (direct tool — call directly by name)`,
       });
     }
   }

--- a/src/tools/router.ts
+++ b/src/tools/router.ts
@@ -1,7 +1,16 @@
 /**
- * Router Tools for KiCAD MCP Server
+ * Tool discovery for the KiCAD MCP Server.
  *
- * Provides discovery and execution of routed tools
+ * These three tools browse and search the registry in `registry.ts`. They do
+ * not execute anything on the caller's behalf. Every tool is registered
+ * directly with the server and is callable by name, so discovery is a search
+ * catalogue rather than a gate.
+ *
+ * The original gated design routed calls through a single `execute_tool`. It
+ * was disabled in 3d9497e because indirect execution made the model
+ * hallucinate tool schemas, and `execute_tool` was deleted in 963a39c. Response
+ * text here must therefore never tell a client to call `execute_tool`; see
+ * tests-ts/no-stale-tool-references.test.ts, which enforces that.
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -28,7 +37,7 @@ export function registerRouterTools(server: McpServer, _callKicadScript: Command
   // ============================================================================
   server.tool(
     "list_tool_categories",
-    "List all available KiCAD tool categories with their descriptions and tool counts. Use this to discover which tools are available via the router.",
+    "List all available KiCAD tool categories with their descriptions and tool counts. Use this to discover which tools exist; every tool can then be called directly by name.",
     {
       // No parameters
     },
@@ -42,7 +51,7 @@ export function registerRouterTools(server: McpServer, _callKicadScript: Command
         total_categories: stats.total_categories,
         total_routed_tools: stats.total_routed_tools,
         total_direct_tools: stats.total_direct_tools,
-        note: "Use get_category_tools to see tools in each category. Direct tools are always available.",
+        note: "Use get_category_tools to see the tools in each category. Every tool is registered directly on the server and is called by name.",
         categories: categories.map((c) => ({
           name: c.name,
           description: c.description,
@@ -102,9 +111,9 @@ export function registerRouterTools(server: McpServer, _callKicadScript: Command
         tool_count: categoryData.tools.length,
         tools: categoryData.tools.map((toolName) => ({
           name: toolName,
-          description: `Use execute_tool with tool_name="${toolName}" to run this tool`,
+          description: `Call ${toolName} directly by name.`,
         })),
-        note: "Use execute_tool to run any of these tools with appropriate parameters",
+        note: "Call any of these tools directly by name with its own parameters.",
       };
 
       return {
@@ -138,7 +147,7 @@ export function registerRouterTools(server: McpServer, _callKicadScript: Command
         matches: matches,
         note:
           matches.length > 0
-            ? "Use execute_tool with the tool name to run it"
+            ? "Call a matching tool directly by name with its own parameters."
             : "No tools found matching your query. Try list_tool_categories to browse all categories.",
       };
 

--- a/tests-ts/no-stale-tool-references.test.ts
+++ b/tests-ts/no-stale-tool-references.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { registerRouterTools } from "../src/tools/router.js";
+
+// The discovery tools (list_tool_categories, get_category_tools, search_tools)
+// return prose telling the client how to run what it just found. That prose is
+// read by a model, so a stale instruction there is not cosmetic: it sends the
+// model after a tool that does not exist.
+//
+// This regressed for two releases. The gated router was disabled in 3d9497e
+// because indirect execution made the model hallucinate tool schemas, and
+// `execute_tool` was deleted in 963a39c -- but the response strings kept
+// telling clients to call it. A single search_tools reply could contain both
+// "call directly, no execute_tool needed" (registry.ts) and "Use execute_tool
+// with the tool name to run it" (router.ts), contradicting itself.
+//
+// The assertion is on RUNTIME OUTPUT rather than source text on purpose. The
+// file header in router.ts legitimately explains this history and names
+// `execute_tool` in a comment; grepping the source would flag that comment and
+// push a future author to delete the explanation. What must stay clean is what
+// actually reaches a client.
+
+const TOOLS_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "tools");
+
+type Handler = (args: Record<string, unknown>) => Promise<{ content: { text: string }[] }>;
+
+/**
+ * Minimal stand-in for McpServer that records what registerRouterTools()
+ * registers, so the handlers can be invoked without standing up a server.
+ */
+function recordRouterTools(): Map<string, Handler> {
+  const handlers = new Map<string, Handler>();
+  const fakeServer = {
+    tool: (name: string, _description: string, _schema: unknown, handler: Handler) => {
+      handlers.set(name, handler);
+    },
+  };
+  // The command function is never called by the discovery tools: they only read
+  // the in-process registry. Failing loudly is better than returning a stub,
+  // because it proves discovery stayed read-only.
+  const callKicad = async () => {
+    throw new Error("discovery tools must not call into KiCAD");
+  };
+  registerRouterTools(fakeServer as never, callKicad as never);
+  return handlers;
+}
+
+async function textOf(handler: Handler, args: Record<string, unknown> = {}): Promise<string> {
+  const res = await handler(args);
+  return res.content.map((c) => c.text).join("\n");
+}
+
+/** Every tool actually wired into the server via server.tool("name", ...). */
+function registeredToolNames(): Set<string> {
+  const names = new Set<string>();
+  for (const file of readdirSync(TOOLS_DIR).filter((f) => f.endsWith(".ts"))) {
+    const src = readFileSync(join(TOOLS_DIR, file), "utf-8");
+    for (const m of src.matchAll(/server\.tool\(\s*["'`]([^"'`]+)["'`]/g)) {
+      names.add(m[1]);
+    }
+  }
+  return names;
+}
+
+describe("discovery responses do not reference deleted tools", () => {
+  it("execute_tool is not registered anywhere", () => {
+    expect(registeredToolNames().has("execute_tool")).toBe(false);
+  });
+
+  it("registers the three read-only discovery tools", () => {
+    const handlers = recordRouterTools();
+    expect([...handlers.keys()].sort()).toEqual([
+      "get_category_tools",
+      "list_tool_categories",
+      "search_tools",
+    ]);
+  });
+
+  it("no discovery response mentions execute_tool", async () => {
+    const handlers = recordRouterTools();
+
+    const responses = [
+      await textOf(handlers.get("list_tool_categories")!),
+      await textOf(handlers.get("get_category_tools")!, { category: "export" }),
+      await textOf(handlers.get("search_tools")!, { query: "gerber" }),
+      // A direct tool, which is the branch in registry.ts searchTools() that
+      // used to say "no execute_tool needed".
+      await textOf(handlers.get("search_tools")!, { query: "project" }),
+      // The no-match branch has its own note; check it too.
+      await textOf(handlers.get("search_tools")!, { query: "zzzz-no-such-tool" }),
+    ];
+
+    for (const body of responses) {
+      expect(body).not.toContain("execute_tool");
+    }
+  });
+
+  it("every tool named in a discovery response is actually registered", async () => {
+    const handlers = recordRouterTools();
+    const registered = registeredToolNames();
+
+    const body = await textOf(handlers.get("get_category_tools")!, { category: "export" });
+    const parsed = JSON.parse(body) as { tools: { name: string }[] };
+
+    expect(parsed.tools.length).toBeGreaterThan(0);
+    for (const tool of parsed.tools) {
+      expect(registered, `${tool.name} is advertised but not registered`).toContain(tool.name);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The three discovery tools (`list_tool_categories`, `get_category_tools`,
`search_tools`) tell the client how to run what it just found. That text is read
by a model, so a stale instruction is not cosmetic: it sends the model after a
tool that does not exist.

They still instruct clients to call `execute_tool`, which is not registered on
the server:

- `c656000` added the gated router with a single `execute_tool` entry point.
- `3d9497e` disabled the gate because routing calls through one indirect entry
  point made the model hallucinate tool schemas.
- `963a39c` deleted `execute_tool` itself.

The response strings were never updated. The result is self-contradictory
within a single reply: `searchTools()` labels direct tools
"call directly, no execute_tool needed" while the router note in the same
response says to use `execute_tool` for routed ones. A model following either
half is sent to a nonexistent tool.

All 144 registry tools are callable directly by name, so the corrected text
simply says so.

## Changes

- `src/tools/router.ts` (5 edits)
  - File header now records the discovery-only status and the
    `3d9497e` -> `963a39c` history, so the next reader does not "restore" the
    removed path.
  - `list_tool_categories` description and note.
  - `get_category_tools` per-tool description and note.
  - `search_tools` note.
- `src/tools/registry.ts` (1 edit)
  - `searchTools()` direct-tool text: "call directly, no execute_tool needed"
    becomes "call directly by name".
- `tests-ts/no-stale-tool-references.test.ts` (new)

## About the test

The guard asserts on **runtime responses**, not on source text.

A source grep would flag the file header in `router.ts` that legitimately
explains this history by name, which would pressure a future author to delete
the explanation in order to make CI pass. What must stay clean is what actually
reaches a client.

The test registers the router against a small recording stand-in for
`McpServer`, invokes the real handlers, and asserts:

1. `execute_tool` is not registered anywhere.
2. Exactly the three read-only discovery tools are registered.
3. No discovery response body mentions `execute_tool`, covering the matched,
   direct-tool, and no-match branches.
4. Every tool name advertised in a response is actually registered via
   `server.tool(`.

The stand-in's command function throws if called, which also proves the
discovery tools stay read-only and never reach into KiCAD.

## Verification

- Guard confirmed non-vacuous: reverting the source fix and re-running it fails
  with `expected '{"category": "export", ...' not to contain 'execute_tool'`.
  The fix was then restored.
- `npm run build` clean.
- Full suite: 77 tests across 9 files pass (73 across 8 before this PR).
- `npm run lint:ts`: 0 errors. The 9 warnings are pre-existing and in files this
  PR does not touch.
- `pre-commit` passes on all changed files.

No behaviour change beyond the corrected text: the discovery tools remain
read-only.

## Relationship to #396 and #398

This is the follow-up named in the "Known follow-up, not in this PR" section of
#396 (`docs: correct documentation to match v2.7.0, and gate the generated tool
inventory in CI`). A third, unrelated fix is open as #398 (`fix: stop
PCB_VIA::GetWidth assert dialog, without breaking KiCad 8`).

The three are deliberately separate and **independent**:

- #396 is a `docs:` change. It touches `docs/`, `README.md`, `*.md` and
  `.github/workflows/ci.yml`, and changes no runtime behaviour.
- This PR is a `fix:` change confined to `src/` and `tests-ts/` (TypeScript).
- #398 is a `fix:` change confined to `python/commands/` and `tests/` (Python).

There is **no file overlap between any of the three**, so there is no merge
conflict and no ordering requirement. Any of them can merge first. I verified
this with a real `git merge-tree` simulation between the branches, which
reported no conflict.

All three branches were cut from `aa53d52` (`chore: release v2.7.0`).

Opened as a draft for review of scope and approach before it is marked ready.
