### PR TITLE
fix: stop PCB_VIA::GetWidth assert dialog, without breaking KiCad 8

### DIFF
--- a/python/commands/routing.py
+++ b/python/commands/routing.py
@@ -702,7 +702,7 @@ class RoutingCommands:
                         "y": position["y"],
                         "unit": position["unit"],
                     },
-                    "size": via.GetWidth(pcbnew.F_Cu) / 1000000,
+                    "size": _via_front_width(via) / 1000000,
                     "drill": via.GetDrill() / 1000000,
                     "from_layer": from_layer,
                     "to_layer": to_layer,
@@ -959,7 +959,7 @@ class RoutingCommands:
                                 },
                                 "net": track.GetNetname(),
                                 "netCode": track.GetNetCode(),
-                                "diameter": track.GetWidth() / scale,
+                                "diameter": _via_front_width(track) / scale,
                                 "drill": track.GetDrillValue() / scale,
                             }
                         )
@@ -1404,7 +1404,7 @@ class RoutingCommands:
                 # Create new via
                 new_via = pcbnew.PCB_VIA(self.board)
                 new_via.SetPosition(pcbnew.VECTOR2I(pos.x + offset_x, pos.y + offset_y))
-                new_via.SetWidth(via.GetWidth(pcbnew.F_Cu))
+                new_via.SetWidth(_via_front_width(via))
                 new_via.SetDrill(via.GetDrillValue())
                 new_via.SetViaType(via.GetViaType())
 
@@ -2119,7 +2119,7 @@ class RoutingCommands:
                 is_via = False
             if is_via:
                 pos = track.GetPosition()
-                width = track.GetWidth()
+                width = _via_front_width(track)
                 drill = 0
                 try:
                     drill = track.GetDrill()
@@ -2309,6 +2309,40 @@ class RoutingCommands:
 # is far below any realistic via-to-track clearance, while staying cheap in the
 # obstacle-gathering loop.
 _ARC_CHORD_SEGMENTS = 8
+
+
+def _via_front_width(via: Any) -> int:
+    """Return a via's front-copper width in nanometres, across KiCad 8, 9 and 10.
+
+    KiCad 9 moved vias onto per-layer padstacks, so ``PCB_VIA`` gained
+    ``GetWidth( PCB_LAYER_ID )`` and the ``GetFrontWidth()`` convenience wrapper
+    that forwards to it (``pcbnew/pcb_track.h`` 9.0 lines 433 and 437). The
+    inherited no-argument ``GetWidth()`` survives only to satisfy the parent
+    class and now trips a ``wxCHECK_MSG`` -- ``pcbnew/pcb_track.cpp`` 9.0:381
+    and 10.0:387, "PCB_VIA::GetWidth called without a layer argument". Under a
+    stable Windows build that surfaces as a modal wxWidgets debug alert, once
+    per via, which is what users actually hit.
+
+    The check returns ``m_padStack.Size( PADSTACK::ALL_LAYERS ).x``, so the
+    returned value was never wrong. The defect is the dialog, not the geometry.
+
+    KiCad 8 has neither accessor: its ``PCB_VIA`` only inherits
+    ``PCB_TRACK::GetWidth()`` (``pcbnew/pcb_track.h`` 8.0 line 107), where the
+    call is legal and silent. This server still supports 8.0 in CI, so calling
+    ``GetFrontWidth()`` unconditionally would trade a cosmetic warning on 9/10
+    for a hard ``AttributeError`` on 8 -- and passing ``F_Cu`` explicitly would
+    raise ``TypeError`` there for the same reason.
+
+    Probing for the attribute rather than branching on a version string keeps
+    this correct for any build that backports or drops the accessor, and works
+    with the test doubles, which define only the methods a case needs.
+    """
+    front_width = getattr(via, "GetFrontWidth", None)
+    if front_width is not None:
+        return int(front_width())
+    # KiCad 8 and earlier: the inherited accessor is the only one, and is the
+    # correct call there -- a via had a single width across all layers.
+    return int(via.GetWidth())
 
 
 def _arc_polyline_points(track: Any) -> List[Tuple[int, int]]:

--- a/tests/test_add_gnd_stitching_vias.py
+++ b/tests/test_add_gnd_stitching_vias.py
@@ -69,6 +69,13 @@ def _via(net_code, x, y, size_mm=0.8, drill_mm=0.4):
     v.GetNetCode.return_value = net_code
     v.GetPosition.return_value = _vector(x, y)
     v.GetWidth.return_value = _mm(size_mm)
