### PR TITLE
fix(windows): include KiCad 10 in UI launcher and footprint library defaults

### DIFF
--- a/python/commands/footprint.py
+++ b/python/commands/footprint.py
@@ -504,10 +504,12 @@ class FootprintCreator:
     def list_footprint_libraries(self, search_paths: Optional[List[str]] = None) -> Dict[str, Any]:
         """List all .pretty libraries and their footprints."""
         default_paths = [
+            r"C:\Program Files\KiCad\10.0\share\kicad\footprints",
             r"C:\Program Files\KiCad\9.0\share\kicad\footprints",
             r"C:\Program Files\KiCad\8.0\share\kicad\footprints",
             "/usr/share/kicad/footprints",
             "/usr/local/share/kicad/footprints",
+            os.path.expanduser("~/Documents/KiCad/10.0/footprints"),
             os.path.expanduser("~/Documents/KiCad/9.0/footprints"),
         ]
         paths = search_paths or default_paths

--- a/python/utils/kicad_process.py
+++ b/python/utils/kicad_process.py
@@ -186,8 +186,10 @@ class KiCADProcessManager:
             ]
         elif system == "Windows":
             candidates = [
+                Path("C:/Program Files/KiCad/10.0/bin/pcbnew.exe"),
                 Path("C:/Program Files/KiCad/9.0/bin/pcbnew.exe"),
                 Path("C:/Program Files/KiCad/8.0/bin/pcbnew.exe"),
+                Path("C:/Program Files (x86)/KiCad/10.0/bin/pcbnew.exe"),
                 Path("C:/Program Files (x86)/KiCad/9.0/bin/pcbnew.exe"),
             ]
         else:


### PR DESCRIPTION
## Problem

On Windows with KiCad 9 and KiCad 10 installed side by side, two code paths still hard-code only the 9.0/8.0 install locations:

- `KiCADProcessManager.get_executable_path()` (`python/utils/kicad_process.py`) never checks `C:\Program Files\KiCad\10.0`, so `launch_kicad_ui` opens the **KiCad 9** GUI even though the server itself is running on the KiCad 10 bundled Python (the TypeScript-side detection in `src/server.ts` already sorts versions descending and correctly picks 10.0).
- `list_footprint_libraries()` (`python/commands/footprint.py`) only scans the 9.0/8.0 `share\kicad\footprints` directories, so footprint discovery reads the old 9.0 libraries.

## Fix

Prepend the 10.0 locations to both fallback lists (Program Files, Program Files (x86), and the per-user `Documents\KiCad\10.0\footprints` path), keeping the existing 9.0/8.0 entries as fallbacks.

Verified locally on Windows 11 with KiCad 9.0 and 10.0.4 installed: `get_executable_path()` now resolves `C:\Program Files\KiCad\10.0\bin\pcbnew.exe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)