### PR TITLE
fix(component): exchange the physical footprint in edit_component, not just the FPID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,15 @@ All notable changes to the KiCAD MCP Server project are documented here.
 
 ### Bug Fixes
 
+- **`edit_component`'s footprint swap now actually replaces the footprint** (#399,
+  reported by @mixelpixx). Passing a new `footprint` rewrote the FPID library-ID
+  string via `SetFPID` and stopped there, so the pads, courtyard and silkscreen
+  stayed whatever the old footprint had. KiCad then reports `lib_footprint_mismatch`
+  plus unconnected pads once the pad counts differ. The handler now loads the new
+  footprint from the library and exchanges it in place, matching KiCad's own
+  `PCB_EDIT_FRAME::ExchangeFootprint()`: reference, value, position and orientation
+  carry over, and each new pad picks up the net of the old pad with the same
+  number.
 - **A missing kicad-skip no longer kills every tool at startup** (#389, @AmirF194).
   Six modules imported `from skip import Schematic` at their own top level.
   Two of them sit on the import chain `kicad_interface` -> `schematic_handlers`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ All notable changes to the KiCAD MCP Server project are documented here.
 ### Bug Fixes
 
 - **`edit_component`'s footprint swap now actually replaces the footprint** (#399,
-  reported by @mixelpixx). Passing a new `footprint` rewrote the FPID library-ID
+  reported by @joseluu). Passing a new `footprint` rewrote the FPID library-ID
   string via `SetFPID` and stopped there, so the pads, courtyard and silkscreen
   stayed whatever the old footprint had. KiCad then reports `lib_footprint_mismatch`
   plus unconnected pads once the pad counts differ. The handler now loads the new

--- a/python/commands/component.py
+++ b/python/commands/component.py
@@ -501,18 +501,52 @@ class ComponentCommands(PlacementOptimizerCommands):
             if value:
                 module.SetValue(value)
             if footprint:
-                # For KiCAD 9.x compatibility, use SetFPID instead of SetFootprintName
                 # Parse footprint string (format: "Library:Footprint")
                 if ":" in footprint:
                     lib_name, fp_name = footprint.split(":", 1)
-                    fpid = pcbnew.LIB_ID(lib_name, fp_name)
-                    module.SetFPID(fpid)
                 else:
                     # If no library specified, keep existing library
                     current_fpid = module.GetFPID()
                     lib_name = current_fpid.GetLibNickname().GetUTF8()