+    # KiCad 9+ vias expose GetFrontWidth(), which _via_front_width() prefers in
+    # order to avoid the "GetWidth called without a layer argument" assert. A
+    # bare MagicMock auto-creates that attribute and int() of the resulting mock
+    # is 1, which would silently shrink every via here to 1 nm and quietly
+    # destroy the obstacle-radius margins these tests exist to pin. Set it
+    # explicitly so the double matches the real KiCad 9/10 object.
+    v.GetFrontWidth.return_value = _mm(size_mm)
     v.GetDrill.return_value = _mm(drill_mm)
     v.GetClass.return_value = "PCB_VIA"  # routing code checks via GetClass()
     return v

--- a/tests/test_via_front_width.py
+++ b/tests/test_via_front_width.py
@@ -1,0 +1,84 @@
+"""Tests for _via_front_width(), the KiCad 8/9/10 via width accessor shim.
+
+KiCad 9 moved vias onto per-layer padstacks. ``PCB_VIA`` gained
+``GetWidth( PCB_LAYER_ID )`` plus the ``GetFrontWidth()`` wrapper, and the
+inherited no-argument ``GetWidth()`` became a trap: it still returns the
+ALL_LAYERS size, but trips ``wxCHECK_MSG`` (``pcbnew/pcb_track.cpp`` 9.0:381,
+10.0:387). On a stable Windows build that is a modal debug alert, once per via,
+which is what users actually reported.
+
+KiCad 8 has neither new accessor -- its ``PCB_VIA`` only inherits
+``PCB_TRACK::GetWidth()`` (``pcbnew/pcb_track.h`` 8.0:107) -- and this server
+supports 8.0 in CI, so the shim cannot simply call the new API.
+
+These fakes are deliberately plain classes rather than MagicMock. A MagicMock
+auto-creates ``GetFrontWidth`` even when simulating KiCad 8, and ``int()`` of
+the returned mock is 1, so the "KiCad 8" case would silently pass while
+returning a 1 nm width. Controlling attribute presence exactly is the entire
+point of this suite.
+"""
+
+import sys
+from pathlib import Path
+
+PYTHON_DIR = Path(__file__).parent.parent / "python"
+sys.path.insert(0, str(PYTHON_DIR))
+
+# Need pcbnew imported (real or stubbed) before the routing module.
+import pcbnew  # noqa: F401, E402
+from commands.routing import _via_front_width  # noqa: E402
+
+
+class _Kicad8Via:
+    """KiCad 8: one width for all layers, and no per-layer accessor at all."""
+
+    def __init__(self, width):
+        self._width = width
+
+    def GetWidth(self):
+        return self._width
+
+
+class _Kicad9Via:
+    """KiCad 9/10: GetFrontWidth() is correct; no-arg GetWidth() asserts.
+
+    GetWidth() raises here to model the wxCHECK_MSG as if it were fatal. The
+    real build only warns and returns a usable value, so a shim that called it
+    would still produce correct numbers and the defect would show up solely as
+    a dialog -- invisible to a test. Making it raise is what lets this suite
+    prove the shim never takes that path.
+    """
+
+    def __init__(self, front_width):
+        self._front_width = front_width
+
+    def GetWidth(self, *args):
+        raise AssertionError("PCB_VIA::GetWidth called without a layer argument")
+
+    def GetFrontWidth(self):
+        return self._front_width
+
+
+def test_uses_front_width_on_kicad_9_and_10():
+    assert _via_front_width(_Kicad9Via(800000)) == 800000
+
+
+def test_never_calls_the_asserting_accessor_on_kicad_9_and_10():
+    # _Kicad9Via.GetWidth raises, so returning at all proves it was not called.
+    via = _Kicad9Via(600000)
+    assert _via_front_width(via) == 600000
+
+
+def test_falls_back_to_plain_getwidth_on_kicad_8():
+    # No GetFrontWidth attribute exists, which is exactly the KiCad 8 shape.
+    via = _Kicad8Via(450000)
+    assert not hasattr(via, "GetFrontWidth")
+    assert _via_front_width(via) == 450000
+
+
+def test_returns_int_not_float():
+    # Callers divide by a scale to produce mm, and some feed the value to
+    # integer floor division (obstacle radii). A float here would change
+    # results silently rather than fail loudly.
+    assert isinstance(_via_front_width(_Kicad9Via(800000)), int)
+    assert isinstance(_via_front_width(_Kicad8Via(800000)), int)


