### PR TITLE
fix(worker): survive a bad request and a failed log rollover (#405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,25 @@ All notable changes to the KiCAD MCP Server project are documented here.
   filtered to the moved unit, and the part's other units count as stationary,
   so their wiring is left where it is.
 
+- **One bad command no longer kills the Python worker for the rest of the
+  session** (#405, reported by @joseluu). The worker's stdin loop caught only
+  invalid JSON per request. Anything else that escaped while a response was
+  being built or written (a handler result holding a value the JSON encoder
+  rejects, a request whose JSON is valid but is not an object) fell through
+  to the outer handler, which exited with code 1; every later tool call then
+  failed with "Python process for KiCAD scripting is not running" until the
+  server was restarted. The loop now answers such a request with an error
+  frame that still carries its request id (a JSON-RPC error for JSON-RPC
+  requests) and keeps serving.
+
+  The same report showed log rotation failing on Windows for two days: the
+  rename that `RotatingFileHandler` performs raises WinError 32 while any
+  other process holds the file open, and the stock handler then drops every
+  record behind a "--- Logging error ---" traceback. Per-process log files
+  (2.7.0, #373) removed the collision between sibling servers; the handler
+  now also treats a failed rollover as best effort, keeps writing to the
+  current file, warns once on stderr, and retries a minute later.
+
 ### Tooling
 
 - **Documentation trued up to the shipped server, and the tool inventory is now

--- a/python/kicad_interface.py
+++ b/python/kicad_interface.py
@@ -13,6 +13,7 @@ import logging
 import os
 import shutil
 import sys
+import time
 import traceback
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
@@ -90,6 +91,54 @@ def _env_flag_enabled(name: str) -> bool:
 
 _LOG_LEVEL = _parse_log_level()
 
+
+class _TolerantRotatingFileHandler(RotatingFileHandler):
+    """A RotatingFileHandler whose failed rollover is not a logging error.
+
+    Rotation renames the live log file, and on Windows that rename fails with
+    WinError 32 for as long as any other process holds the file open (an
+    antivirus scanner, a search indexer, a ``tail``). The stock handler then
+    prints a "--- Logging error ---" traceback to stderr for every record and
+    writes nothing more to the file: each emit re-attempts the rename, fails
+    again, and drops the record (#405).
+
+    Here a failed rollover keeps the current file open for writing instead,
+    warns once on stderr, and waits a minute before trying to rotate again.
+    The file can exceed ``maxBytes`` while the lock lasts; rotation resumes
+    at the first attempt after it is released.
+    """
+
+    _RETRY_SECONDS = 60.0
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._next_rollover_attempt = 0.0
+        self._rollover_warned = False
+
+    def shouldRollover(self, record: logging.LogRecord) -> int:  # noqa: N802 - stdlib name
+        if time.monotonic() < self._next_rollover_attempt:
+            return 0
+        return super().shouldRollover(record)
+
+    def doRollover(self) -> None:  # noqa: N802 - stdlib name
+        try:
+            super().doRollover()
+            self._next_rollover_attempt = 0.0
+        except OSError as exc:
+            self._next_rollover_attempt = time.monotonic() + self._RETRY_SECONDS
+            if not self._rollover_warned:
+                self._rollover_warned = True
+                sys.stderr.write(
+                    f"kicad_interface: log rotation of {self.baseFilename} failed "
+                    f"({exc}); continuing in the current file\n"
+                )
+            # The base class closed the stream before the rename attempt;
+            # reopen it (append mode) so the record that triggered the
+            # rollover, and every later one, still lands in the file.
+            if self.stream is None and not self.delay:
+                self.stream = self._open()
+
+
 # Configure logging.
 # The file handler rotates (default 10 MB x 3 backups) so the log can never
 # grow without bound (issue #181); the level honors the environment instead of
@@ -106,9 +155,7 @@ try:
     # Best-effort sweep of logs from dead processes so per-PID naming cannot
     # accumulate without bound (the concern that motivated #181's rotation).
     try:
-        import time as _time
-
-        _cutoff = _time.time() - 7 * 24 * 3600
+        _cutoff = time.time() - 7 * 24 * 3600
         for _old_log in log_dir.glob("kicad_interface-*.log*"):
             if _old_log.stat().st_mtime < _cutoff:
                 _old_log.unlink()
@@ -117,7 +164,7 @@ try:
     max_log_bytes = _parse_positive_int_env("KICAD_MCP_LOG_MAX_BYTES", 10 * 1024 * 1024)
     backup_count = _parse_positive_int_env("KICAD_MCP_LOG_BACKUP_COUNT", 3)
     if max_log_bytes:
-        log_handler: logging.Handler = RotatingFileHandler(
+        log_handler: logging.Handler = _TolerantRotatingFileHandler(
             log_file,
             maxBytes=max_log_bytes,
             backupCount=backup_count,
@@ -6360,14 +6407,19 @@ def main() -> None:
                 # Parse command
                 logger.debug(f"Received input: {line.strip()}")
                 internal_request_id = None
+                rpc_request_id = None
+                is_jsonrpc = False
+                command_name: Optional[str] = None
                 command_data = json.loads(line)
 
                 # Check if this is JSON-RPC 2.0 format
                 if "jsonrpc" in command_data and command_data["jsonrpc"] == "2.0":
                     logger.info("Detected JSON-RPC 2.0 format message")
+                    is_jsonrpc = True
                     method = command_data.get("method")
                     params = command_data.get("params", {})
                     request_id = command_data.get("id")
+                    rpc_request_id = request_id
 
                     # Handle MCP protocol methods
                     if method == "initialize":
@@ -6435,6 +6487,7 @@ def main() -> None:
                         logger.info("Handling MCP tools/call")
                         tool_name = params.get("name")
                         tool_params = params.get("arguments", {})
+                        command_name = tool_name
 
                         # Execute the command
                         result = interface.handle_command(tool_name, tool_params)
@@ -6490,6 +6543,7 @@ def main() -> None:
                     command = command_data.get("command")
                     params = command_data.get("params", {})
                     internal_request_id = command_data.get("requestId")
+                    command_name = command
 
                     if not command:
                         logger.error("Missing command field")
@@ -6516,11 +6570,47 @@ def main() -> None:
                 }
                 _write_response(_response_fd, response)
 
+            except Exception as e:
+                # One bad request must not take the worker down (#405).
+                # Errors raised inside a handler are already answered by
+                # handle_command; what reaches here escaped while the
+                # response was being built or written -- a result value
+                # json.dumps rejects, a request whose JSON is valid but is not
+                # an object -- and used to fall through to the sys.exit(1)
+                # below, failing every later call with "Python process for
+                # KiCAD scripting is not running".
+                logger.error(
+                    f"Unhandled error while processing {command_name or 'request'}: "
+                    f"{e}\n{traceback.format_exc()}"
+                )
+                what = f"command {command_name!r}" if command_name else "request"
+                message = f"Internal error while processing {what}: {type(e).__name__}: {e}"
+                if is_jsonrpc:
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": rpc_request_id,
+                        "error": {"code": -32603, "message": message},
+                    }
+                else:
+                    response = _attach_internal_request_id(
+                        {
+                            "success": False,
+                            "message": message,
+                            "errorDetails": str(e),
+                        },
+                        internal_request_id,
+                    )
+                # If this write fails as well, the response channel itself is
+                # broken (the host is gone) and the outer handler exits.
+                _write_response(_response_fd, response)
+
     except KeyboardInterrupt:
         logger.info("KiCAD interface stopped")
         sys.exit(0)
 
     except Exception as e:
+        # Only failures outside a single request reach here now: stdin
+        # itself failing, or the response channel being unwritable.
         logger.error(f"Unexpected error: {str(e)}\n{traceback.format_exc()}")
         sys.exit(1)
 

--- a/tests/test_log_rotation_tolerance.py
+++ b/tests/test_log_rotation_tolerance.py
@@ -1,0 +1,115 @@
+"""Regression tests for #405: a failed log rollover must not stop logging.
+
+``RotatingFileHandler.doRollover`` renames the live log file. On Windows that
+rename raises ``PermissionError`` (WinError 32) while any other process holds
+the file open. The stock handler then reports "--- Logging error ---" on every
+record and writes nothing more: the file in the report sat at exactly the
+rotation threshold for two days.
+
+``_TolerantRotatingFileHandler`` treats a failed rollover as best effort: it
+keeps writing to the current file, warns once, backs off before retrying, and
+rotates normally once the rename succeeds again.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python"))
+
+from kicad_interface import _TolerantRotatingFileHandler  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+_LOCKED = PermissionError(
+    32, "The process cannot access the file because it is being used by another process"
+)
+
+
+def _make_handler(tmp_path, max_bytes=200):
+    handler = _TolerantRotatingFileHandler(
+        str(tmp_path / "worker.log"),
+        maxBytes=max_bytes,
+        backupCount=2,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    log = logging.Logger("rotation-tolerance-test")
+    log.addHandler(handler)
+    return handler, log
+
+
+def _emit(log, count):
+    for i in range(count):
+        log.info("x" * 20 + f" record {i}")
+
+
+def test_failed_rollover_keeps_writing_to_the_current_file(tmp_path, monkeypatch, capsys):
+    handler, log = _make_handler(tmp_path)
+
+    def locked(self, source, dest):
+        raise _LOCKED
+
+    monkeypatch.setattr(_TolerantRotatingFileHandler, "rotate", locked)
+    logging_errors = []
+    monkeypatch.setattr(handler, "handleError", logging_errors.append)
+
+    _emit(log, 50)
+    handler.close()
+
+    text = (tmp_path / "worker.log").read_text(encoding="utf-8")
+    assert "record 0" in text and "record 49" in text
+    assert logging_errors == [], "a failed rollover must not be reported as a logging error"
+    assert not (tmp_path / "worker.log.1").exists()
+    assert capsys.readouterr().err.count("log rotation") == 1, "warn once, not per record"
+
+
+def test_failed_rollover_backs_off_instead_of_retrying_every_record(tmp_path, monkeypatch):
+    handler, log = _make_handler(tmp_path)
+    attempts = []
+
+    def locked(self, source, dest):
+        attempts.append(source)
+        raise _LOCKED
+
+    monkeypatch.setattr(_TolerantRotatingFileHandler, "rotate", locked)
+    monkeypatch.setattr(handler, "handleError", lambda record: None)
+
+    _emit(log, 50)
+    handler.close()
+
+    assert len(attempts) == 1
+
+
+def test_rotation_resumes_once_the_rename_succeeds(tmp_path, monkeypatch):
+    handler, log = _make_handler(tmp_path)
+    handler._RETRY_SECONDS = 0.0
+    calls = []
+    real_rotate = _TolerantRotatingFileHandler.rotate
+
+    def flaky(self, source, dest):
+        calls.append(source)
+        if len(calls) == 1:
+            raise _LOCKED
+        return real_rotate(self, source, dest)
+
+    monkeypatch.setattr(_TolerantRotatingFileHandler, "rotate", flaky)
+    monkeypatch.setattr(handler, "handleError", lambda record: None)
+
+    _emit(log, 50)
+    handler.close()
+
+    assert len(calls) >= 2
+    assert (tmp_path / "worker.log.1").exists()
+    assert "record 49" in (tmp_path / "worker.log").read_text(encoding="utf-8")
+
+
+def test_successful_rollover_is_unchanged(tmp_path):
+    handler, log = _make_handler(tmp_path)
+    _emit(log, 50)
+    handler.close()
+
+    assert (tmp_path / "worker.log.1").exists()
+    assert (tmp_path / "worker.log").stat().st_size <= 200

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -22,6 +22,7 @@ from kicad_interface import (  # noqa: E402
     _env_flag_enabled,
     _parse_log_level,
     _parse_positive_int_env,
+    _TolerantRotatingFileHandler,
 )
 
 
@@ -103,11 +104,19 @@ class TestLoggingSideEffects:
             assert logging.getLogger(name).level == logging.WARNING
 
     def test_no_unbounded_handler_for_kicad_log(self):
-        # The regression was a plain logging.FileHandler on kicad_interface.log
-        # that grows forever. Any handler targeting that file must rotate.
-        # (Unrelated handlers, e.g. a NUL-device sink from the test harness,
-        # are ignored — they can't grow.)
-        for handler in logging.getLogger().handlers:
-            base = getattr(handler, "baseFilename", "")
-            if base and base.endswith("kicad_interface.log"):
-                assert isinstance(handler, RotatingFileHandler)
+        # The regression was a plain logging.FileHandler on the worker log
+        # that grows forever. Any handler targeting that file must rotate,
+        # and rotate tolerantly (#405): a rollover that fails because another
+        # process holds the file must not stop logging. The file has been
+        # per-PID (kicad_interface-<pid>.log) since #373. (Unrelated handlers,
+        # e.g. a NUL-device sink from the test harness, are ignored — they
+        # can't grow.)
+        worker_log_handlers = [
+            handler
+            for handler in logging.getLogger().handlers
+            if "kicad_interface-" in Path(getattr(handler, "baseFilename", "")).name
+        ]
+        assert worker_log_handlers, "kicad_interface installs a file handler at import"
+        for handler in worker_log_handlers:
+            assert isinstance(handler, RotatingFileHandler)
+            assert isinstance(handler, _TolerantRotatingFileHandler)

--- a/tests/test_worker_survives_bad_command.py
+++ b/tests/test_worker_survives_bad_command.py
@@ -1,0 +1,144 @@
+"""Regression tests for #405: one bad command must not kill the Python worker.
+
+The worker's stdin loop in ``kicad_interface.main()`` caught only
+``json.JSONDecodeError`` per line. Anything else that escaped while a response
+was being built or written -- a value ``json.dumps`` rejects in a handler's
+result, a request whose JSON is valid but not an object -- fell through to
+the outer ``except Exception``, which called ``sys.exit(1)``. From then on every
+tool call failed with "Python process for KiCAD scripting is not running"
+until someone restarted the server.
+
+These run the real ``main()`` in a subprocess (the fd redirection it does at
+startup cannot be undone in-process) with ``handle_command`` patched to return
+an unserialisable result for one command, and check that the commands after
+it are still answered and that the process ends normally at stdin EOF.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PYTHON_DIR = Path(__file__).resolve().parent.parent / "python"
+
+_WORKER = f"""
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, {str(PYTHON_DIR)!r})
+
+pcbnew = MagicMock(name="pcbnew")
+pcbnew.__file__ = "/fake/pcbnew.py"
+pcbnew.__spec__ = None
+pcbnew.GetBuildVersion.return_value = "9.0.0-stub"
+sys.modules["pcbnew"] = pcbnew
+
+import kicad_interface
+
+_real_handle_command = kicad_interface.KiCADInterface.handle_command
+
+
+def _handle_command(self, command, params):
+    if command == "ping":
+        return {{"success": True, "n": params.get("n")}}
+    if command == "unserialisable":
+        # handle_command's own try/except never sees this: the handler
+        # returns normally and json.dumps rejects the value later.
+        return {{"success": True, "payload": object()}}
+    return _real_handle_command(self, command, params)
+
+
+kicad_interface.KiCADInterface.handle_command = _handle_command
+kicad_interface.main()
+"""
+
+
+def _run_worker(lines, tmp_path):
+    env = dict(os.environ)
+    # Keep the worker's per-PID log file out of the real profile directory
+    # and skip the symbol-library warm-up thread.
+    env["HOME"] = str(tmp_path)
+    env["USERPROFILE"] = str(tmp_path)
+    env["KICAD_SKIP_SYMBOL_WARMUP"] = "1"
+    result = subprocess.run(
+        [sys.executable, "-c", _WORKER],
+        input="".join(line + "\n" for line in lines),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+    frames = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    return result, frames
+
+
+def test_worker_answers_commands_after_an_unserialisable_result(tmp_path):
+    lines = [
+        json.dumps({"command": "ping", "params": {"n": 1}, "requestId": 1}),
+        json.dumps({"command": "unserialisable", "params": {}, "requestId": 2}),
+        json.dumps({"command": "ping", "params": {"n": 3}, "requestId": 3}),
+    ]
+    result, frames = _run_worker(lines, tmp_path)
+
+    assert result.returncode == 0, (
+        "the worker must reach stdin EOF and exit normally, not die on the bad "
+        f"command\nstderr:\n{result.stderr[-3000:]}"
+    )
+    assert frames[0] == {"type": "ready"}
+    by_id = {f.get("_requestId"): f for f in frames[1:]}
+    assert by_id[1]["n"] == 1
+
+    error = by_id[2]
+    assert error["success"] is False
+    assert "not JSON serializable" in error["errorDetails"]
+    assert "unserialisable" in error["message"]
+
+    # The request after the failure is answered by the same worker.
+    assert by_id[3]["n"] == 3
+
+
+def test_worker_survives_request_that_is_valid_json_but_not_an_object(tmp_path):
+    lines = [
+        "42",
+        "[1, 2]",
+        json.dumps({"command": "ping", "params": {"n": 9}, "requestId": 9}),
+    ]
+    result, frames = _run_worker(lines, tmp_path)
+
+    assert result.returncode == 0, result.stderr[-3000:]
+    assert frames[0] == {"type": "ready"}
+    errors = [f for f in frames[1:] if f.get("success") is False]
+    assert len(errors) == 2
+    for error in errors:
+        # No request id could be read from the input, so none is echoed;
+        # the host discards the frame as stale rather than misrouting it.
+        assert "_requestId" not in error
+    assert frames[-1] == {"success": True, "n": 9, "_requestId": 9}
+
+
+def test_worker_reports_json_rpc_error_instead_of_dying(tmp_path):
+    lines = [
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "tools/call",
+                "params": {"name": "unserialisable", "arguments": {}},
+            }
+        ),
+        json.dumps({"command": "ping", "params": {"n": 8}, "requestId": 8}),
+    ]
+    result, frames = _run_worker(lines, tmp_path)
+
+    assert result.returncode == 0, result.stderr[-3000:]
+    rpc_error = frames[1]
+    assert rpc_error["jsonrpc"] == "2.0"
+    assert rpc_error["id"] == 7
+    assert rpc_error["error"]["code"] == -32603
+    assert "not JSON serializable" in rpc_error["error"]["message"]
+    assert frames[2] == {"success": True, "n": 8, "_requestId": 8}


### PR DESCRIPTION
## Summary

Refs #405 (the crash half; respawn on worker exit lands with #390).

The report showed the Python worker exiting with code 1 during a `run_drc` call and every later tool call failing with "Python process for KiCAD scripting is not running". Two separate defects were behind it.

**One bad request killed the worker.** The stdin loop in `kicad_interface.main()` caught only `json.JSONDecodeError` per line. Anything else that escaped while a response was being built or written fell through to the outer `except Exception`, which called `sys.exit(1)`. Errors raised inside a handler never reach that path (`handle_command` answers them itself); what does is a handler result holding a value `json.dumps` rejects (a `set`, a pcbnew object), a request whose JSON is valid but is not an object (`42`), or the equivalent on the JSON-RPC path. The loop now catches `Exception` per line, logs the traceback, and writes an error frame that still carries the request id (`_requestId` for bridge requests, a JSON-RPC `-32603` error for JSON-RPC requests) so the host resolves the pending call instead of timing out, then keeps serving. The outer handler is left for failures outside a request: stdin itself failing, or the response channel being unwritable, where exiting is right because the host is gone.

**Failed log rotation stopped logging.** `RotatingFileHandler.doRollover` renames the live file, and on Windows that raises WinError 32 while any other process holds it open. The stock handler then reports "--- Logging error ---" on every record and writes nothing more; the reporter's file sat at exactly the 10 MiB threshold for two days. Per-process log files (#373, in 2.7.0) already removed the collision between sibling servers. This adds `_TolerantRotatingFileHandler`: a failed rollover keeps the current file open for writing, warns once on stderr, and waits 60 s before the next attempt; rotation resumes at the first attempt after the lock is released. The file can exceed `maxBytes` while the lock lasts, which is the trade the report asked for (suggestion 1).

## Tests

- `tests/test_worker_survives_bad_command.py` runs the real `main()` in a subprocess (its fd redirection cannot be undone in-process) with `handle_command` patched to return an unserialisable value for one command. On main the worker answers the first request and exits 1; with this change it answers the bad request with an error frame carrying its id, answers the next request, and exits 0 at stdin EOF. Also covers a non-object request line and the JSON-RPC error shape.
- `tests/test_log_rotation_tolerance.py`: a rename that always fails leaves every record in the file, reports no logging error, warns once, and attempts rotation once per burst; a rename that fails once then succeeds rotates on the retry; a normal rollover is unchanged.
- `tests/test_logging_config.py::test_no_unbounded_handler_for_kicad_log` was checking for a handler on `kicad_interface.log`, a name that no longer exists since #373 made the file per-PID, so it passed vacuously. It now asserts the per-PID handler exists and is the tolerant subclass.

## Verification

- pre-commit (black, isort, flake8, mypy, prettier, eslint) clean on `--all-files`
- pytest: 4 failed / 2365 passed / 35 skipped on this machine; the 4 are the known environmental failures (`test_ipc_open_board_path` path separator, 3x `test_svg_to_png_render` no converter), identical to the baseline set on main