-                    fpid = pcbnew.LIB_ID(lib_name, footprint)
-                    module.SetFPID(fpid)
+                    fp_name = footprint
+
+                library_path = self.library_manager.get_library_path(lib_name)
+                if not library_path:
+                    return {
+                        "success": False,
+                        "message": "Library not found",
+                        "errorDetails": f"Could not find footprint library: {lib_name}",
+                    }
+
+                new_module = pcbnew.FootprintLoad(library_path, fp_name)
+                if not new_module:
+                    return {
+                        "success": False,
+                        "message": "Failed to load footprint",
+                        "errorDetails": f"Could not load footprint from {lib_name}:{fp_name}",
+                    }
+
+                # Replace the physical footprint (pads, courtyard, silkscreen, ...), not just
+                # the FPID string: mirrors KiCAD's own PCB_EDIT_FRAME::ExchangeFootprint(),
+                # preserving identity, placement and pad-to-net connectivity by pad number.
+                new_module.SetReference(module.GetReference())
+                new_module.SetValue(module.GetValue())
+                new_module.SetPosition(module.GetPosition())
+                new_module.SetOrientation(module.GetOrientation())
+                new_module.SetFPID(pcbnew.LIB_ID(lib_name, fp_name))
+
+                old_nets = {pad.GetNumber(): pad.GetNet() for pad in module.Pads()}
+                for pad in new_module.Pads():
+                    net = old_nets.get(pad.GetNumber())
+                    if net is not None:
+                        pad.SetNet(net)
+
+                was_flipped = module.IsFlipped()
+                self.board.Add(new_module)
+                if was_flipped and not new_module.IsFlipped():
+                    new_module.Flip(new_module.GetPosition(), False)
+                delete_board_item(self.board, module)
+                module = new_module
 
             return {
                 "success": True,

--- a/python/commands/component.py
+++ b/python/commands/component.py
@@ -504,13 +504,28 @@ class ComponentCommands(PlacementOptimizerCommands):
                 # Parse footprint string (format: "Library:Footprint")
                 if ":" in footprint:
                     lib_name, fp_name = footprint.split(":", 1)
+                    library_path = self.library_manager.get_library_path(lib_name)
                 else:
                     # If no library specified, keep existing library
                     current_fpid = module.GetFPID()
                     lib_name = current_fpid.GetLibNickname().GetUTF8()
                     fp_name = footprint
+                    library_path = (
+                        self.library_manager.get_library_path(lib_name) if lib_name else None
+                    )
 
-                library_path = self.library_manager.get_library_path(lib_name)
+                    if not library_path:
+                        # Empty nickname (footprint placed without a library, or an
+                        # imported board) or one the table no longer resolves: search
+                        # every library, same fallback place_component uses.
+                        fallback = self.library_manager.find_footprint(fp_name)
+                        if fallback:
+                            library_path, fp_name = fallback
+                            for nick, path in self.library_manager.libraries.items():
+                                if path == library_path:
+                                    lib_name = nick
+                                    break
+
                 if not library_path:
                     return {
                         "success": False,
@@ -534,6 +549,9 @@ class ComponentCommands(PlacementOptimizerCommands):
                 new_module.SetPosition(module.GetPosition())
                 new_module.SetOrientation(module.GetOrientation())
                 new_module.SetFPID(pcbnew.LIB_ID(lib_name, fp_name))
+                new_module.SetPath(module.GetPath())
+                new_module.SetAttributes(module.GetAttributes())
+                new_module.SetLocked(module.IsLocked())
 
                 old_nets = {pad.GetNumber(): pad.GetNet() for pad in module.Pads()}
                 for pad in new_module.Pads():

--- a/tests/test_edit_component_footprint_exchange.py
+++ b/tests/test_edit_component_footprint_exchange.py
@@ -1,0 +1,178 @@
+"""Regression tests for #399: edit_component's footprint swap only rewrote the FPID.
+
+``edit_component(footprint=...)`` used to call ``module.SetFPID(fpid)`` and stop: the
+library-ID string changed but the physical footprint (pads, courtyard, silkscreen) stayed
+whatever the component already had. KiCAD then reports ``lib_footprint_mismatch`` plus
+unconnected pads once the new and old footprints have a different pad count.
+
+The fix loads the new footprint from the library and exchanges it in place, preserving
+reference, value, position, orientation and pad-to-net connectivity (matched by pad
+number), mirroring KiCAD's own ``PCB_EDIT_FRAME::ExchangeFootprint()``.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+pytestmark = pytest.mark.unit
+
+import pcbnew as _pcbnew_stub  # noqa: E402 (must come after sys.path insert)
+
+
+def _make_pad(number, net):
+    pad = MagicMock(name=f"pad:{number}")
+    pad.GetNumber.return_value = number
+    pad.GetNet.return_value = net
+    return pad
+
+
+def _make_footprint(reference, value, position, orientation, pads, flipped=False):
+    fp = MagicMock(name=f"footprint:{reference}")
+    fp.GetReference.return_value = reference
+    fp.GetValue.return_value = value
+    fp.GetPosition.return_value = position
+    fp.GetOrientation.return_value = orientation
+    fp.Pads.return_value = pads
+    fp.IsFlipped.return_value = flipped
+    return fp
+
+
+def _make_component_commands(old_module, new_module, library_path="/libs/SOT-23.pretty"):
+    """Wire a ComponentCommands whose board holds old_module and whose library manager
+    resolves any lib name to library_path, with pcbnew.FootprintLoad returning new_module."""
+    from commands.component import ComponentCommands
+
+    board = MagicMock(name="board")
+    board.FindFootprintByReference.return_value = old_module
+
+    lib_mgr = MagicMock(name="library_manager")
+    lib_mgr.get_library_path.return_value = library_path
+
+    cmd = ComponentCommands.__new__(ComponentCommands)
+    cmd.board = board
+    cmd.library_manager = lib_mgr
+
+    _pcbnew_stub.reset_mock()
+    _pcbnew_stub.FootprintLoad.return_value = new_module
+    _pcbnew_stub.LIB_ID.side_effect = lambda lib, fp: (lib, fp)
+    return cmd, board
+
+
+class TestFootprintExchange:
+    def test_swap_loads_new_footprint_instead_of_only_rewriting_fpid(self):
+        old_pads = [_make_pad("1", "net:VCC"), _make_pad("2", "net:GND")]
+        old = _make_footprint("D1", "1N4148", (1000, 2000), 900, old_pads)
+
+        new_pads = [_make_pad("1", None), _make_pad("2", None), _make_pad("3", None)]
+        new = _make_footprint("SOT-23-proto", "", (0, 0), 0, new_pads)
+
+        cmd, board = _make_component_commands(old, new)
+
+        result = cmd.edit_component(
+            {"reference": "D1", "footprint": "Package_TO_SOT_SMD:SOT-23"}
+        )
+
+        assert result["success"] is True
+        # The loaded footprint was fetched from the library, not fabricated from the FPID.
+        _pcbnew_stub.FootprintLoad.assert_called_once_with(
+            "/libs/SOT-23.pretty", "SOT-23"
+        )
+        # It replaced the old footprint on the board rather than mutating it in place.
+        board.Add.assert_called_once_with(new)
+        board.Delete.assert_called_once_with(old)
+
+    def test_position_reference_and_value_survive_the_swap(self):
+        old = _make_footprint("D1", "1N4148", (1000, 2000), 900, [])
+        new = _make_footprint("SOT-23-proto", "", (0, 0), 0, [])
+        cmd, _board = _make_component_commands(old, new)
+
+        cmd.edit_component({"reference": "D1", "footprint": "Package_TO_SOT_SMD:SOT-23"})
+
+        new.SetReference.assert_called_once_with("D1")
+        new.SetValue.assert_called_once_with("1N4148")
+        new.SetPosition.assert_called_once_with((1000, 2000))
+        new.SetOrientation.assert_called_once_with(900)
+
+    def test_pads_are_reconnected_to_the_old_nets_by_number(self):
+        """The prior fix (SetFPID only) left every new pad netless; a maintainer-cited DRC
+        symptom was unconnected pads even when the pad count happened to match."""
+        old_pads = [_make_pad("1", "net:VCC"), _make_pad("2", "net:GND")]
+        old = _make_footprint("D1", "1N4148", (1000, 2000), 900, old_pads)
+
+        new_pad_1 = _make_pad("1", None)
+        new_pad_2 = _make_pad("2", None)
+        new = _make_footprint("SOT-23-proto", "", (0, 0), 0, [new_pad_1, new_pad_2])
+
+        cmd, _board = _make_component_commands(old, new)
+        cmd.edit_component({"reference": "D1", "footprint": "Package_TO_SOT_SMD:SOT-23"})
+
+        new_pad_1.SetNet.assert_called_once_with("net:VCC")
+        new_pad_2.SetNet.assert_called_once_with("net:GND")
+
+    def test_extra_pad_on_the_new_footprint_is_left_unset(self):
+        """SOT-23 has 3 pads where SOD-323 has 2, the reporter's exact repro shape.
+        The unmatched pad number must not raise and must be left without a SetNet call."""
+        old_pads = [_make_pad("1", "net:A"), _make_pad("2", "net:K")]
+        old = _make_footprint("D1", "1N4148", (0, 0), 0, old_pads)
+
+        new_pads = [_make_pad("1", None), _make_pad("2", None), _make_pad("3", None)]
+        new = _make_footprint("SOT-23-proto", "", (0, 0), 0, new_pads)
+
+        cmd, _board = _make_component_commands(old, new)
+        result = cmd.edit_component(
+            {"reference": "D1", "footprint": "Package_TO_SOT_SMD:SOT-23"}
+        )
+
+        assert result["success"] is True
+        _pcbnew_stub.FootprintLoad.assert_called_once_with(
+            "/libs/SOT-23.pretty", "SOT-23"
+        )
+        new_pads[2].SetNet.assert_not_called()
+
+    def test_bare_footprint_name_keeps_the_existing_library(self):
+        old_fpid = MagicMock()
+        old_fpid.GetLibNickname.return_value.GetUTF8.return_value = "Diode_SMD"
+        old = _make_footprint("D1", "1N4148", (0, 0), 0, [])
+        old.GetFPID.return_value = old_fpid
+
+        new = _make_footprint("proto", "", (0, 0), 0, [])
+        cmd, _board = _make_component_commands(old, new)
+
+        cmd.edit_component({"reference": "D1", "footprint": "D_SOD-323"})
+
+        _pcbnew_stub.FootprintLoad.assert_called_once_with(
+            "/libs/SOT-23.pretty", "D_SOD-323"
+        )
+
+    def test_flipped_component_is_flipped_after_re_add(self):
+        """Flip() needs board context in KiCAD 9 (established convention elsewhere in this
+        file); calling it before board.Add() would hang, so the new footprint must be
+        added to the board first and only flipped afterwards."""
+        old = _make_footprint("D1", "1N4148", (0, 0), 0, [], flipped=True)
+        new = _make_footprint("proto", "", (0, 0), 0, [], flipped=False)
+        cmd, board = _make_component_commands(old, new)
+
+        calls = []
+        board.Add.side_effect = lambda *_a: calls.append("add")
+        new.Flip.side_effect = lambda *_a, **_k: calls.append("flip")
+
+        cmd.edit_component({"reference": "D1", "footprint": "Package_TO_SOT_SMD:SOT-23"})
+
+        assert calls == ["add", "flip"]
+
+    def test_unknown_library_reports_failure_without_touching_the_board(self):
+        old = _make_footprint("D1", "1N4148", (0, 0), 0, [])
+        new = _make_footprint("proto", "", (0, 0), 0, [])
+        cmd, board = _make_component_commands(old, new, library_path=None)
+
+        result = cmd.edit_component(
+            {"reference": "D1", "footprint": "NoSuchLib:Whatever"}
+        )
+
+        assert result["success"] is False
+        board.Add.assert_not_called()
+        board.Delete.assert_not_called()

--- a/tests/test_edit_component_footprint_exchange.py
+++ b/tests/test_edit_component_footprint_exchange.py
@@ -164,3 +164,61 @@ class TestFootprintExchange:
         assert result["success"] is False
         board.Add.assert_not_called()
         board.Delete.assert_not_called()
+
+    def test_empty_nickname_falls_back_to_searching_all_libraries(self):
+        """A footprint placed without a library, or on an imported board, reports an
+        empty nickname from GetFPID(); get_library_path("") then has nothing to look
+        up even though the footprint exists. Fall back to find_footprint(), the same
+        way place_component does."""
+        old_fpid = MagicMock()
+        old_fpid.GetLibNickname.return_value.GetUTF8.return_value = ""
+        old = _make_footprint("D1", "1N4148", (0, 0), 0, [])
+        old.GetFPID.return_value = old_fpid
+
+        new = _make_footprint("proto", "", (0, 0), 0, [])
+        cmd, _board = _make_component_commands(old, new)
+        cmd.library_manager.get_library_path.return_value = None
+        cmd.library_manager.find_footprint.return_value = ("/libs/SOT-23.pretty", "D_SOD-323")
+        cmd.library_manager.libraries = {"Diode_SMD": "/libs/SOT-23.pretty"}
+
+        result = cmd.edit_component({"reference": "D1", "footprint": "D_SOD-323"})
+
+        assert result["success"] is True
+        cmd.library_manager.find_footprint.assert_called_once_with("D_SOD-323")
+        _pcbnew_stub.FootprintLoad.assert_called_once_with("/libs/SOT-23.pretty", "D_SOD-323")
+
+    def test_unresolvable_nickname_and_no_fallback_match_reports_failure(self):
+        old_fpid = MagicMock()
+        old_fpid.GetLibNickname.return_value.GetUTF8.return_value = ""
+        old = _make_footprint("D1", "1N4148", (0, 0), 0, [])
+        old.GetFPID.return_value = old_fpid
+
+        new = _make_footprint("proto", "", (0, 0), 0, [])
+        cmd, board = _make_component_commands(old, new)
+        cmd.library_manager.get_library_path.return_value = None
+        cmd.library_manager.find_footprint.return_value = None
+
+        result = cmd.edit_component({"reference": "D1", "footprint": "NoSuchFootprint"})
+
+        assert result["success"] is False
+        board.Add.assert_not_called()
+
+    def test_carried_over_fields_survive_the_swap(self):
+        """KiCAD's own PCB_EDIT_FRAME::ExchangeFootprint() also carries the KIID_PATH
+        (the schematic-symbol link Update PCB from Schematic matches by), the DNP /
+        exclude-from-BOM / exclude-from-POS attribute bits, and the locked flag. A swap
+        that drops them desyncs the new footprint from its schematic symbol and
+        silently clears DNP/locked."""
+        old = _make_footprint("D1", "1N4148", (0, 0), 0, [])
+        old.GetPath.return_value = "/abc123/def456"
+        old.GetAttributes.return_value = 42
+        old.IsLocked.return_value = True
+
+        new = _make_footprint("proto", "", (0, 0), 0, [])
+        cmd, _board = _make_component_commands(old, new)
+
+        cmd.edit_component({"reference": "D1", "footprint": "Package_TO_SOT_SMD:SOT-23"})
+
+        new.SetPath.assert_called_once_with("/abc123/def456")
+        new.SetAttributes.assert_called_once_with(42)
+        new.SetLocked.assert_called_once_with(True)

--- a/tests/test_edit_component_footprint_exchange.py
+++ b/tests/test_edit_component_footprint_exchange.py
@@ -72,15 +72,11 @@ class TestFootprintExchange:
 
         cmd, board = _make_component_commands(old, new)
 
-        result = cmd.edit_component(
-            {"reference": "D1", "footprint": "Package_TO_SOT_SMD:SOT-23"}
-        )
+        result = cmd.edit_component({"reference": "D1", "footprint": "Package_TO_SOT_SMD:SOT-23"})
 
         assert result["success"] is True
         # The loaded footprint was fetched from the library, not fabricated from the FPID.
-        _pcbnew_stub.FootprintLoad.assert_called_once_with(
-            "/libs/SOT-23.pretty", "SOT-23"
-        )
+        _pcbnew_stub.FootprintLoad.assert_called_once_with("/libs/SOT-23.pretty", "SOT-23")
         # It replaced the old footprint on the board rather than mutating it in place.
         board.Add.assert_called_once_with(new)
         board.Delete.assert_called_once_with(old)
@@ -123,14 +119,10 @@ class TestFootprintExchange:
         new = _make_footprint("SOT-23-proto", "", (0, 0), 0, new_pads)
 
         cmd, _board = _make_component_commands(old, new)
-        result = cmd.edit_component(
-            {"reference": "D1", "footprint": "Package_TO_SOT_SMD:SOT-23"}
-        )
+        result = cmd.edit_component({"reference": "D1", "footprint": "Package_TO_SOT_SMD:SOT-23"})
 
         assert result["success"] is True
-        _pcbnew_stub.FootprintLoad.assert_called_once_with(
-            "/libs/SOT-23.pretty", "SOT-23"
-        )
+        _pcbnew_stub.FootprintLoad.assert_called_once_with("/libs/SOT-23.pretty", "SOT-23")
         new_pads[2].SetNet.assert_not_called()
 
     def test_bare_footprint_name_keeps_the_existing_library(self):
@@ -144,9 +136,7 @@ class TestFootprintExchange:
 
         cmd.edit_component({"reference": "D1", "footprint": "D_SOD-323"})
 
-        _pcbnew_stub.FootprintLoad.assert_called_once_with(
-            "/libs/SOT-23.pretty", "D_SOD-323"
-        )
+        _pcbnew_stub.FootprintLoad.assert_called_once_with("/libs/SOT-23.pretty", "D_SOD-323")
 
     def test_flipped_component_is_flipped_after_re_add(self):
         """Flip() needs board context in KiCAD 9 (established convention elsewhere in this
@@ -169,9 +159,7 @@ class TestFootprintExchange:
         new = _make_footprint("proto", "", (0, 0), 0, [])
         cmd, board = _make_component_commands(old, new, library_path=None)
 
-        result = cmd.edit_component(
-            {"reference": "D1", "footprint": "NoSuchLib:Whatever"}
-        )
+        result = cmd.edit_component({"reference": "D1", "footprint": "NoSuchLib:Whatever"})
 
         assert result["success"] is False
         board.Add.assert_not_called()


### PR DESCRIPTION
Did it, following the shape you laid out. `edit_component`'s footprint branch only called `SetFPID`, so the pads, courtyard and silkscreen stayed whatever the old footprint had, matching what you and the reporter both described.

Loads the new footprint from the library and swaps it in for the old one: reference, value, position and orientation carry over, and each new pad picks up the net of the old pad with the same number, so a resistor keeps its connections when it becomes a bigger resistor. A pad number with no match on the old footprint (your 2-pad-to-3-pad example) is left unset rather than guessed at.

Tests mock `pcbnew` the way the rest of this suite does, since there's no real board here to check DRC against. `test_edit_component_footprint_exchange.py` covers the swap itself, net reassignment by pad number, the unmatched-pad case, the bare-footprint-name path that keeps the existing library, and the flip-after-add ordering (matches the existing `place_component` comment about `Flip()` needing board context).

Fixes #399
