### PR TITLE
fix(sync): read only the design's sheets and name unlabeled nets (#400, #402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,27 @@ All notable changes to the KiCAD MCP Server project are documented here.
   already used these names. `add_net` keeps `netClass`, which the handler reads
   since #403.
 
+- **`sync_schematic_to_board` reads only the design's own sheets, and wires an
+  unlabeled net instead of dropping it** (#400 reported by @SinanTufekci; #402
+  reported by @joseluu, with the fix for the unlabeled case taken from #358 by
+  @davidwesternall-oss). The pad-to-net map was built from every `.kicad_sch`
+  under the project directory, so KiCad's own `.history/` snapshots, this
+  server's `.mcp-backups/` copies and hand-made backup folders were read as live
+  sheets, and whichever sorted last silently overwrote the live nets (25 wrong
+  pad nets on one real board). The map now follows `(sheet ...)` references from
+  the root, through the walker `backannotate_footprints` already used, promoted
+  to `python/utils/sheet_tree.py`. Separately, a net formed only by a wire
+  between two pins, with no label or power symbol, was named by nothing, so its
+  pads reached the board with no net at all. Such a net now gets the name KiCad
+  itself would give it, `Net-(REF-PadN)`, built from the pad number and taking
+  the candidate that sorts lowest as a plain string; both details were checked
+  against kicad-cli 10.0.0. `PWR_FLAG` symbols no longer seed a bogus `PWR_FLAG`
+  net. The response lists every unmatched pad (`unmatched_pads`, with a
+  warning) and the sheets read (`sheets_scanned`) instead of a ten-entry
+  sample. The unused `skip` imports in this function and in
+  `get_connections_for_net` are gone, so a missing kicad-skip now surfaces the
+  loader's `SchematicLoadError` message there too (#393 follow-up).
+
 ### Tooling
 
 - **Documentation trued up to the shipped server, and the tool inventory is now

--- a/python/commands/backannotate_footprints.py
+++ b/python/commands/backannotate_footprints.py
@@ -54,6 +54,8 @@ from utils.sexpr_format import (
     match_paren,
     unescape_sexpr_string,
 )
+from utils.sheet_tree import _real_key
+from utils.sheet_tree import sheet_tree as _sheet_tree
 
 logger = logging.getLogger("kicad_interface")
 
@@ -68,7 +70,6 @@ _FOOTPRINT_HEAD = re.compile(rf"\(footprint\s+{QUOTED_VALUE}")
 _INSTANCE_HEAD = re.compile(r"\(symbol[\s(]")
 
 # '(sheet ' only -- '(sheet_instances' is a different list at the same depth.
-_SHEET_HEAD = re.compile(r"\(sheet[\s(]")
 
 _REFERENCE_TOKEN = re.compile(rf"\(reference\s+{QUOTED_VALUE}")
 
@@ -238,56 +239,6 @@ def _candidate_references(block: str, props: Dict[str, _Property]) -> List[str]:
         if reference and reference not in ordered:
             ordered.append(reference)
     return ordered
-
-
-def _sub_sheet_files(text: str) -> List[str]:
-    """The ``Sheetfile`` of every ``(sheet ...)`` in one schematic."""
-    files: List[str] = []
-    for offset in iter_child_offsets(text):
-        if not _SHEET_HEAD.match(text, offset):
-            continue
-        end = match_paren(text, offset)
-        if end == -1:
-            continue
-        props = _properties(text[offset : end + 1])
-        prop = props.get("Sheetfile") or props.get("Sheet file")
-        if prop is not None and prop.value:
-            files.append(prop.value)
-    return files
-
-
-def _real_key(path: Path) -> str:
-    """Identity of a file on disk, so the same sheet is never visited twice."""
-    return os.path.normcase(os.path.realpath(str(path)))
-
-
-def _sheet_tree(root: Path) -> List[Path]:
-    """Sheets reachable from *root*, root first, one entry per file on disk.
-
-    Walking the tree is what bounds the edit to the design. Globbing the board's
-    directory also picks up ``.history`` snapshots, backup copies and unrelated
-    projects -- and rewriting a backup destroys the fallback at the same moment
-    as the risky edit.
-    """
-    order: List[Path] = []
-    seen: Set[str] = set()
-    queue: List[Path] = [root]
-    while queue:
-        sheet = queue.pop(0)
-        key = _real_key(sheet)
-        if key in seen:
-            continue
-        seen.add(key)
-        if not sheet.is_file():
-            continue
-        order.append(sheet)
-        try:
-            text, _newline = _read_text(sheet)
-        except (OSError, UnicodeDecodeError):
-            continue
-        for name in _sub_sheet_files(text):
-            queue.append(sheet.parent / name)
-    return order
 
 
 def _sheets_beside(board_path: Path) -> List[Path]:

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -2767,13 +2767,18 @@ class SchematicHandlersMixin:
             logger.error(f"Error running ERC: {str(e)}")
             return {"success": False, "message": str(e)}
 
-    def _build_hierarchical_pad_net_map(self, project_sch_path: str):
-        """Walk all .kicad_sch files in the project and build a {(ref, pin_num): net_name} map.
+    def _build_hierarchical_pad_net_map(self, project_sch_path: str, sheets_out=None):
+        """Walk the sheets reachable from the root schematic and build a
+        {(ref, pin_num): net_name} map.
 
