### PR TITLE
fix(process): detect KiCad launched via PATH on Linux

### DIFF
--- a/python/utils/kicad_process.py
+++ b/python/utils/kicad_process.py
@@ -291,17 +291,28 @@ class KiCADProcessManager:
                         and "kicad_interface.py" not in line
                         and "grep" not in line
                     ):
-                        # More specific check: must have /pcbnew or /kicad in the path
-                        if "/pcbnew" in line or "/kicad" in line or "KiCad.app" in line:
-                            parts = line.split()
-                            if len(parts) >= 11:
-                                processes.append(
-                                    {
-                                        "pid": parts[1],
-                                        "name": parts[10],
-                                        "command": " ".join(parts[10:]),
-                                    }
-                                )
+                        parts = line.split()
+                        if len(parts) < 11:
+                            continue
+                        proc_name = parts[10]
+                        # ps shows a bare command name (no leading slash) when the
+                        # process was launched via $PATH lookup rather than an
+                        # absolute path, so also accept an exact "kicad"/"pcbnew"
+                        # basename alongside the path-based checks.
+                        base_name = proc_name.rsplit("/", 1)[-1].lower()
+                        if (
+                            "/pcbnew" in line
+                            or "/kicad" in line
+                            or "KiCad.app" in line
+                            or base_name in ("kicad", "pcbnew")
+                        ):
+                            processes.append(
+                                {
+                                    "pid": parts[1],
+                                    "name": proc_name,
+                                    "command": " ".join(parts[10:]),
+                                }
+                            )
 
             elif system == "Windows":
                 for proc in KiCADProcessManager._windows_list_processes():


### PR DESCRIPTION
get_process_info() required /kicad or /pcbnew (with leading slash) in the ps line, which excluded processes whose argv[0] is the bare command name (common when launched from a desktop launcher or terminal via PATH).

Extract the base name and also accept it when it matches "kicad" or "pcbnew" exactly, avoiding false matches against our own Python scripts.

Launching kicad from UI:

<img width="1143" height="134" alt="Command_output" src="https://github.com/user-attachments/assets/f04825f9-84a7-4b43-88c9-b76ceaa8820d" />

Before the patch:

<img width="1228" height="486" alt="Kicad_not_running" src="https://github.com/user-attachments/assets/a27e81bb-df1c-4e5c-bcca-a93e903b2a0f" />

"Shows kicad not running".

After the patch:

<img width="642" height="517" alt="MCP-kicad-afer" src="https://github.com/user-attachments/assets/944c112a-6651-4396-b034-ad51a2b4b57b" />

Shows "kicad running".