### PR TITLE
fix(schematic): report unsnapped wire endpoints; fix linting pin transform (#404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,28 @@ All notable changes to the KiCAD MCP Server project are documented here.
   filtered to the moved unit, and the part's other units count as stationary,
   so their wiring is left where it is.
 
+- **`add_schematic_wire` said "success" for a wire that connected nothing**
+  (#404, reported by @andersresen). With `snapToPins` on (the default), an
+  endpoint that was not within `snapTolerance` of any pin was left where it
+  was and the response did not say so, which is how a wire drawn from a
+  miscalculated pin position ends up floating next to the pin. The response
+  now reports, for the start and end points, whether they snapped, the
+  nearest pin and its distance, and carries a warning (also appended to the
+  message) when an endpoint is outside the tolerance of every pin.
+
+  The report's own numbers turned out to be the y-up/y-down mistake: KiCad
+  library symbols are drawn y-up and sheets are y-down, so a rotation-0
+  instance at (x, y) puts a library pin (px, py) at (x + px, y - py), which
+  is what `get_schematic_pin_locations` returns and what kicad-cli netlists
+  confirm. Two linting helpers in `schematic_analysis.py` did have that bug
+  and more: `_compute_pin_positions_direct` (behind
+  `find_wires_crossing_symbols` and `get_elements_in_region`) never flipped y
+  and rotated the wrong way, so its pin positions were wrong at every
+  rotation, and `_transform_local_point` (symbol body boxes) was wrong at 90
+  and 270 degrees. Both now delegate to the netlist-verified transform in
+  `WireDragger.pin_world_xy`, pinned by a test whose expected coordinates are
+  the verified formulas rather than the code under test.
+
 ### Tooling
 
 - **Documentation trued up to the shipped server, and the tool inventory is now

--- a/python/commands/schematic_analysis.py
+++ b/python/commands/schematic_analysis.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import sexpdata
 from commands.pin_locator import PinLocator
 from commands.wire_connectivity import _parse_virtual_connections, _to_iu
+from commands.wire_dragger import WireDragger
 from sexpdata import Symbol
 
 logger = logging.getLogger("kicad_interface")
@@ -348,24 +349,15 @@ def _transform_local_point(
     mirror_y: bool,
 ) -> Tuple[float, float]:
     """
-    Transform a point from local symbol coordinates to absolute schematic
-    coordinates using KiCad's transform order:
-    negate-y (lib y-up → schematic y-down) → mirror → rotate → translate.
+    Transform a point from library symbol coordinates (y-up) to sheet
+    coordinates (y-down) for a placed symbol instance.
+
+    Delegates to WireDragger.pin_world_xy, the one transform verified against
+    kicad-cli netlists (y-flip → rotate screen-CCW → mirror → translate). The
+    earlier local copy rotated the other way and mirrored before rotating,
+    which was wrong at 90 and 270 degrees (#404).
     """
-    # Library symbols use y-up; schematic uses y-down
-    ly = -ly
-
-    # Apply mirroring in local coords
-    if mirror_x:
-        ly = -ly
-    if mirror_y:
-        lx = -lx
-
-    # Apply rotation
-    if rotation != 0:
-        lx, ly = PinLocator.rotate_point(lx, ly, rotation)
-
-    return (sym_x + lx, sym_y + ly)
+    return WireDragger.pin_world_xy(lx, ly, sym_x, sym_y, rotation, mirror_x, mirror_y)
 
 
 def _compute_symbol_bbox_direct(
@@ -730,7 +722,10 @@ def _compute_pin_positions_direct(
     lookup in the schematic, so it works correctly when multiple symbols share
     the same reference designator (e.g. unannotated "Q?").
 
-    KiCad transform order: mirror (in local coords) → rotate → translate.
+    The transform itself is WireDragger.pin_world_xy, verified against
+    kicad-cli netlists. The earlier local copy never flipped library y-up to
+    sheet y-down and rotated the other way, so its positions were wrong at
+    every rotation (#404); only these linting helpers used it.
     """
     sym_x = sym["x"]
     sym_y = sym["y"]
@@ -740,20 +735,16 @@ def _compute_pin_positions_direct(
 
     result: Dict[str, List[float]] = {}
     for pin_num, pin_data in pin_defs.items():
-        rel_x = float(pin_data["x"])
-        rel_y = float(pin_data["y"])
-
-        # Apply mirroring in local symbol coordinates
-        if mirror_x:
-            rel_y = -rel_y
-        if mirror_y:
-            rel_x = -rel_x
-
-        # Apply symbol rotation
-        if rotation != 0:
-            rel_x, rel_y = PinLocator.rotate_point(rel_x, rel_y, rotation)
-
-        result[pin_num] = [sym_x + rel_x, sym_y + rel_y]
+        x, y = WireDragger.pin_world_xy(
+            float(pin_data["x"]),
+            float(pin_data["y"]),
+            sym_x,
+            sym_y,
+            rotation,
+            mirror_x,
+            mirror_y,
+        )
+        result[pin_num] = [x, y]
     return result
 
 

--- a/python/commands/schematic_handlers.py
+++ b/python/commands/schematic_handlers.py
@@ -1146,8 +1146,17 @@ class SchematicHandlersMixin:
             # Make a mutable copy of points
             points = [list(p) for p in points]
 
-            # Pin snapping: adjust first and last endpoints to nearest pin
-            snapped_info = []
+            # Pin snapping: adjust first and last endpoints to nearest pin.
+            # The response says what happened to each endpoint. Snapping
+            # nothing used to be silent, so a wire drawn from a miscalculated
+            # pin position was reported as a success while floating next to
+            # the pin it was meant for (#404).
+            snapped_info: List[str] = []
+            warnings: List[str] = []
+            endpoints: Dict[str, Dict[str, Any]] = {
+                "start": {"position": list(points[0]), "snapped": False},
+                "end": {"position": list(points[-1]), "snapped": False},
+            }
             if snap_to_pins:
                 from commands.pin_locator import PinLocator
 
@@ -1170,40 +1179,51 @@ class SchematicHandlersMixin:
                     for pin_num, coords in pin_locs.items():
                         all_pins.append((ref, pin_num, coords))
 
-                def find_nearest_pin(point: Any, tolerance: Any) -> Any:
-                    """Find the nearest pin within tolerance of a point."""
+                def find_nearest_pin(point: Any) -> Any:
+                    """Return (ref, pin_num, coords, distance) of the closest pin."""
                     best = None
-                    best_dist = tolerance
                     for ref, pin_num, coords in all_pins:
                         dx = point[0] - coords[0]
                         dy = point[1] - coords[1]
                         dist = (dx * dx + dy * dy) ** 0.5
-                        if dist <= best_dist:
-                            best_dist = dist
-                            best = (ref, pin_num, coords)
+                        if best is None or dist < best[3]:
+                            best = (ref, pin_num, coords, dist)
                     return best
 
-                # Snap first endpoint
-                match = find_nearest_pin(points[0], snap_tolerance)
-                if match:
-                    ref, pin_num, coords = match
-                    logger.info(
-                        f"Snapped start point {points[0]} -> {coords} (pin {ref}/{pin_num})"
-                    )
-                    snapped_info.append(
-                        f"start snapped to {ref}/{pin_num} at [{coords[0]}, {coords[1]}]"
-                    )
-                    points[0] = list(coords)
-
-                # Snap last endpoint
-                match = find_nearest_pin(points[-1], snap_tolerance)
-                if match:
-                    ref, pin_num, coords = match
-                    logger.info(f"Snapped end point {points[-1]} -> {coords} (pin {ref}/{pin_num})")
-                    snapped_info.append(
-                        f"end snapped to {ref}/{pin_num} at [{coords[0]}, {coords[1]}]"
-                    )
-                    points[-1] = list(coords)
+                for label, index in (("start", 0), ("end", -1)):
+                    requested = points[index]
+                    info = endpoints[label]
+                    match = find_nearest_pin(requested)
+                    if match is None:
+                        warnings.append(
+                            f"{label} point [{requested[0]}, {requested[1]}] was not snapped: "
+                            "the schematic has no symbol pins"
+                        )
+                        continue
+                    ref, pin_num, coords, dist = match
+                    info["nearestPin"] = {
+                        "reference": ref,
+                        "pin": pin_num,
+                        "position": [coords[0], coords[1]],
+                    }
+                    info["nearestPinDistance"] = round(dist, 4)
+                    if dist <= snap_tolerance:
+                        logger.info(
+                            f"Snapped {label} point {requested} -> {coords} ({ref}/{pin_num})"
+                        )
+                        snapped_info.append(
+                            f"{label} snapped to {ref}/{pin_num} at [{coords[0]}, {coords[1]}]"
+                        )
+                        points[index] = list(coords)
+                        info["position"] = list(coords)
+                        info["snapped"] = True
+                    else:
+                        warnings.append(
+                            f"{label} point [{requested[0]}, {requested[1]}] is {dist:.2f} mm from "
+                            f"the nearest pin {ref}/{pin_num} at [{coords[0]}, {coords[1]}], "
+                            f"outside snapTolerance {snap_tolerance} mm; the endpoint was left "
+                            "where it was and the wire may be floating"
+                        )
 
             # Extract wire properties
             stroke_width = properties.get("stroke_width", 0)
@@ -1230,8 +1250,17 @@ class SchematicHandlersMixin:
                 message = "Wire added successfully"
                 if snapped_info:
                     message += "; " + "; ".join(snapped_info)
+                if warnings:
+                    message += ". Warning: " + " ".join(warnings)
                 self._reload_kicad_schematic()
-                return {"success": True, "message": message}
+                result: Dict[str, Any] = {
+                    "success": True,
+                    "message": message,
+                    "endpoints": endpoints,
+                }
+                if warnings:
+                    result["warnings"] = warnings
+                return result
             else:
                 return {"success": False, "message": "Failed to add wire"}
         except SchematicLoadError as e:

--- a/python/schemas/tool_schemas.py
+++ b/python/schemas/tool_schemas.py
@@ -2402,7 +2402,7 @@ SCHEMATIC_TOOLS = [
     {
         "name": "add_schematic_wire",
         "title": "Draw Wire Between Pins",
-        "description": "Draws a wire on the schematic between two or more coordinate points. Always call get_schematic_pin_locations first to get the approximate pin coordinates, then pass them as the first and last waypoints. snapToPins (on by default) will correct any float imprecision by snapping endpoints to the exact nearest pin coordinate. To route around components, add intermediate waypoints between the start and end: e.g. [[x1,y1], [xMid,y1], [xMid,y2], [x2,y2]] routes horizontally then vertically. Intermediate waypoints are never snapped.",
+        "description": "Draws a wire on the schematic between two or more coordinate points. Always call get_schematic_pin_locations first to get the approximate pin coordinates, then pass them as the first and last waypoints. snapToPins (on by default) will correct any float imprecision by snapping endpoints to the exact nearest pin coordinate. To route around components, add intermediate waypoints between the start and end: e.g. [[x1,y1], [xMid,y1], [xMid,y2], [x2,y2]] routes horizontally then vertically. Intermediate waypoints are never snapped. The response says, for the start and end points, whether they snapped and how far the nearest pin is, and warns when an endpoint is outside snapTolerance of every pin: such a wire is floating.",
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/src/tools/schematic.ts
+++ b/src/tools/schematic.ts
@@ -547,7 +547,7 @@ edit_schematic_component and set its value to an empty string.`,
   // Draw wire between coordinate waypoints with optional pin snapping
   server.tool(
     "add_schematic_wire",
-    "Draws a wire on the schematic between two or more coordinate points. Always call get_schematic_pin_locations first to get the approximate pin coordinates, then pass them as the first and last waypoints. snapToPins (on by default) will correct any float imprecision by snapping endpoints to the exact nearest pin coordinate. To route around components, add intermediate waypoints between the start and end: e.g. [[x1,y1], [xMid,y1], [xMid,y2], [x2,y2]] routes horizontally then vertically. Intermediate waypoints are never snapped.",
+    "Draws a wire on the schematic between two or more coordinate points. Always call get_schematic_pin_locations first to get the approximate pin coordinates, then pass them as the first and last waypoints. snapToPins (on by default) will correct any float imprecision by snapping endpoints to the exact nearest pin coordinate. To route around components, add intermediate waypoints between the start and end: e.g. [[x1,y1], [xMid,y1], [xMid,y2], [x2,y2]] routes horizontally then vertically. Intermediate waypoints are never snapped. The response says, for the start and end points, whether they snapped and how far the nearest pin is, and warns when an endpoint is outside snapTolerance of every pin: such a wire is floating.",
     {
       schematicPath: z.string().describe("Path to the .kicad_sch file"),
       waypoints: z

--- a/tests/test_issue_404_pin_transform.py
+++ b/tests/test_issue_404_pin_transform.py
@@ -1,0 +1,243 @@
+"""Regression tests for #404: pin geometry in the schematic linting helpers,
+and add_schematic_wire admitting when an endpoint snapped to nothing.
+
+The report claimed get_schematic_pin_locations had the y sign wrong. It does
+not: KiCad library symbols are drawn y-up and sheets are y-down, so a
+rotation-0 instance at (x, y) puts a library pin (px, py) at (x + px, y - py).
+That transform (WireDragger.pin_world_xy) is verified against kicad-cli
+netlists in tests/test_pin_world_xy_eeschema_truth.py; the demo-file survey
+in the issue thread confirms it at every rotation.
+
+Two helpers in schematic_analysis.py did have the bug the report described,
+and more. ``_compute_pin_positions_direct`` (behind find_wires_crossing_symbols
+and get_elements_in_region) never flipped y and rotated the other way, so it
+was wrong at every rotation; ``_transform_local_point`` (symbol body boxes)
+rotated the other way and mirrored before rotating, wrong at 90 and 270.
+Both now delegate to pin_world_xy.
+
+The expected coordinates below are the netlist-verified placement formulas,
+written out by hand rather than derived from the code under test:
+
+    rot 0:   (x + px, y - py)
+    rot 90:  (x - py, y - px)
+    rot 180: (x - px, y + py)
+    rot 270: (x + py, y + px)
+    (mirror y) negates the x offset after rotation; (mirror x) the y offset.
+"""
+
+import shutil
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import sexpdata
+from sexpdata import Symbol
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "python"))
+
+from commands.schematic_analysis import (  # noqa: E402
+    _compute_pin_positions_direct,
+    _transform_local_point,
+    get_elements_in_region,
+)
+
+pytestmark = pytest.mark.unit
+
+TEMPLATE = Path(__file__).resolve().parent.parent / "python" / "templates" / "empty.kicad_sch"
+
+PX, PY = 2.54, 5.08  # asymmetric offsets so every rotation and mirror is distinguishable
+SX, SY = 100.0, 50.0
+
+
+def _expected(rotation: int, mirror_x: bool, mirror_y: bool) -> tuple:
+    dx, dy = {0: (PX, -PY), 90: (-PY, -PX), 180: (-PX, PY), 270: (PY, PX)}[rotation]
+    if mirror_y:
+        dx = -dx
+    if mirror_x:
+        dy = -dy
+    return (SX + dx, SY + dy)
+
+
+CASES = [
+    (rotation, mirror_x, mirror_y)
+    for rotation in (0, 90, 180, 270)
+    for mirror_x, mirror_y in ((False, False), (True, False), (False, True))
+]
+
+
+@pytest.mark.parametrize("rotation,mirror_x,mirror_y", CASES)
+def test_compute_pin_positions_direct_matches_eeschema(rotation, mirror_x, mirror_y):
+    sym = {"x": SX, "y": SY, "rotation": rotation, "mirror_x": mirror_x, "mirror_y": mirror_y}
+    positions = _compute_pin_positions_direct(sym, {"1": {"x": PX, "y": PY}})
+    assert positions["1"] == pytest.approx(_expected(rotation, mirror_x, mirror_y))
+
+
+@pytest.mark.parametrize("rotation,mirror_x,mirror_y", CASES)
+def test_transform_local_point_matches_eeschema(rotation, mirror_x, mirror_y):
+    point = _transform_local_point(PX, PY, SX, SY, rotation, mirror_x, mirror_y)
+    assert point == pytest.approx(_expected(rotation, mirror_x, mirror_y))
+
+
+def test_reporters_example_from_issue_404():
+    # LM2596 VIN pin at library offset (-12.7, +2.54), symbol at (100, 100),
+    # rotation 0: the tool answered (87.3, 97.46) and the report expected
+    # (87.3, 102.54). The tool was right; the helpers now agree with it.
+    sym = {"x": 100.0, "y": 100.0, "rotation": 0, "mirror_x": False, "mirror_y": False}
+    positions = _compute_pin_positions_direct(sym, {"VIN": {"x": -12.7, "y": 2.54}})
+    assert positions["VIN"] == pytest.approx((87.3, 97.46))
+
+
+# ---------------------------------------------------------------------------
+# End to end through a real schematic file
+# ---------------------------------------------------------------------------
+
+
+def _symbol_sexp(lib_id: str, ref: str, x: float, y: float, rotation: int) -> str:
+    return f"""
+  (symbol (lib_id "{lib_id}") (at {x} {y} {rotation}) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no)
+    (uuid "{uuid.uuid4()}")
+    (property "Reference" "{ref}" (at {x} {y} 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "{ref}" (at {x} {y} 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "" (at {x} {y} 0) (effects (font (size 1.27 1.27)) hide))
+    (property "Datasheet" "~" (at {x} {y} 0) (effects (font (size 1.27 1.27)) hide))
+    (pin "1" (uuid "{uuid.uuid4()}"))
+    (pin "2" (uuid "{uuid.uuid4()}"))
+    (instances (project "test" (path "/" (reference "{ref}") (unit 1))))
+  )
+"""
+
+
+def _schematic_with(extra: str) -> Path:
+    """Copy empty.kicad_sch (which carries Device:R and Device:LED in its
+    lib_symbols) to a temp file and append ``extra`` before the final paren."""
+    path = Path(tempfile.mkdtemp()) / "test.kicad_sch"
+    shutil.copy(TEMPLATE, path)
+    text = path.read_text(encoding="utf-8")
+    idx = text.rfind(")")
+    path.write_text(text[:idx] + "\n" + extra + "\n)", encoding="utf-8")
+    return path
+
+
+def test_get_elements_in_region_reports_true_pin_positions_for_a_rotated_led():
+    # Device:LED: pin 1 (K) at library (-3.81, 0), pin 2 (A) at (3.81, 0).
+    # Rotated 90 degrees at (100, 100), pin 1 is at (100, 103.81) and pin 2
+    # at (100, 96.19). The old helper swapped them.
+    path = _schematic_with(_symbol_sexp("Device:LED", "D1", 100.0, 100.0, 90))
+    region = get_elements_in_region(path, 90.0, 90.0, 110.0, 110.0)
+    (d1,) = [s for s in region["symbols"] if s["reference"] == "D1"]
+    assert d1["pins"]["1"] == {"x": 100.0, "y": 103.81}
+    assert d1["pins"]["2"] == {"x": 100.0, "y": 96.19}
+
+
+# ---------------------------------------------------------------------------
+# add_schematic_wire: say so when an endpoint snapped to nothing
+# ---------------------------------------------------------------------------
+
+
+def _make_iface() -> Any:
+    with patch("kicad_interface.USE_IPC_BACKEND", False):
+        from kicad_interface import KiCADInterface
+
+        return KiCADInterface.__new__(KiCADInterface)
+
+
+def _wires(path: Path) -> list:
+    data = sexpdata.loads(path.read_text(encoding="utf-8"))
+    out = []
+    for item in data:
+        if isinstance(item, list) and item and item[0] == Symbol("wire"):
+            for sub in item[1:]:
+                if isinstance(sub, list) and sub and sub[0] == Symbol("pts"):
+                    out.append([[float(pt[1]), float(pt[2])] for pt in sub[1:]])
+    return out
+
+
+class TestAddSchematicWireSnapReport:
+    """R1 (Device:R) at (100, 100), rotation 0: pin 1 at (100, 96.19), pin 2
+    at (100, 103.81)."""
+
+    def setup_method(self) -> None:
+        self.path = _schematic_with(_symbol_sexp("Device:R", "R1", 100.0, 100.0, 0))
+        self.iface = _make_iface()
+
+    def test_endpoint_outside_tolerance_is_reported_not_silently_left_floating(self):
+        result = self.iface._handle_add_schematic_wire(
+            {
+                "schematicPath": str(self.path),
+                # start is 3 mm above pin 1; end is 0.31 mm from pin 2
+                "waypoints": [[100.0, 93.19], [100.3, 103.9]],
+            }
+        )
+        assert result["success"] is True
+
+        start = result["endpoints"]["start"]
+        assert start["snapped"] is False
+        assert start["position"] == [100.0, 93.19]
+        assert start["nearestPin"] == {"reference": "R1", "pin": "1", "position": [100.0, 96.19]}
+        assert start["nearestPinDistance"] == pytest.approx(3.0)
+
+        end = result["endpoints"]["end"]
+        assert end["snapped"] is True
+        assert end["position"] == [100.0, 103.81]
+        assert end["nearestPin"]["pin"] == "2"
+
+        (warning,) = result["warnings"]
+        assert "start point [100.0, 93.19]" in warning
+        assert "R1/1" in warning
+        assert "snapTolerance" in warning
+        assert warning in result["message"]
+
+        # The file got exactly what the response describes.
+        assert _wires(self.path) == [[[100.0, 93.19], [100.0, 103.81]]]
+
+    def test_both_endpoints_snapped_carries_no_warning(self):
+        result = self.iface._handle_add_schematic_wire(
+            {
+                "schematicPath": str(self.path),
+                "waypoints": [[100.2, 96.0], [110.0, 96.0], [110.0, 104.0], [100.1, 103.7]],
+            }
+        )
+        assert result["success"] is True
+        assert "warnings" not in result
+        assert result["endpoints"]["start"]["snapped"] is True
+        assert result["endpoints"]["end"]["snapped"] is True
+        assert result["endpoints"]["start"]["position"] == [100.0, 96.19]
+        assert result["endpoints"]["end"]["position"] == [100.0, 103.81]
+        # Intermediate waypoints are never snapped.
+        assert _wires(self.path) == [
+            [[100.0, 96.19], [110.0, 96.0]],
+            [[110.0, 96.0], [110.0, 104.0]],
+            [[110.0, 104.0], [100.0, 103.81]],
+        ]
+
+    def test_snapping_off_reports_positions_without_a_pin_search(self):
+        result = self.iface._handle_add_schematic_wire(
+            {
+                "schematicPath": str(self.path),
+                "waypoints": [[100.0, 93.19], [100.3, 103.9]],
+                "snapToPins": False,
+            }
+        )
+        assert result["success"] is True
+        assert "warnings" not in result
+        assert result["endpoints"] == {
+            "start": {"position": [100.0, 93.19], "snapped": False},
+            "end": {"position": [100.3, 103.9], "snapped": False},
+        }
+        assert _wires(self.path) == [[[100.0, 93.19], [100.3, 103.9]]]
+
+    def test_schematic_without_pins_warns_for_both_endpoints(self):
+        path = _schematic_with("")
+        result = self.iface._handle_add_schematic_wire(
+            {"schematicPath": str(path), "waypoints": [[10.0, 10.0], [20.0, 10.0]]}
+        )
+        assert result["success"] is True
+        assert len(result["warnings"]) == 2
+        assert all("no symbol pins" in w for w in result["warnings"])
+        assert result["endpoints"]["start"]["snapped"] is False
+        assert "nearestPin" not in result["endpoints"]["start"]

--- a/tests/test_schematic_analysis.py
+++ b/tests/test_schematic_analysis.py
@@ -769,10 +769,14 @@ class TestTransformLocalPoint:
         assert y == pytest.approx(-2.0)
 
     def test_rotation_90(self) -> None:
-        # ly=0 negated is still 0, then rotate lx=1 by 90°
+        # A library point (px, py) on a symbol rotated 90 degrees lands at
+        # (x - py, y - px): eeschema rotates screen-CCW in y-down space. This
+        # used to expect (0, 1), the math-CCW direction, which is what the
+        # old local transform produced (#404); the netlist-verified value is
+        # (0, -1). See tests/test_issue_404_pin_transform.py.
         x, y = _transform_local_point(1.0, 0.0, 0.0, 0.0, 90, False, False)
         assert x == pytest.approx(0.0, abs=1e-9)
-        assert y == pytest.approx(1.0, abs=1e-9)
+        assert y == pytest.approx(-1.0, abs=1e-9)
 
 
 # ===================================================================

--- a/tests/test_wire_junction_changes.py
+++ b/tests/test_wire_junction_changes.py
@@ -386,8 +386,14 @@ class TestPinSnapping:
                 }
             )
             assert result["success"] is True
-            # No snapping info in message
-            assert "snapped" not in result.get("message", "")
+            # Coordinates reach the writer unchanged, and the response says
+            # so instead of staying silent about the missed snap (#404).
+            assert mw.call_args[0][1] == [100.0, 100.0]
+            assert mw.call_args[0][2] == [200.0, 100.0]
+            assert result["endpoints"]["start"]["snapped"] is False
+            assert result["endpoints"]["end"]["snapped"] is False
+            assert len(result["warnings"]) == 2
+            assert "Warning:" in result["message"]
 
     @patch("commands.wire_manager.WireManager.add_polyline_wire", return_value=True)
     def test_intermediate_waypoints_not_snapped(self, mock_poly: Any) -> None:


### PR DESCRIPTION
## Summary

Closes #404.

The report said `get_schematic_pin_locations` had the y sign wrong and that wires drawn from its coordinates ended up floating. The transform is correct (the thread has the kicad-cli verification: library symbols are y-up, sheets are y-down, so a rotation-0 instance at (x, y) puts a library pin (px, py) at (x + px, y - py)). Two real defects sat next to the claim, and this fixes both.

**`add_schematic_wire` said "success" for a wire that connected nothing.** With `snapToPins` on (the default), an endpoint that was not within `snapTolerance` of any pin was left where it was and the response did not mention it. A wire drawn from a miscalculated pin position therefore reported success while floating next to the pin it was meant for, which is the most likely way the reporter's wires went wrong. The response now carries `endpoints.start` and `endpoints.end` with `position`, `snapped`, the `nearestPin` (reference, pin, position) and `nearestPinDistance`, plus a `warnings` list (also appended to `message`, which is what the MCP tool returns as text) whenever an endpoint is outside the tolerance of every pin or the schematic has no pins at all. With `snapToPins: false` the endpoints are reported without a pin search and no warning is raised. The tool description in both schema layers says so.

**Two linting helpers had the transform the report described, and worse.** In `python/commands/schematic_analysis.py`, `_compute_pin_positions_direct` (behind `find_wires_crossing_symbols`, `get_elements_in_region` and the bounding boxes `find_overlapping_elements` uses) never flipped library y to sheet y and rotated math-CCW instead of screen-CCW, so its pin positions were wrong at every rotation; `_transform_local_point` (symbol body boxes) rotated the wrong way and mirrored before rotating, wrong at 90 and 270 degrees. Both now delegate to `WireDragger.pin_world_xy`, the transform `get_schematic_pin_locations` and wire dragging already use and that `tests/test_pin_world_xy_eeschema_truth.py` checks against kicad-cli netlists. `PinLocator.rotate_point` has no callers left in `schematic_analysis.py`.

## Tests

- `tests/test_issue_404_pin_transform.py`: both helpers against hand-written expected coordinates for rotation 0/90/180/270 with and without each mirror (the netlist-verified formulas, not values derived from the code under test); the reporter's own LM2596 example; an end-to-end `get_elements_in_region` on a real file with a Device:LED rotated 90 degrees, whose pins the old helper swapped; and four `add_schematic_wire` cases on a real file (one endpoint outside tolerance, both snapped through a polyline, snapping off, schematic without pins), each also checking the wire that reached the file.
- `tests/test_schematic_analysis.py::TestTransformLocalPoint::test_rotation_90` expected the old math-CCW result (0, 1); the verified value is (0, -1) and the comment says why.
- `tests/test_wire_junction_changes.py::test_snap_miss_leaves_coords_unchanged` used "no word 'snapped' in the message" as its proxy for "nothing was snapped"; it now checks the coordinates that reached the writer and the structured report.

## Verification

- pre-commit clean on `--all-files`; `npm run build`, vitest 84/84, `docs:tools:check` up to date
- pytest: 4 failed / 2398 passed / 35 skipped on this machine; the 4 are the known environmental failures (`test_ipc_open_board_path` path separator, 3x `test_svg_to_png_render` no converter), identical to the baseline set on main