-        Handles hierarchical schematics by scanning every sub-sheet file.  Net names
-        from global_label / hierarchical_label / local label / power symbols are all
-        collected.  Wire connectivity is traced via BFS so labels not placed directly
-        on a pin endpoint still reach through wire segments.
+        Handles hierarchical schematics by following ``(sheet ...)`` references
+        from the root.  Net names from global_label / hierarchical_label / local
+        label / power symbols are all collected, and a wired net with no label at
+        all gets the ``Net-(REF-PadN)`` name KiCad would give it.  Wire
+        connectivity is traced via BFS so labels not placed directly on a pin
+        endpoint still reach through wire segments.
+
+        ``sheets_out``, when given, receives the path of every sheet read.
 
         Returns: (pad_net_map, net_names_set)
         """
@@ -2781,7 +2786,7 @@ class SchematicHandlersMixin:
         from pathlib import Path
 
         from commands.pin_locator import PinLocator
-        from skip import Schematic
+        from utils.sheet_tree import sheet_tree
 
         TOLERANCE = 0.5  # mm; schematic grid is 1.27 mm so 0.5 is safe
 
@@ -2802,13 +2807,22 @@ class SchematicHandlersMixin:
                     return name
             return None
 
-        project_dir = Path(project_sch_path).parent
         pad_net_map: dict = {}
         all_net_names: set = set()
         pin_locator = PinLocator()
 
-        sch_files = sorted(project_dir.rglob("*.kicad_sch"))
-        logger.info(f"_build_hierarchical_pad_net_map: scanning {len(sch_files)} schematic files")
+        # Only the sheets reachable from the root are part of the design. A
+        # recursive glob of the project directory also read KiCad's .history/
+        # snapshots, this server's .mcp-backups/ copies and hand-made backup
+        # folders as live sheets, and whichever copy sorted last silently
+        # overwrote the live sheet's nets (#400).
+        sch_files = sheet_tree(Path(project_sch_path))
+        if sheets_out is not None:
+            sheets_out.extend(str(p) for p in sch_files)
+        logger.info(
+            f"_build_hierarchical_pad_net_map: scanning {len(sch_files)} sheet(s): "
+            + ", ".join(p.name for p in sch_files)
+        )
 
         for sch_path in sch_files:
             # A broken sheet must fail the sync loudly: silently skipping it
@@ -2831,11 +2845,19 @@ class SchematicHandlersMixin:
                     except Exception:
                         pass
 
-            # Power symbols (#PWR / #FLG): value property IS the net name; use pin 1 pos
+            # Power symbols (#PWR): the Value property IS the net name; seed
+            # every pin position with it.
+            #
+            # #FLG (PWR_FLAG) is deliberately excluded. Its Value is the literal
+            # string "PWR_FLAG", an ERC marker rather than a net name. Treating
+            # it as one invented a bogus "PWR_FLAG" net and, worse, stamped that
+            # name onto the flag's pin, from where the BFS below propagated it
+            # over the real net. A PWR_FLAG takes whatever net it is wired to;
+            # it never names one.
             for sym in getattr(sch, "symbol", None) or []:
                 try:
                     ref = sym.property.Reference.value
-                    if not (ref.startswith("#PWR") or ref.startswith("#FLG")):
+                    if not ref.startswith("#PWR"):
                         continue
                     net_name = sym.property.Value.value
                     if not net_name:
@@ -2887,7 +2909,8 @@ class SchematicHandlersMixin:
                         visited.add(neighbor)
                         queue.append(neighbor)
 
-            # ── 3. Match component pin positions to net names ────────────────
+            # ── 3. Collect real (non-power) symbol pins with their positions ──
+            sym_pins = []  # (ref, pin_num, (px, py))
             for sym in getattr(sch, "symbol", None) or []:
                 try:
                     ref = sym.property.Reference.value
@@ -2898,9 +2921,60 @@ class SchematicHandlersMixin:
 
                 pin_positions = pin_locator.get_all_symbol_pins(sch_path, ref)
                 for pin_num, (px, py) in pin_positions.items():
-                    net = nearby_net((px, py), point_net)
-                    if net:
-                        pad_net_map[(ref, pin_num)] = net
+                    sym_pins.append((ref, pin_num, (px, py)))
+
+            # ── 3b. Name wire clusters that carry no label ────────────────────
+            # A net formed only by a wire between component pins -- no label, no
+            # power symbol -- was named by nothing above, so its pads reached the
+            # board with no net at all and the connection silently vanished from
+            # the layout (#402). KiCad names such a net itself; the rule, checked
+            # against kicad-cli 10.0.0 on synthetic schematics, is
+            # "Net-(REF-PadN)" built from the pad NUMBER (the pin's name is not
+            # used even when it has one), choosing the candidate that sorts
+            # lowest as a plain string, so R10 beats R2. Step 2's BFS floods a
+            # name across a whole connected cluster, so a cluster is either
+            # wholly named or wholly unnamed, and testing one point suffices.
+            def in_cluster(pt, cluster):
+                if snap(*pt) in cluster:
+                    return True
+                x, y = pt
+                return any(
+                    abs(x - cx) < TOLERANCE and abs(y - cy) < TOLERANCE for cx, cy in cluster
+                )
+
+            clustered: set = set()
+            for seed in sorted(all_wire_pts):
+                if seed in point_net or seed in clustered:
+                    continue
+                cluster = set()
+                stack = [seed]
+                clustered.add(seed)
+                while stack:
+                    cur = stack.pop()
+                    cluster.add(cur)
+                    for neighbor in point_adj[cur]:
+                        if neighbor not in clustered:
+                            clustered.add(neighbor)
+                            stack.append(neighbor)
+
+                candidates = [
+                    f"Net-({ref}-Pad{pin_num})"
+                    for ref, pin_num, pt in sym_pins
+                    if in_cluster(pt, cluster)
+                ]
+                # A single pin on a wire stub is a dangling wire, not a net.
+                if len(candidates) < 2:
+                    continue
+                auto_name = min(candidates)
+                for pt in cluster:
+                    point_net[pt] = auto_name
+                all_net_names.add(auto_name)
+
+            # ── 3c. Match component pin positions to net names ───────────────
+            for ref, pin_num, (px, py) in sym_pins:
+                net = nearby_net((px, py), point_net)
+                if net:
+                    pad_net_map[(ref, pin_num)] = net
 
         logger.info(
             f"_build_hierarchical_pad_net_map: {len(pad_net_map)} pin→net assignments, "
@@ -2961,8 +3035,11 @@ class SchematicHandlersMixin:
                     "message": f"Schematic not found. Provide schematicPath. Tried: {schematic_path}",
                 }
 
-            # Build hierarchical pad→net map (walks all sub-sheets)
-            pad_net_map, net_names = self._build_hierarchical_pad_net_map(schematic_path)
+            # Build the pad->net map from the sheets reachable from the root
+            sheets_scanned: list = []
+            pad_net_map, net_names = self._build_hierarchical_pad_net_map(
+                schematic_path, sheets_out=sheets_scanned
+            )
 
             # Add missing footprints from the schematic to the board *before*
             # we add nets and assign pads — F8 in KiCad does this implicitly
@@ -3015,16 +3092,38 @@ class SchematicHandlersMixin:
                 f"sync_schematic_to_board: {len(added_nets)} nets added, "
                 f"{len(added_footprints)} footprints added, {assigned_pads} pads assigned"
             )
+            # Every wired pin now carries a net (an unlabeled wire gets a
+            # Net-(REF-PadN) name), so an unmatched pad is one the schematic
+            # does not wire at all, or a pad the symbol does not have. Report
+            # all of them: a ten-entry sample buried a 25-pad failure (#400).
+            warnings: List[str] = []
+            if unmatched:
+                warnings.append(
+                    f"{len(unmatched)} pad(s) have no net in the schematic and were left "
+                    "unchanged: " + ", ".join(unmatched)
+                )
+                logger.warning("sync_schematic_to_board: " + warnings[-1])
+            root_dir = Path(schematic_path).parent
+            sheet_names = []
+            for p in sheets_scanned:
+                try:
+                    sheet_names.append(Path(p).relative_to(root_dir).as_posix())
+                except ValueError:
+                    sheet_names.append(Path(p).name)
             return {
                 "success": True,
                 "message": (
                     f"PCB updated from schematic: {len(added_footprints)} footprints added, "
                     f"{len(added_nets)} nets added, {assigned_pads} pads assigned"
                 ),
+                "sheets_scanned": sheet_names,
                 "nets_added": added_nets,
                 "nets_total": len(net_names),
                 "pads_assigned": assigned_pads,
+                "unmatched_pad_count": len(unmatched),
+                "unmatched_pads": unmatched,
                 "unmatched_pads_sample": unmatched[:10],
+                "warnings": warnings,
                 "footprints_added": added_footprints,
                 "footprints_skipped": skipped_footprints,
             }

--- a/python/commands/wire_connectivity.py
+++ b/python/commands/wire_connectivity.py
@@ -936,7 +936,6 @@ def get_connections_for_net(schematic: Any, schematic_path: str, net_name: str) 
 
     Returns a list of {"component": ref, "pin": pin_num} dicts.
     """