### PR DESCRIPTION
## Summary

Vias trigger a modal wxWidgets debug alert on KiCad 9 and 10:

```
pcb_track.cpp(387): assert "false" failed in GetWidth():
Warning: PCB_VIA::GetWidth called without a layer argument
```

It fires once per via, so listing traces or running `add_gnd_stitching_vias` on
a real board buries the user in dialogs.

KiCad 9 moved vias onto per-layer padstacks. `PCB_VIA` gained
`GetWidth( PCB_LAYER_ID )` and the `GetFrontWidth()` wrapper, and the inherited
no-argument `GetWidth()` was kept only to satisfy the parent class:

```
pcbnew/pcb_track.cpp  9.0:381   wxCHECK_MSG( false, m_padStack.Size( ALL_LAYERS ).x,
pcbnew/pcb_track.cpp 10.0:387     "Warning: PCB_VIA::GetWidth called without a layer argument" );
```

The check returns the ALL_LAYERS size, so **the value was never wrong**. The
defect is the dialog, not the geometry.

## Why not just call GetFrontWidth()

Because it does not exist on KiCad 8, which this repo still tests in CI
(`Integration Tests (Linux + KiCAD)` covers 8.0, 9.0 and 10.0):

```
pcbnew/pcb_track.h  8.0 : PCB_VIA only inherits  int GetWidth() const     (line 107)
pcbnew/pcb_track.h  9.0 : 430  int GetWidth() const override
                          433  int GetWidth( PCB_LAYER_ID aLayer ) const
                          437  int GetFrontWidth() const { return GetWidth( F_Cu ); }
```

Calling `GetFrontWidth()` unconditionally would trade a cosmetic warning on
9/10 for an `AttributeError` on 8. Passing `F_Cu` explicitly raises `TypeError`
there for the same reason.

That is not hypothetical: **two call sites were already broken on KiCad 8**,
both passing `pcbnew.F_Cu` (`add_via` and `copy_routing_pattern`). This PR
fixes those as well.

## Changes

`python/commands/routing.py` adds `_via_front_width()`, which probes for the
accessor rather than branching on a version string, and routes all four
via-width reads through it:

| Call site | Was | Problem |
|---|---|---|
| `get_traces_and_vias` (`"diameter"`) | `GetWidth()` | assert dialog on 9/10 |
| `add_gnd_stitching_vias` (obstacle radius) | `GetWidth()` | assert dialog on 9/10 |
| `add_via` (`"size"`) | `GetWidth(F_Cu)` | broken on KiCad 8 |
| `copy_routing_pattern` | `GetWidth(F_Cu)` | broken on KiCad 8 |

## Test double correction (please read)

`tests/test_add_gnd_stitching_vias.py` builds vias from `MagicMock`, which
auto-creates `GetFrontWidth`. `int()` of the resulting mock is `1`, so the new
shim silently returned a **1 nm** via width, every obstacle radius in that
suite collapsed to the drill size, and **all 24 tests still passed**.

That is worth flagging on its own: the suite was not sensitive to via width at
all. The double now pins `GetFrontWidth` explicitly.

`tests/test_via_front_width.py` is new and deliberately uses plain classes
instead of `MagicMock`, because attribute presence is the thing under test. The
KiCad 9/10 fake **raises** from `GetWidth()`, so taking the asserting path is a
test failure rather than an invisible dialog.

## Verification

- Reproduced the assert from the command line against KiCad 10.0.6, and
  confirmed all three accessors return the same value
  (`GetWidth(F_Cu)` = `GetFrontWidth()` = `GetWidth()` = 600000).
- Full Python suite: **2164 passed, 36 skipped**.
- The single failure, `tests/test_ipc_open_board_path.py`, reproduces unchanged
  on clean `main` (`aa53d52`) in a separate worktree. It is pre-existing and
  unrelated.
- `pre-commit` passes on all changed files (black, isort, flake8, mypy).

## Relationship to #396 and #397

Third of three independent branches cut from `aa53d52` (`chore: release
v2.7.0`):

- #396 is `docs:` and touches `docs/`, `README.md` and `.github/workflows/ci.yml`.
- #397 is `fix:` and touches `src/tools/` and `tests-ts/` (TypeScript).
- This PR is `fix:` and touches `python/commands/` and `tests/` (Python).

There is **no file overlap between any of the three**, so there is no merge
conflict and no ordering requirement. Any of them can merge first.

Opened as a draft for review of scope and approach before it is marked ready.