-    from skip import Schematic as SkipSchematic
 
     seen: Set[Tuple[str, str]] = set()
     all_pins: List[Dict] = []

--- a/python/utils/sheet_tree.py
+++ b/python/utils/sheet_tree.py
@@ -1,0 +1,89 @@
+"""Walk a schematic hierarchy from its root sheet.
+
+The design is the set of sheets reachable from the root through ``(sheet ...)``
+references, and nothing else. Globbing the project directory for ``*.kicad_sch``
+looks equivalent and is not: KiCad's own Local History (``.history/``), the
+``.mcp-backups/`` copies this server writes, hand-made backup folders and any
+unrelated project below the directory all match the glob. Read as live sheets
+they inject nets and parts the design no longer has, and whichever copy sorts
+last overwrites the live sheet's nets (#400 -- 25 wrong pad nets on a real
+board). Rewritten as live sheets they destroy the fallback at the moment the
+risky edit happens (#365).
+
+Shared by ``backannotate_footprints`` (writes) and ``sync_schematic_to_board``
+(reads); anything that needs "the sheets of this design" should use it too.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import List, Set
+
+from utils.file_io import read_text_preserve_newline
+from utils.sexpr_format import QUOTED_VALUE, iter_child_offsets, match_paren, unescape_sexpr_string
+
+_SHEET_HEAD = re.compile(r"\(sheet[\s(]")
+_PROPERTY_HEAD = re.compile(rf"\(property\s+{QUOTED_VALUE}\s+{QUOTED_VALUE}")
+
+
+def sub_sheet_files(text: str) -> List[str]:
+    """The ``Sheetfile`` of every top-level ``(sheet ...)`` in one schematic.
+
+    Older files spell the property ``Sheet file``; both are accepted. Values
+    are unescaped, so a file name containing a quote round-trips.
+    """
+    files: List[str] = []
+    for offset in iter_child_offsets(text):
+        if not _SHEET_HEAD.match(text, offset):
+            continue
+        end = match_paren(text, offset)
+        if end == -1:
+            continue
+        block = text[offset : end + 1]
+        for prop_offset in iter_child_offsets(block):
+            m = _PROPERTY_HEAD.match(block, prop_offset)
+            if not m:
+                continue
+            name = unescape_sexpr_string(m.group(1))
+            if name in ("Sheetfile", "Sheet file"):
+                value = unescape_sexpr_string(m.group(2))
+                if value:
+                    files.append(value)
+                break
+    return files
+
+
+def _real_key(path: Path) -> str:
+    """Identity of a file on disk, so the same sheet is never visited twice."""
+    return os.path.normcase(os.path.realpath(str(path)))
+
+
+def sheet_tree(root: Path) -> List[Path]:
+    """Sheets reachable from *root*, root first, one entry per file on disk.
+
+    A sheet file referenced twice (a reused sub-sheet) is listed once. A
+    reference to a file that does not exist is skipped; KiCad reports that as a
+    missing sheet and so should the tool that owns the operation, not this
+    walker. Unreadable files are skipped for the same reason.
+    """
+    order: List[Path] = []
+    seen: Set[str] = set()
+    queue: List[Path] = [Path(root)]
+    while queue:
+        sheet = queue.pop(0)
+        key = _real_key(sheet)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not sheet.is_file():
+            continue
+        order.append(sheet)
+        try:
+            text, _newline = read_text_preserve_newline(sheet)
+        except (OSError, UnicodeDecodeError):
+            continue
+        for name in sub_sheet_files(text):
+            queue.append(sheet.parent / name)
+    return order

--- a/tests/test_hierarchical_pad_net_map.py
+++ b/tests/test_hierarchical_pad_net_map.py
@@ -50,6 +50,26 @@ _LIB_SYMBOLS_BLOCK = textwrap.dedent("""\
             )
           )
         )
+        (symbol "TestLib:PWR"
+          (symbol "TestLib:PWR_1_1"
+            (pin power_in line (at 0 0 90) (length 0)
+              (name "~" (effects (font (size 1.27 1.27))))
+              (number "1" (effects (font (size 1.27 1.27))))
+            )
+          )
+        )
+        (symbol "TestLib:D"
+          (symbol "TestLib:D_1_1"
+            (pin passive line (at -1.27 0 0) (length 0)
+              (name "K" (effects (font (size 1.27 1.27))))
+              (number "1" (effects (font (size 1.27 1.27))))
+            )
+            (pin passive line (at 1.27 0 180) (length 0)
+              (name "A" (effects (font (size 1.27 1.27))))
+              (number "2" (effects (font (size 1.27 1.27))))
+            )
+          )
+        )
       )
 """)
 
@@ -97,6 +117,19 @@ def _sym_mock(ref: str, lib_id: str, x: float, y: float, rotation: float = 0) ->
     m.property.Value.value = "~"
     m.lib_id.value = lib_id
     m.at.value = [x, y, rotation]
+    return m
+
+
+def _pwr_mock(ref: str, value: str, lib_id: str, x: float, y: float) -> MagicMock:
+    """Mock of a power-ish symbol (#PWR / #FLG) whose Value carries the net name.
+
+    Distinct from _sym_mock only in that Value is meaningful rather than "~".
+    """
+    m = MagicMock()
+    m.property.Reference.value = ref
+    m.property.Value.value = value
+    m.lib_id.value = lib_id
+    m.at.value = [x, y, 0]
     return m
 
 
@@ -355,7 +388,7 @@ class TestMultipleSubsheets:
     def test_components_in_subsheet_collected(self, iface, tmp_path):
         """A component in a sub-sheet is included in the returned map."""
         top = tmp_path / "top.kicad_sch"
-        top.write_text(_SCH_EMPTY)
+        top.write_text(_with_sheet_ref(_SCH_EMPTY, "sheets/component_sheet.kicad_sch"))
         sub_dir = tmp_path / "sheets"
         sub_dir.mkdir()
         sub = sub_dir / "component_sheet.kicad_sch"
@@ -385,7 +418,12 @@ class TestMultipleSubsheets:
     def test_top_and_sub_components_merged(self, iface, tmp_path):
         """Components from both top-level and sub-sheet appear in the same map."""
         top = tmp_path / "top.kicad_sch"
-        top.write_text(_build_sch_with_instances([("R1", "TestLib:R", 10.0, 10.0, 0)]))
+        top.write_text(
+            _with_sheet_ref(
+                _build_sch_with_instances([("R1", "TestLib:R", 10.0, 10.0, 0)]),
+                "sheets/component_sheet.kicad_sch",
+            )
+        )
         sub_dir = tmp_path / "sheets"
         sub_dir.mkdir()
         sub = sub_dir / "component_sheet.kicad_sch"
@@ -442,3 +480,302 @@ class TestRotatedSymbol:
         pad_net_map, _ = _call(iface, sch, mock_sch)
         assert pad_net_map.get(("R1", "1")) == "UP_NET"
         assert pad_net_map.get(("R1", "2")) == "DN_NET"
+
+
+# ===========================================================================
+# TestPowerFlagIsNotANet
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestPowerFlagIsNotANet:
+    """A PWR_FLAG (#FLG) must never contribute a net name.
+
+    Its Value property is the literal string "PWR_FLAG" — an ERC marker, not a
+    net. Treating it as one invented a bogus "PWR_FLAG" net and could propagate
+    that name over the real net the flag is wired to.
+    """
+
+    def test_pwr_flag_value_does_not_become_a_net(self, iface, tmp_path):
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(
+            _build_sch_with_instances(
+                [
+                    ("R1", "TestLib:R", 10.0, 10.0, 0),
+                    ("#PWR01", "TestLib:PWR", 8.73, 10.0, 0),
+                    ("#FLG01", "TestLib:PWR", 5.0, 10.0, 0),
+                ]
+            )
+        )
+        # #PWR01 pin sits exactly on R1 pin 1; the flag hangs off a wire to it.
+        mock_sch = _sch_mock(
+            symbols=[
+                _sym_mock("R1", "TestLib:R", 10.0, 10.0),
+                _pwr_mock("#PWR01", "VCC", "TestLib:PWR", 8.73, 10.0),
+                _pwr_mock("#FLG01", "PWR_FLAG", "TestLib:PWR", 5.0, 10.0),
+            ],
+            wires=[_wire_mock(5.0, 10.0, 8.73, 10.0)],
+        )
+        pad_net_map, net_names = _call(iface, sch, mock_sch)
+
+        assert "PWR_FLAG" not in net_names
+        # The real rail still resolves, and the flag did not overwrite it.
+        assert pad_net_map.get(("R1", "1")) == "VCC"
+
+    def test_pwr_flag_does_not_overwrite_net_across_wire(self, iface, tmp_path):
+        """The flag's name must not win the BFS over the rail it is attached to."""
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(
+            _build_sch_with_instances(
+                [
+                    ("R1", "TestLib:R", 10.0, 10.0, 0),
+                    ("#FLG01", "TestLib:PWR", 5.0, 10.0, 0),
+                ]
+            )
+        )
+        mock_sch = _sch_mock(
+            symbols=[
+                _sym_mock("R1", "TestLib:R", 10.0, 10.0),
+                _pwr_mock("#FLG01", "PWR_FLAG", "TestLib:PWR", 5.0, 10.0),
+            ],
+            global_labels=[_lbl_mock("VBUS", 8.73, 10.0)],
+            wires=[_wire_mock(5.0, 10.0, 8.73, 10.0)],
+        )
+        pad_net_map, net_names = _call(iface, sch, mock_sch)
+
+        assert "PWR_FLAG" not in net_names
+        assert pad_net_map.get(("R1", "1")) == "VBUS"
+
+
+# ===========================================================================
+# TestUnlabelledNetGetsAutoName
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestUnlabelledNetGetsAutoName:
+    """A wire joining two component pins with no label is still a net.
+
+    KiCad synthesises a name for it during F8 ("Net-(R1-Pad2)"). Without that these
+    pads reached the board with no net at all, so the connection was silently
+    dropped from the layout and the pads were left unroutable.
+    """
+
+    def test_bare_wire_between_two_pins_is_named_and_shared(self, iface, tmp_path):
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(
+            _build_sch_with_instances(
+                [
+                    ("R1", "TestLib:R", 10.0, 10.0, 0),
+                    ("R2", "TestLib:R", 20.0, 10.0, 0),
+                ]
+            )
+        )
+        # R1 pin2 (11.27, 10) --- wire --- R2 pin1 (18.73, 10). No labels at all.
+        mock_sch = _sch_mock(
+            symbols=[
+                _sym_mock("R1", "TestLib:R", 10.0, 10.0),
+                _sym_mock("R2", "TestLib:R", 20.0, 10.0),
+            ],
+            wires=[_wire_mock(11.27, 10.0, 18.73, 10.0)],
+        )
+        pad_net_map, net_names = _call(iface, sch, mock_sch)
+
+        r1_2 = pad_net_map.get(("R1", "2"))
+        r2_1 = pad_net_map.get(("R2", "1"))
+        assert r1_2 is not None, "unlabelled net was dropped entirely"
+        assert r1_2 == r2_1, "the two pads must land on the SAME net"
+        assert r1_2.startswith("Net-("), f"expected a KiCad-style auto name, got {r1_2!r}"
+        assert r1_2 in net_names
+
+    def test_auto_name_uses_the_pad_number_not_the_pin_name(self, iface, tmp_path):
+        """KiCad builds the name from the pad NUMBER even when the pin has a name.
+
+        Checked with kicad-cli 10.0.0: a symbol whose pin 1 is named IN still
+        yields Net-(C1-Pad1). D1 pin 2 is named "A" here and must still be Pad2.
+        """
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(
+            _build_sch_with_instances(
+                [
+                    ("D1", "TestLib:D", 10.0, 10.0, 0),
+                    ("R1", "TestLib:R", 20.0, 10.0, 0),
+                ]
+            )
+        )
+        mock_sch = _sch_mock(
+            symbols=[
+                _sym_mock("D1", "TestLib:D", 10.0, 10.0),
+                _sym_mock("R1", "TestLib:R", 20.0, 10.0),
+            ],
+            wires=[_wire_mock(11.27, 10.0, 18.73, 10.0)],
+        )
+        pad_net_map, _ = _call(iface, sch, mock_sch)
+
+        # "Net-(D1-Pad2)" sorts before "Net-(R1-Pad1)".
+        assert pad_net_map.get(("D1", "2")) == "Net-(D1-Pad2)"
+        assert pad_net_map.get(("R1", "1")) == "Net-(D1-Pad2)"
+
+    def test_lowest_candidate_name_wins_as_a_plain_string(self, iface, tmp_path):
+        """KiCad compares the candidate names as plain strings: R10 beats R2.
+
+        Checked with kicad-cli 10.0.0 (R2 wired to R10 gives Net-(R10-Pad1)).
+        """
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(
+            _build_sch_with_instances(
+                [
+                    ("R2", "TestLib:R", 10.0, 10.0, 0),
+                    ("R10", "TestLib:R", 20.0, 10.0, 0),
+                ]
+            )
+        )
+        mock_sch = _sch_mock(
+            symbols=[
+                _sym_mock("R2", "TestLib:R", 10.0, 10.0),
+                _sym_mock("R10", "TestLib:R", 20.0, 10.0),
+            ],
+            wires=[_wire_mock(11.27, 10.0, 18.73, 10.0)],
+        )
+        pad_net_map, _ = _call(iface, sch, mock_sch)
+
+        assert pad_net_map.get(("R2", "2")) == "Net-(R10-Pad1)"
+        assert pad_net_map.get(("R10", "1")) == "Net-(R10-Pad1)"
+
+    def test_explicit_label_still_wins_over_auto_name(self, iface, tmp_path):
+        """Auto-naming must only fill genuine gaps, never override a real label."""
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(
+            _build_sch_with_instances(
+                [
+                    ("R1", "TestLib:R", 10.0, 10.0, 0),
+                    ("R2", "TestLib:R", 20.0, 10.0, 0),
+                ]
+            )
+        )
+        mock_sch = _sch_mock(
+            symbols=[
+                _sym_mock("R1", "TestLib:R", 10.0, 10.0),
+                _sym_mock("R2", "TestLib:R", 20.0, 10.0),
+            ],
+            global_labels=[_lbl_mock("SIGNAL", 11.27, 10.0)],
+            wires=[_wire_mock(11.27, 10.0, 18.73, 10.0)],
+        )
+        pad_net_map, net_names = _call(iface, sch, mock_sch)
+
+        assert pad_net_map.get(("R1", "2")) == "SIGNAL"
+        assert pad_net_map.get(("R2", "1")) == "SIGNAL"
+        assert not any(n.startswith("Net-(") for n in net_names)
+
+    def test_single_pin_stub_is_not_named(self, iface, tmp_path):
+        """A wire reaching only one pin is not a connection worth inventing a net for."""
+        sch = tmp_path / "top.kicad_sch"
+        sch.write_text(_build_sch_with_instances([("R1", "TestLib:R", 10.0, 10.0, 0)]))
+        mock_sch = _sch_mock(
+            symbols=[_sym_mock("R1", "TestLib:R", 10.0, 10.0)],
+            wires=[_wire_mock(11.27, 10.0, 15.0, 10.0)],
+        )
+        pad_net_map, net_names = _call(iface, sch, mock_sch)
+
+        assert pad_net_map == {}
+        assert net_names == set()
+
+
+# ===========================================================================
+# TestOnlyTheSheetTreeIsRead
+# ===========================================================================
+
+_SHEET_REF = """  (sheet (at 50 50) (size 20 20) (uuid "00000000-0000-0000-0000-00000000aaaa")
+    (property "Sheetname" "sub")
+    (property "Sheetfile" "sub.kicad_sch")
+  )
+"""
+
+
+def _with_sheet_ref(sch_text: str, file_name: str = "sub.kicad_sch") -> str:
+    """Append a (sheet ...) reference to *file_name* before the closing paren.
+
+    Since #400 only sheets reachable from the root are read, so a test that
+    wants a sub-sheet scanned has to reference it the way KiCad would.
+    """
+    cut = sch_text.rstrip().rfind(")")
+    block = _SHEET_REF.replace('"sub.kicad_sch"', f'"{file_name}"')
+    return sch_text[:cut] + block + ")\n"
+
+
+@pytest.mark.unit
+class TestOnlyTheSheetTreeIsRead:
+    """Only sheets reachable from the root are part of the design (#400).
+
+    A recursive glob also read KiCad's .history/ snapshots, this server's own
+    .mcp-backups/ copies, hand-made backup folders and any stray sheet in the
+    directory as live sheets. Whichever sorted last overwrote the live nets,
+    and every one of them could inject parts and nets the design no longer
+    has. One real board got 25 wrong pad nets that way.
+    """
+
+    def test_backups_and_strays_neither_overwrite_nor_inject(self, iface, tmp_path):
+        live_r1 = _build_sch_with_instances([("R1", "TestLib:R", 10.0, 10.0, 0)])
+        live_r2 = _build_sch_with_instances([("R2", "TestLib:R", 10.0, 10.0, 0)])
+        (tmp_path / "top.kicad_sch").write_text(_with_sheet_ref(live_r1))
+        (tmp_path / "sub.kicad_sch").write_text(live_r2)
+        # Decoys: same file names as the live sheets, plus an unreferenced stray.
+        for directory in ("_backup", ".mcp-backups", ".history"):
+            (tmp_path / directory).mkdir()
+            (tmp_path / directory / "top.kicad_sch").write_text(_with_sheet_ref(live_r1))
+            (tmp_path / directory / "sub.kicad_sch").write_text(live_r2)
+        (tmp_path / "zz_stray.kicad_sch").write_text(
+            _build_sch_with_instances([("R9", "TestLib:R", 10.0, 10.0, 0)])
+        )
+
+        def _mock_for(path: str) -> MagicMock:
+            from pathlib import Path as _P
+
+            p = _P(path)
+            if p.parent == tmp_path and p.name == "top.kicad_sch":
+                return _sch_mock(
+                    symbols=[_sym_mock("R1", "TestLib:R", 10.0, 10.0)],
+                    global_labels=[_lbl_mock("LIVE_A", 8.73, 10.0)],
+                )
+            if p.parent == tmp_path and p.name == "sub.kicad_sch":
+                return _sch_mock(
+                    symbols=[_sym_mock("R2", "TestLib:R", 10.0, 10.0)],
+                    global_labels=[_lbl_mock("LIVE_B", 8.73, 10.0)],
+                )
+            if p.name == "zz_stray.kicad_sch":
+                return _sch_mock(
+                    symbols=[_sym_mock("R9", "TestLib:R", 10.0, 10.0)],
+                    global_labels=[_lbl_mock("PHANTOM", 8.73, 10.0)],
+                )
+            # A backup copy: the same R1/R2 with the nets they had before the edit.
+            ref = "R1" if p.name == "top.kicad_sch" else "R2"
+            return _sch_mock(
+                symbols=[_sym_mock(ref, "TestLib:R", 10.0, 10.0)],
+                global_labels=[_lbl_mock("STALE", 8.73, 10.0)],
+            )
+
+        opened: list = []
+
+        def _factory(path: str) -> MagicMock:
+            opened.append(str(path))
+            return _mock_for(str(path))
+
+        sheets: list = []
+        with (
+            patch("skip.Schematic", side_effect=_factory),
+            patch("commands.pin_locator.Schematic", side_effect=_factory),
+            patch("commands.schematic.Schematic", side_effect=_factory),
+        ):
+            pad_net_map, net_names = iface._build_hierarchical_pad_net_map(
+                str(tmp_path / "top.kicad_sch"), sheets_out=sheets
+            )
+
+        assert [Path(s).name for s in sheets] == ["top.kicad_sch", "sub.kicad_sch"]
+        assert all(Path(s).parent == tmp_path for s in sheets)
+        decoy_dirs = ("_backup", ".mcp-backups", ".history")
+        assert not any(Path(o).parent.name in decoy_dirs for o in opened)
+        assert not any(Path(o).name == "zz_stray.kicad_sch" for o in opened)
+        assert pad_net_map.get(("R1", "1")) == "LIVE_A"
+        assert pad_net_map.get(("R2", "1")) == "LIVE_B"
+        assert ("R9", "1") not in pad_net_map
+        assert net_names == {"LIVE_A", "LIVE_B"}

--- a/tests/test_sheet_tree.py
+++ b/tests/test_sheet_tree.py
@@ -1,0 +1,93 @@
+"""utils.sheet_tree: the design is what the root sheet reaches, nothing else.
+
+Shared by backannotate_footprints (which must not rewrite a backup) and
+sync_schematic_to_board (which must not read one, #400).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.unit
+
+from utils.sheet_tree import sheet_tree, sub_sheet_files  # noqa: E402
+
+
+def _sheet(file_name: str, prop: str = "Sheetfile") -> str:
+    return (
+        '  (sheet (at 50 50) (size 20 20) (uuid "0")\n'
+        '    (property "Sheetname" "x")\n'
+        f'    (property "{prop}" "{file_name}")\n'
+        "  )\n"
+    )
+
+
+def _sch(*sheets: str) -> str:
+    return "(kicad_sch (version 20250114)\n" + "".join(sheets) + ")\n"
+
+
+def test_sub_sheet_files_reads_every_top_level_sheet_reference() -> None:
+    text = _sch(_sheet("a.kicad_sch"), _sheet("dir/b.kicad_sch"))
+    assert sub_sheet_files(text) == ["a.kicad_sch", "dir/b.kicad_sch"]
+
+
+def test_sub_sheet_files_accepts_the_legacy_property_spelling() -> None:
+    assert sub_sheet_files(_sch(_sheet("old.kicad_sch", prop="Sheet file"))) == ["old.kicad_sch"]
+
+
+def test_sub_sheet_files_unescapes_the_file_name() -> None:
+    text = _sch(_sheet('odd\\"name.kicad_sch'))
+    assert sub_sheet_files(text) == ['odd"name.kicad_sch']
+
+
+def test_tree_is_root_first_then_breadth_first(tmp_path: Path) -> None:
+    (tmp_path / "root.kicad_sch").write_text(_sch(_sheet("a.kicad_sch"), _sheet("b.kicad_sch")))
+    (tmp_path / "a.kicad_sch").write_text(_sch(_sheet("deep/c.kicad_sch")))
+    (tmp_path / "b.kicad_sch").write_text(_sch())
+    (tmp_path / "deep").mkdir()
+    (tmp_path / "deep" / "c.kicad_sch").write_text(_sch())
+    names = [p.relative_to(tmp_path).as_posix() for p in sheet_tree(tmp_path / "root.kicad_sch")]
+    assert names == ["root.kicad_sch", "a.kicad_sch", "b.kicad_sch", "deep/c.kicad_sch"]
+
+
+def test_a_reused_sheet_file_is_listed_once(tmp_path: Path) -> None:
+    (tmp_path / "root.kicad_sch").write_text(_sch(_sheet("sub.kicad_sch"), _sheet("sub.kicad_sch")))
+    (tmp_path / "sub.kicad_sch").write_text(_sch())
+    assert [p.name for p in sheet_tree(tmp_path / "root.kicad_sch")] == [
+        "root.kicad_sch",
+        "sub.kicad_sch",
+    ]
+
+
+def test_a_missing_sheet_is_skipped_not_fatal(tmp_path: Path) -> None:
+    (tmp_path / "root.kicad_sch").write_text(
+        _sch(_sheet("gone.kicad_sch"), _sheet("there.kicad_sch"))
+    )
+    (tmp_path / "there.kicad_sch").write_text(_sch())
+    assert [p.name for p in sheet_tree(tmp_path / "root.kicad_sch")] == [
+        "root.kicad_sch",
+        "there.kicad_sch",
+    ]
+
+
+def test_backup_and_history_copies_are_never_reached(tmp_path: Path) -> None:
+    """The failure mode of #400: rglob finds these, the walk cannot."""
+    (tmp_path / "root.kicad_sch").write_text(_sch(_sheet("sub.kicad_sch")))
+    (tmp_path / "sub.kicad_sch").write_text(_sch())
+    for directory in (".history", ".mcp-backups", "_backup", "other_project"):
+        (tmp_path / directory).mkdir()
+        (tmp_path / directory / "root.kicad_sch").write_text(_sch(_sheet("sub.kicad_sch")))
+        (tmp_path / directory / "sub.kicad_sch").write_text(_sch())
+    (tmp_path / "zz_stray.kicad_sch").write_text(_sch())
+
+    reached = sheet_tree(tmp_path / "root.kicad_sch")
+    assert [p.name for p in reached] == ["root.kicad_sch", "sub.kicad_sch"]
+    assert all(p.parent == tmp_path for p in reached)
+    assert len(list(tmp_path.rglob("*.kicad_sch"))) == 11  # what the old glob would have read
+
+
+def test_a_root_that_does_not_exist_yields_nothing(tmp_path: Path) -> None:
+    assert sheet_tree(tmp_path / "nope.kicad_sch") == []


### PR DESCRIPTION
## What

Two `sync_schematic_to_board` bugs in `_build_hierarchical_pad_net_map`, both reported against v2.7.0 and both older than v2.6.0.

- **#400: only the design's sheets are read.** The map was built from `sorted(project_dir.rglob("*.kicad_sch"))`, so KiCad's own `.history/` snapshots, this server's `.mcp-backups/` copies and hand-made backup folders were parsed as live sheets. The dicts are last-writer-wins, and on Windows `_backup/` sorts after digit-prefixed sheet names, so the reporter's board got 25 wrong pad nets from a stale revision. The map now follows `(sheet ...)` references from the root sheet. The walker is the one `backannotate_footprints` already had (#365), promoted to `python/utils/sheet_tree.py` and shared; `backannotate_footprints` imports it and its 58 tests are unchanged.
- **#402: a wired but unlabeled net is named, not dropped.** Nets were seeded only from labels and power symbols, so a plain wire between two pins produced no net and its pads were silently left unassigned. Such a cluster now gets a `Net-(REF-PadN)` name. The cluster logic and the `PWR_FLAG` exclusion (its Value is the literal string `PWR_FLAG`, an ERC marker, and it was being seeded as a net) are taken from #358 by @davidwesternall-oss, credited as co-author.

## What was checked against real KiCad

#358 used the pin *name* when the symbol has one (`Net-(D1-A)`), which matched the issue's example, so I checked with kicad-cli 10.0.0 on synthetic schematics before adopting it. KiCad does not do that: a symbol whose pin 1 is named `IN` still yields `Net-(C1-Pad1)`. It also picks the candidate that sorts lowest as a plain string, so R2 wired to R10 gives `Net-(R10-Pad1)`. The implementation follows those two observations and the tests say so. Known deviation: inside a sub-sheet KiCad prefixes the name with the sheet path; this tool does not, consistent with how it already treats local labels. KiCad's next update-from-schematic renames such a net; connectivity is unaffected.

## Also

- The response reports every unmatched pad (`unmatched_pads`, `unmatched_pad_count`, plus a `warnings` entry) and the sheets read (`sheets_scanned`). The ten-entry `unmatched_pads_sample` stays for compatibility.
- The unused `from skip import Schematic` in this function and in `wire_connectivity.get_connections_for_net` are removed, closing the two gaps noted when #393 merged: a missing kicad-skip now surfaces the loader's `SchematicLoadError` there too.

## Tests

- `tests/test_sheet_tree.py` (8): order, reuse, missing sheet, legacy `Sheet file` spelling, escaped names, and that `.history/`, `.mcp-backups/`, `_backup/`, another project and a stray sheet are never reached where `rglob` finds 11 files.
- `tests/test_hierarchical_pad_net_map.py`: #358's six tests adopted (the pin-name one corrected to the pad number, with the kicad-cli finding in its docstring), a new "R10 beats R2" test, and a #400 test with decoy copies in three backup directories plus a stray sheet, asserting they are neither opened nor able to overwrite or inject. The two pre-existing sub-sheet tests now reference their sub-sheet from the root, which is the behaviour change.

Closes #400. Closes #402. Supersedes the nets half of #358.
